### PR TITLE
Add Conv2DLutFused with fused spatial unfolding CUDA kernels

### DIFF
--- a/native/lutorch/lutorch.cu
+++ b/native/lutorch/lutorch.cu
@@ -889,72 +889,70 @@ static __device__ __forceinline__ scalar_t conv2d_read(
     return x_ptr[b * (C * H * W) + c * (H * W) + h_in * W + w_in];
 }
 
+// Decoded-coordinate variant: (c, kr, kc) pre-decoded, no integer division.
 template <typename scalar_t>
-static __device__ __forceinline__ scalar_t conv2d_delta(
+static __device__ __forceinline__ scalar_t conv2d_delta_decoded(
     const scalar_t* x_ptr,
     int64_t b,
     int64_t h_out, int64_t w_out,
-    int64_t anchor_flat_a, int64_t anchor_flat_b,
+    int64_t c_a, int64_t kr_a, int64_t kc_a,
+    int64_t c_b, int64_t kr_b, int64_t kc_b,
     int64_t C, int64_t H, int64_t W,
-    int64_t kH, int64_t kW,
     int64_t sH, int64_t sW,
     int64_t pH, int64_t pW
 ) {
-    int64_t kHkW = kH * kW;
-    int64_t c_a  = anchor_flat_a / kHkW;
-    int64_t kr_a = (anchor_flat_a % kHkW) / kW;
-    int64_t kc_a = anchor_flat_a % kW;
-    int64_t h_a  = h_out * sH + kr_a - pH;
-    int64_t w_a  = w_out * sW + kc_a - pW;
-
-    int64_t c_b  = anchor_flat_b / kHkW;
-    int64_t kr_b = (anchor_flat_b % kHkW) / kW;
-    int64_t kc_b = anchor_flat_b % kW;
-    int64_t h_b  = h_out * sH + kr_b - pH;
-    int64_t w_b  = w_out * sW + kc_b - pW;
-
+    int64_t h_a = h_out * sH + kr_a - pH;
+    int64_t w_a = w_out * sW + kc_a - pW;
+    int64_t h_b = h_out * sH + kr_b - pH;
+    int64_t w_b = w_out * sW + kc_b - pW;
     scalar_t va = conv2d_read(x_ptr, b, c_a, h_a, w_a, C, H, W);
     scalar_t vb = conv2d_read(x_ptr, b, c_b, h_b, w_b, C, H, W);
     return va - vb;
 }
 
 template <typename scalar_t>
+// Forward kernel with pre-decoded anchor coordinates — no integer division in hot loop.
+// anchor_pairs_a/b_c/kr/kc: [n_tables, n_anchor_pairs] int32 decoded coords.
 __global__ void conv2d_anchor_pairs_lookup_forward_na3_kernel(
-    const scalar_t* x_ptr,        // [B, C, H, W] contiguous
+    const scalar_t* x_ptr,          // [B, C, H, W] contiguous
     int64_t B, int64_t C, int64_t H, int64_t W,
     int64_t H_out, int64_t W_out,
-    int64_t kH, int64_t kW,
     int64_t sH, int64_t sW,
     int64_t pH, int64_t pW,
-    const int64_t* anchor_pairs_a_ptr,  // [n_tables, n_anchor_pairs]
+    const int32_t* anc_a_c_ptr,    // [n_tables, nap] channel of anchor_a
+    const int32_t* anc_a_kr_ptr,   // [n_tables, nap] kernel-row of anchor_a
+    const int32_t* anc_a_kc_ptr,   // [n_tables, nap] kernel-col of anchor_a
+    const int32_t* anc_b_c_ptr,
+    const int32_t* anc_b_kr_ptr,
+    const int32_t* anc_b_kc_ptr,
+    const int64_t* anchor_pairs_a_ptr,  // [n_tables, nap] flat (saved for anchor ids output)
     const int64_t* anchor_pairs_b_ptr,
     int64_t n_tables,
     int64_t n_anchor_pairs,
     scalar_t cmp_eps,
     int64_t* lookup_indices_ptr,        // [B*H_out*W_out, n_tables]
     int64_t* lookup_alt_indices_ptr,    // [B*H_out*W_out*n_tables*3]
-    scalar_t* lookup_alt_deltas_ptr,    // [B*H_out*W_out*n_tables*3]
-    int64_t* anchor1_ids_ptr,           // [B*H_out*W_out*n_tables*3]
+    scalar_t* lookup_alt_deltas_ptr,
+    int64_t* anchor1_ids_ptr,
     int64_t* anchor2_ids_ptr
 ) {
-    // One thread per (spatial_pos, table) = (b*H_out*W_out + h_out*W_out + w_out, t)
-    // Flatten as: linear_tid = b*H_out*W_out*n_tables + h_out*W_out*n_tables + w_out*n_tables + t
     int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     int64_t total = B * H_out * W_out * n_tables;
     if (linear_tid >= total) return;
 
-    // Decode: linear_tid = (b * H_out * W_out + h_out * W_out + w_out) * n_tables + t
-    int64_t t           = linear_tid % n_tables;
-    int64_t spatial     = linear_tid / n_tables;
-    int64_t w_out       = spatial % W_out;
-    int64_t hw          = spatial / W_out;
-    int64_t h_out       = hw % H_out;
-    int64_t b           = hw / H_out;
+    int64_t t       = linear_tid % n_tables;
+    int64_t spatial = linear_tid / n_tables;
+    int64_t w_out   = spatial % W_out;
+    int64_t hw      = spatial / W_out;
+    int64_t h_out   = hw % H_out;
+    int64_t b       = hw / H_out;
+
+    // Precompute base input row/col offsets for this spatial position (no per-pair division)
+    int64_t h_base = h_out * sH - pH;
+    int64_t w_base = w_out * sW - pW;
 
     int64_t table_offset = t * n_anchor_pairs;
-
-    // Patch index: b*H_out*W_out + h_out*W_out + w_out
-    int64_t patch_idx = b * H_out * W_out + h_out * W_out + w_out;
+    int64_t patch_idx    = b * H_out * W_out + h_out * W_out + w_out;
 
     int64_t lookup_idx = 0;
     scalar_t big = static_cast<scalar_t>(1e30);
@@ -966,31 +964,40 @@ __global__ void conv2d_anchor_pairs_lookup_forward_na3_kernel(
     int64_t min1_bit = 0, min2_bit = 0, min3_bit = 0;
 
     for (int64_t p = 0; p < n_anchor_pairs; ++p) {
-        int64_t anc_a = anchor_pairs_a_ptr[table_offset + p];
-        int64_t anc_b = anchor_pairs_b_ptr[table_offset + p];
-        scalar_t delta = conv2d_delta(x_ptr, b, h_out, w_out,
-                                       anc_a, anc_b, C, H, W, kH, kW, sH, sW, pH, pW);
+        int64_t off = table_offset + p;
+        // Load pre-decoded coordinates — no integer division
+        int64_t c_a  = anc_a_c_ptr[off];
+        int64_t h_a  = h_base + anc_a_kr_ptr[off];
+        int64_t w_a  = w_base + anc_a_kc_ptr[off];
+        int64_t c_b  = anc_b_c_ptr[off];
+        int64_t h_b  = h_base + anc_b_kr_ptr[off];
+        int64_t w_b  = w_base + anc_b_kc_ptr[off];
+
+        scalar_t va = conv2d_read(x_ptr, b, c_a, h_a, w_a, C, H, W);
+        scalar_t vb = conv2d_read(x_ptr, b, c_b, h_b, w_b, C, H, W);
+        scalar_t delta = va - vb;
+
         if (delta > cmp_eps) {
             lookup_idx |= (static_cast<int64_t>(1) << p);
         }
         scalar_t abs_d = lutorch_abs(delta);
+        int64_t anc_a_flat = anchor_pairs_a_ptr[off];
+        int64_t anc_b_flat = anchor_pairs_b_ptr[off];
         if (abs_d < min1_abs) {
             min3_abs = min2_abs; min3_d = min2_d; min3_a = min2_a; min3_b_ = min2_b_; min3_bit = min2_bit;
             min2_abs = min1_abs; min2_d = min1_d; min2_a = min1_a; min2_b_ = min1_b_; min2_bit = min1_bit;
-            min1_abs = abs_d; min1_d = delta; min1_a = anc_a; min1_b_ = anc_b; min1_bit = p;
+            min1_abs = abs_d; min1_d = delta; min1_a = anc_a_flat; min1_b_ = anc_b_flat; min1_bit = p;
         } else if (abs_d < min2_abs) {
             min3_abs = min2_abs; min3_d = min2_d; min3_a = min2_a; min3_b_ = min2_b_; min3_bit = min2_bit;
-            min2_abs = abs_d; min2_d = delta; min2_a = anc_a; min2_b_ = anc_b; min2_bit = p;
+            min2_abs = abs_d; min2_d = delta; min2_a = anc_a_flat; min2_b_ = anc_b_flat; min2_bit = p;
         } else if (abs_d < min3_abs) {
-            min3_abs = abs_d; min3_d = delta; min3_a = anc_a; min3_b_ = anc_b; min3_bit = p;
+            min3_abs = abs_d; min3_d = delta; min3_a = anc_a_flat; min3_b_ = anc_b_flat; min3_bit = p;
         }
     }
 
-    // lookup_indices: [B*H_out*W_out, n_tables] -> index = patch_idx * n_tables + t
     int64_t out_main = patch_idx * n_tables + t;
     lookup_indices_ptr[out_main] = lookup_idx;
 
-    // alt/anchor arrays: [B*H_out*W_out*n_tables*3] -> base = out_main * 3
     int64_t base3 = out_main * 3;
     lookup_alt_indices_ptr[base3 + 0] = lookup_idx ^ (static_cast<int64_t>(1) << min1_bit);
     lookup_alt_indices_ptr[base3 + 1] = lookup_idx ^ (static_cast<int64_t>(1) << min2_bit);
@@ -2027,11 +2034,16 @@ public:
 
     py::tuple
     conv2d_anchor_pairs_lookup_na3_forward(
-        const torch::Tensor& x,           // [B, C, H, W] float32 contiguous
-        const torch::Tensor& anchors_a,   // [n_tables, nap] int64
-        const torch::Tensor& anchors_b,   // [n_tables, nap] int64
+        const torch::Tensor& x,            // [B, C, H, W] float32 contiguous
+        const torch::Tensor& anchors_a,    // [n_tables, nap] int64 flat
+        const torch::Tensor& anchors_b,    // [n_tables, nap] int64 flat
+        const torch::Tensor& anc_a_c,     // [n_tables, nap] int32 decoded channel
+        const torch::Tensor& anc_a_kr,    // [n_tables, nap] int32 decoded kernel-row
+        const torch::Tensor& anc_a_kc,    // [n_tables, nap] int32 decoded kernel-col
+        const torch::Tensor& anc_b_c,
+        const torch::Tensor& anc_b_kr,
+        const torch::Tensor& anc_b_kc,
         int64_t H_out, int64_t W_out,
-        int64_t kH, int64_t kW,
         int64_t sH, int64_t sW,
         int64_t pH, int64_t pW,
         double cmp_eps
@@ -2060,8 +2072,8 @@ public:
         if (n_anchor_pairs < 3)
             throw py::value_error("conv2d_na3 requires n_anchor_pairs >= 3");
 
-        int64_t n_patches = B * H_out * W_out;
-        int64_t n_total_bt = n_patches * n_tables;  // B*H_out*W_out*n_tables
+        int64_t n_patches  = B * H_out * W_out;
+        int64_t n_total_bt = n_patches * n_tables;
 
         auto opts_i64 = torch::TensorOptions().dtype(torch::kInt64).device(x.device());
         auto opts_x   = torch::TensorOptions().dtype(x.dtype()).device(x.device());
@@ -2074,14 +2086,20 @@ public:
 
         int dev = x.device().index();
         c10::cuda::CUDAGuard guard(dev);
-        int64_t total = n_total_bt;  // one thread per (patch, table)
+        int64_t total = n_total_bt;
         int threads = 256;
         int blocks  = static_cast<int>((total + threads - 1) / threads);
 
         AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "conv2d_anchor_pairs_lookup_forward_na3_kernel", [&] {
             conv2d_anchor_pairs_lookup_forward_na3_kernel<scalar_t><<<blocks, threads>>>(
                 reinterpret_cast<const scalar_t*>(x.data_ptr()),
-                B, C, H, W, H_out, W_out, kH, kW, sH, sW, pH, pW,
+                B, C, H, W, H_out, W_out, sH, sW, pH, pW,
+                reinterpret_cast<const int32_t*>(anc_a_c.data_ptr()),
+                reinterpret_cast<const int32_t*>(anc_a_kr.data_ptr()),
+                reinterpret_cast<const int32_t*>(anc_a_kc.data_ptr()),
+                reinterpret_cast<const int32_t*>(anc_b_c.data_ptr()),
+                reinterpret_cast<const int32_t*>(anc_b_kr.data_ptr()),
+                reinterpret_cast<const int32_t*>(anc_b_kc.data_ptr()),
                 reinterpret_cast<const int64_t*>(anchors_a.data_ptr()),
                 reinterpret_cast<const int64_t*>(anchors_b.data_ptr()),
                 n_tables, n_anchor_pairs,
@@ -2920,10 +2938,14 @@ void PB_LUTorchManager(py::module& m) {
             py::arg("x"),
             py::arg("anchors_a"),
             py::arg("anchors_b"),
+            py::arg("anc_a_c"),
+            py::arg("anc_a_kr"),
+            py::arg("anc_a_kc"),
+            py::arg("anc_b_c"),
+            py::arg("anc_b_kr"),
+            py::arg("anc_b_kc"),
             py::arg("H_out"),
             py::arg("W_out"),
-            py::arg("kH"),
-            py::arg("kW"),
             py::arg("sH"),
             py::arg("sW"),
             py::arg("pH"),

--- a/native/lutorch/lutorch.cu
+++ b/native/lutorch/lutorch.cu
@@ -865,6 +865,223 @@ __global__ void lprojection_backward_smooth_weights_kernel(
         atomicAdd(weights_grad_ptr + widx_alt, g_alt);
     }
 }
+
+// ============================================================
+// Conv2D fused kernels (na3 only)
+// Reads directly from 4D input [B, C, H, W] — no F.unfold intermediate.
+// anchor_flat ∈ [0, C*kH*kW) encodes (c, kr, kc):
+//   c  = anchor_flat / (kH*kW)
+//   kr = (anchor_flat % (kH*kW)) / kW
+//   kc = anchor_flat % kW
+// Spatial: h_in = h_out*sH + kr - pH,  w_in = w_out*sW + kc - pW
+// ============================================================
+
+template <typename scalar_t>
+static __device__ __forceinline__ scalar_t conv2d_read(
+    const scalar_t* x_ptr,
+    int64_t b,
+    int64_t c, int64_t h_in, int64_t w_in,
+    int64_t C, int64_t H, int64_t W
+) {
+    if (h_in < 0 || h_in >= H || w_in < 0 || w_in >= W) {
+        return static_cast<scalar_t>(0);
+    }
+    return x_ptr[b * (C * H * W) + c * (H * W) + h_in * W + w_in];
+}
+
+template <typename scalar_t>
+static __device__ __forceinline__ scalar_t conv2d_delta(
+    const scalar_t* x_ptr,
+    int64_t b,
+    int64_t h_out, int64_t w_out,
+    int64_t anchor_flat_a, int64_t anchor_flat_b,
+    int64_t C, int64_t H, int64_t W,
+    int64_t kH, int64_t kW,
+    int64_t sH, int64_t sW,
+    int64_t pH, int64_t pW
+) {
+    int64_t kHkW = kH * kW;
+    int64_t c_a  = anchor_flat_a / kHkW;
+    int64_t kr_a = (anchor_flat_a % kHkW) / kW;
+    int64_t kc_a = anchor_flat_a % kW;
+    int64_t h_a  = h_out * sH + kr_a - pH;
+    int64_t w_a  = w_out * sW + kc_a - pW;
+
+    int64_t c_b  = anchor_flat_b / kHkW;
+    int64_t kr_b = (anchor_flat_b % kHkW) / kW;
+    int64_t kc_b = anchor_flat_b % kW;
+    int64_t h_b  = h_out * sH + kr_b - pH;
+    int64_t w_b  = w_out * sW + kc_b - pW;
+
+    scalar_t va = conv2d_read(x_ptr, b, c_a, h_a, w_a, C, H, W);
+    scalar_t vb = conv2d_read(x_ptr, b, c_b, h_b, w_b, C, H, W);
+    return va - vb;
+}
+
+template <typename scalar_t>
+__global__ void conv2d_anchor_pairs_lookup_forward_na3_kernel(
+    const scalar_t* x_ptr,        // [B, C, H, W] contiguous
+    int64_t B, int64_t C, int64_t H, int64_t W,
+    int64_t H_out, int64_t W_out,
+    int64_t kH, int64_t kW,
+    int64_t sH, int64_t sW,
+    int64_t pH, int64_t pW,
+    const int64_t* anchor_pairs_a_ptr,  // [n_tables, n_anchor_pairs]
+    const int64_t* anchor_pairs_b_ptr,
+    int64_t n_tables,
+    int64_t n_anchor_pairs,
+    scalar_t cmp_eps,
+    int64_t* lookup_indices_ptr,        // [B*H_out*W_out, n_tables]
+    int64_t* lookup_alt_indices_ptr,    // [B*H_out*W_out*n_tables*3]
+    scalar_t* lookup_alt_deltas_ptr,    // [B*H_out*W_out*n_tables*3]
+    int64_t* anchor1_ids_ptr,           // [B*H_out*W_out*n_tables*3]
+    int64_t* anchor2_ids_ptr
+) {
+    // One thread per (spatial_pos, table) = (b*H_out*W_out + h_out*W_out + w_out, t)
+    // Flatten as: linear_tid = b*H_out*W_out*n_tables + h_out*W_out*n_tables + w_out*n_tables + t
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    int64_t total = B * H_out * W_out * n_tables;
+    if (linear_tid >= total) return;
+
+    // Decode: linear_tid = (b * H_out * W_out + h_out * W_out + w_out) * n_tables + t
+    int64_t t           = linear_tid % n_tables;
+    int64_t spatial     = linear_tid / n_tables;
+    int64_t w_out       = spatial % W_out;
+    int64_t hw          = spatial / W_out;
+    int64_t h_out       = hw % H_out;
+    int64_t b           = hw / H_out;
+
+    int64_t table_offset = t * n_anchor_pairs;
+
+    // Patch index: b*H_out*W_out + h_out*W_out + w_out
+    int64_t patch_idx = b * H_out * W_out + h_out * W_out + w_out;
+
+    int64_t lookup_idx = 0;
+    scalar_t big = static_cast<scalar_t>(1e30);
+    scalar_t min1_abs = big, min2_abs = big, min3_abs = big;
+    scalar_t min1_d = 0, min2_d = 0, min3_d = 0;
+    int64_t min1_a = 0, min1_b_ = 0;
+    int64_t min2_a = 0, min2_b_ = 0;
+    int64_t min3_a = 0, min3_b_ = 0;
+    int64_t min1_bit = 0, min2_bit = 0, min3_bit = 0;
+
+    for (int64_t p = 0; p < n_anchor_pairs; ++p) {
+        int64_t anc_a = anchor_pairs_a_ptr[table_offset + p];
+        int64_t anc_b = anchor_pairs_b_ptr[table_offset + p];
+        scalar_t delta = conv2d_delta(x_ptr, b, h_out, w_out,
+                                       anc_a, anc_b, C, H, W, kH, kW, sH, sW, pH, pW);
+        if (delta > cmp_eps) {
+            lookup_idx |= (static_cast<int64_t>(1) << p);
+        }
+        scalar_t abs_d = lutorch_abs(delta);
+        if (abs_d < min1_abs) {
+            min3_abs = min2_abs; min3_d = min2_d; min3_a = min2_a; min3_b_ = min2_b_; min3_bit = min2_bit;
+            min2_abs = min1_abs; min2_d = min1_d; min2_a = min1_a; min2_b_ = min1_b_; min2_bit = min1_bit;
+            min1_abs = abs_d; min1_d = delta; min1_a = anc_a; min1_b_ = anc_b; min1_bit = p;
+        } else if (abs_d < min2_abs) {
+            min3_abs = min2_abs; min3_d = min2_d; min3_a = min2_a; min3_b_ = min2_b_; min3_bit = min2_bit;
+            min2_abs = abs_d; min2_d = delta; min2_a = anc_a; min2_b_ = anc_b; min2_bit = p;
+        } else if (abs_d < min3_abs) {
+            min3_abs = abs_d; min3_d = delta; min3_a = anc_a; min3_b_ = anc_b; min3_bit = p;
+        }
+    }
+
+    // lookup_indices: [B*H_out*W_out, n_tables] -> index = patch_idx * n_tables + t
+    int64_t out_main = patch_idx * n_tables + t;
+    lookup_indices_ptr[out_main] = lookup_idx;
+
+    // alt/anchor arrays: [B*H_out*W_out*n_tables*3] -> base = out_main * 3
+    int64_t base3 = out_main * 3;
+    lookup_alt_indices_ptr[base3 + 0] = lookup_idx ^ (static_cast<int64_t>(1) << min1_bit);
+    lookup_alt_indices_ptr[base3 + 1] = lookup_idx ^ (static_cast<int64_t>(1) << min2_bit);
+    lookup_alt_indices_ptr[base3 + 2] = lookup_idx ^ (static_cast<int64_t>(1) << min3_bit);
+    lookup_alt_deltas_ptr[base3 + 0]  = min1_d;
+    lookup_alt_deltas_ptr[base3 + 1]  = min2_d;
+    lookup_alt_deltas_ptr[base3 + 2]  = min3_d;
+    if (anchor1_ids_ptr != nullptr) {
+        anchor1_ids_ptr[base3 + 0] = min1_a;  anchor2_ids_ptr[base3 + 0] = min1_b_;
+        anchor1_ids_ptr[base3 + 1] = min2_a;  anchor2_ids_ptr[base3 + 1] = min2_b_;
+        anchor1_ids_ptr[base3 + 2] = min3_a;  anchor2_ids_ptr[base3 + 2] = min3_b_;
+    }
+}
+
+template <typename scalar_t>
+__global__ void conv2d_anchor_pairs_lookup_backward_na3_kernel(
+    int64_t total,               // B*H_out*W_out*n_tables*3
+    const int64_t* anchor1_ids_ptr,
+    const int64_t* anchor2_ids_ptr,
+    const scalar_t* lookup_alt_deltas_ptr,
+    const scalar_t* grad_main_ptr,    // [B*H_out*W_out, n_tables] contiguous
+    const scalar_t* grad_alt_ptr,     // [B*H_out*W_out*n_tables*3]
+    int64_t B, int64_t C, int64_t H, int64_t W,
+    int64_t H_out, int64_t W_out,
+    int64_t kH, int64_t kW,
+    int64_t sH, int64_t sW,
+    int64_t pH, int64_t pW,
+    int64_t n_tables,
+    bool inv_l1,
+    scalar_t* grad_input_ptr   // [B, C, H, W] zero-initialised
+) {
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (linear_tid >= total) return;
+
+    // Decode: linear_tid = patch_idx * n_tables * 3 + t * 3 + alt_idx
+    int64_t alt_idx  = linear_tid % 3;
+    int64_t pt       = linear_tid / 3;       // patch_idx * n_tables + t
+    int64_t t        = pt % n_tables;
+    int64_t patch    = pt / n_tables;        // b * H_out * W_out + h_out * W_out + w_out
+    int64_t w_out    = patch % W_out;
+    int64_t hw       = patch / W_out;
+    int64_t h_out    = hw % H_out;
+    int64_t b        = hw / H_out;
+
+    scalar_t delta = lookup_alt_deltas_ptr[linear_tid];
+    scalar_t minus_uncertainty_derivative;
+    if (inv_l1) {
+        scalar_t one_plus_abs = static_cast<scalar_t>(1) + lutorch_abs(delta);
+        minus_uncertainty_derivative =
+            static_cast<scalar_t>(0.5) * lutorch_sign(delta) / (one_plus_abs * one_plus_abs);
+    } else {
+        scalar_t one_plus_sq = static_cast<scalar_t>(1) + delta * delta;
+        minus_uncertainty_derivative = delta / (one_plus_sq * one_plus_sq);
+    }
+
+    // grad_main has shape [B*H_out*W_out, n_tables] with strides (n_tables, 1)
+    int64_t patch_t  = patch * n_tables + t;
+    scalar_t gm      = grad_main_ptr[patch_t];
+    scalar_t ga      = grad_alt_ptr[linear_tid];
+    scalar_t du      = (gm - ga) * minus_uncertainty_derivative / static_cast<scalar_t>(3.0);
+
+    // Decode anchor flat index to 4D coordinates and atomicAdd
+    int64_t kHkW = kH * kW;
+
+    // anchor1
+    {
+        int64_t af  = anchor1_ids_ptr[linear_tid];
+        int64_t c   = af / kHkW;
+        int64_t kr  = (af % kHkW) / kW;
+        int64_t kc  = af % kW;
+        int64_t hi  = h_out * sH + kr - pH;
+        int64_t wi  = w_out * sW + kc - pW;
+        if (hi >= 0 && hi < H && wi >= 0 && wi < W) {
+            int64_t idx = b * (C * H * W) + c * (H * W) + hi * W + wi;
+            atomicAdd(grad_input_ptr + idx, du);
+        }
+    }
+    // anchor2
+    {
+        int64_t af  = anchor2_ids_ptr[linear_tid];
+        int64_t c   = af / kHkW;
+        int64_t kr  = (af % kHkW) / kW;
+        int64_t kc  = af % kW;
+        int64_t hi  = h_out * sH + kr - pH;
+        int64_t wi  = w_out * sW + kc - pW;
+        if (hi >= 0 && hi < H && wi >= 0 && wi < W) {
+            int64_t idx = b * (C * H * W) + c * (H * W) + hi * W + wi;
+            atomicAdd(grad_input_ptr + idx, -du);
+        }
+    }
+}
 #endif
 
 class SPIKY_HIDDEN LUTorchManager {
@@ -1804,6 +2021,150 @@ public:
         return x_grad_flat;
     }
 
+    // ============================================================
+    // Conv2D fused methods (na3 only)
+    // ============================================================
+
+    py::tuple
+    conv2d_anchor_pairs_lookup_na3_forward(
+        const torch::Tensor& x,           // [B, C, H, W] float32 contiguous
+        const torch::Tensor& anchors_a,   // [n_tables, nap] int64
+        const torch::Tensor& anchors_b,   // [n_tables, nap] int64
+        int64_t H_out, int64_t W_out,
+        int64_t kH, int64_t kW,
+        int64_t sH, int64_t sW,
+        int64_t pH, int64_t pW,
+        double cmp_eps
+    ) {
+        if (x.dim() != 4) throw py::value_error("x must be 4D [B, C, H, W]");
+        if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
+        if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
+        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
+        if (anchors_a.dim() != 2 || anchors_b.dim() != 2)
+            throw py::value_error("anchors_a/b must be 2D [n_tables, nap]");
+        if (anchors_a.sizes() != anchors_b.sizes())
+            throw py::value_error("anchors_a and anchors_b must have the same shape");
+        if (anchors_a.dtype() != torch::kInt64 || anchors_b.dtype() != torch::kInt64)
+            throw py::value_error("anchors_a/b must be int64");
+        if (!anchors_a.is_contiguous() || !anchors_b.is_contiguous())
+            throw py::value_error("anchors_a/b must be contiguous");
+        if (anchors_a.device() != x.device() || anchors_b.device() != x.device())
+            throw py::value_error("All tensors must be on the same CUDA device");
+
+        const int64_t B  = x.size(0);
+        const int64_t C  = x.size(1);
+        const int64_t H  = x.size(2);
+        const int64_t W  = x.size(3);
+        const int64_t n_tables     = anchors_a.size(0);
+        const int64_t n_anchor_pairs = anchors_a.size(1);
+        if (n_anchor_pairs < 3)
+            throw py::value_error("conv2d_na3 requires n_anchor_pairs >= 3");
+
+        int64_t n_patches = B * H_out * W_out;
+        int64_t n_total_bt = n_patches * n_tables;  // B*H_out*W_out*n_tables
+
+        auto opts_i64 = torch::TensorOptions().dtype(torch::kInt64).device(x.device());
+        auto opts_x   = torch::TensorOptions().dtype(x.dtype()).device(x.device());
+
+        torch::Tensor lookup_indices     = torch::empty({n_patches, n_tables}, opts_i64);
+        torch::Tensor lookup_alt_indices = torch::empty({n_total_bt * 3}, opts_i64);
+        torch::Tensor lookup_alt_deltas  = torch::empty({n_total_bt * 3}, opts_x);
+        torch::Tensor anchor1_ids        = torch::empty({n_total_bt * 3}, opts_i64);
+        torch::Tensor anchor2_ids        = torch::empty({n_total_bt * 3}, opts_i64);
+
+        int dev = x.device().index();
+        c10::cuda::CUDAGuard guard(dev);
+        int64_t total = n_total_bt;  // one thread per (patch, table)
+        int threads = 256;
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "conv2d_anchor_pairs_lookup_forward_na3_kernel", [&] {
+            conv2d_anchor_pairs_lookup_forward_na3_kernel<scalar_t><<<blocks, threads>>>(
+                reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                B, C, H, W, H_out, W_out, kH, kW, sH, sW, pH, pW,
+                reinterpret_cast<const int64_t*>(anchors_a.data_ptr()),
+                reinterpret_cast<const int64_t*>(anchors_b.data_ptr()),
+                n_tables, n_anchor_pairs,
+                static_cast<scalar_t>(cmp_eps),
+                reinterpret_cast<int64_t*>(lookup_indices.data_ptr()),
+                reinterpret_cast<int64_t*>(lookup_alt_indices.data_ptr()),
+                reinterpret_cast<scalar_t*>(lookup_alt_deltas.data_ptr()),
+                reinterpret_cast<int64_t*>(anchor1_ids.data_ptr()),
+                reinterpret_cast<int64_t*>(anchor2_ids.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
+
+        // Reshape to match LProjection expectations:
+        //   lookup_indices:     [B*H_out*W_out, n_tables]
+        //   lookup_alt_indices: [B*H_out*W_out, n_tables, 3]
+        //   lookup_alt_deltas:  [B*H_out*W_out, n_tables, 3]
+        //   anchor1/2_ids:      [B*H_out*W_out*n_tables*3] (flat, used in backward)
+        lookup_alt_indices = lookup_alt_indices.view({n_patches, n_tables, 3});
+        lookup_alt_deltas  = lookup_alt_deltas.view({n_patches, n_tables, 3});
+
+        py::tuple out(5);
+        out[0] = lookup_indices;
+        out[1] = lookup_alt_indices;
+        out[2] = lookup_alt_deltas;
+        out[3] = anchor1_ids;
+        out[4] = anchor2_ids;
+        return out;
+    }
+
+    torch::Tensor
+    conv2d_anchor_pairs_lookup_na3_backward(
+        const torch::Tensor& anchor1_ids,       // [B*H_out*W_out*n_tables*3]
+        const torch::Tensor& anchor2_ids,
+        const torch::Tensor& lookup_alt_deltas, // [B*H_out*W_out*n_tables*3]
+        const torch::Tensor& grad_main,         // [B*H_out*W_out, n_tables]
+        const torch::Tensor& grad_alt,          // [B*H_out*W_out*n_tables*3]
+        int64_t B, int64_t C, int64_t H, int64_t W,
+        int64_t H_out, int64_t W_out,
+        int64_t kH, int64_t kW,
+        int64_t sH, int64_t sW,
+        int64_t pH, int64_t pW,
+        int64_t n_tables, bool inv_l1
+    ) {
+        if (!anchor1_ids.is_cuda()) throw py::value_error("tensors must be CUDA");
+        if (anchor1_ids.dtype() != torch::kInt64 || anchor2_ids.dtype() != torch::kInt64)
+            throw py::value_error("anchor ids must be int64");
+        if (!grad_main.is_floating_point())
+            throw py::value_error("grad_main must be floating point");
+
+        auto opts_x = torch::TensorOptions().dtype(grad_main.dtype()).device(grad_main.device());
+        torch::Tensor grad_input = torch::zeros({B, C, H, W}, opts_x);
+
+        // Flatten inputs to 1D
+        torch::Tensor a1_flat      = anchor1_ids.reshape({-1}).contiguous();
+        torch::Tensor a2_flat      = anchor2_ids.reshape({-1}).contiguous();
+        torch::Tensor deltas_flat  = lookup_alt_deltas.reshape({-1}).contiguous();
+        torch::Tensor gm_flat      = grad_main.reshape({-1}).contiguous();  // [B*H_out*W_out*n_tables]
+        torch::Tensor ga_flat      = grad_alt.reshape({-1}).contiguous();   // [B*H_out*W_out*n_tables*3]
+
+        int64_t total = B * H_out * W_out * n_tables * 3;
+        int dev = grad_main.device().index();
+        c10::cuda::CUDAGuard guard(dev);
+        int threads = 256;
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(grad_main.scalar_type(), "conv2d_anchor_pairs_lookup_backward_na3_kernel", [&] {
+            conv2d_anchor_pairs_lookup_backward_na3_kernel<scalar_t><<<blocks, threads>>>(
+                total,
+                reinterpret_cast<const int64_t*>(a1_flat.data_ptr()),
+                reinterpret_cast<const int64_t*>(a2_flat.data_ptr()),
+                reinterpret_cast<const scalar_t*>(deltas_flat.data_ptr()),
+                reinterpret_cast<const scalar_t*>(gm_flat.data_ptr()),
+                reinterpret_cast<const scalar_t*>(ga_flat.data_ptr()),
+                B, C, H, W, H_out, W_out, kH, kW, sH, sW, pH, pW,
+                n_tables, inv_l1,
+                reinterpret_cast<scalar_t*>(grad_input.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
+        return grad_input;
+    }
+
     // Backward for generic n_alternatives (matching Python fallback semantics).
     torch::Tensor
     anchor_pairs_lookup_backward_all(
@@ -2552,6 +2913,45 @@ void PB_LUTorchManager(py::module& m) {
             py::arg("main_weight"),
             py::arg("alt_weight"),
             py::arg("threads_per_block") = 256
+        )
+        .def(
+            "conv2d_anchor_pairs_lookup_na3_forward",
+            &LUTorchManager::conv2d_anchor_pairs_lookup_na3_forward,
+            py::arg("x"),
+            py::arg("anchors_a"),
+            py::arg("anchors_b"),
+            py::arg("H_out"),
+            py::arg("W_out"),
+            py::arg("kH"),
+            py::arg("kW"),
+            py::arg("sH"),
+            py::arg("sW"),
+            py::arg("pH"),
+            py::arg("pW"),
+            py::arg("cmp_eps")
+        )
+        .def(
+            "conv2d_anchor_pairs_lookup_na3_backward",
+            &LUTorchManager::conv2d_anchor_pairs_lookup_na3_backward,
+            py::arg("anchor1_ids"),
+            py::arg("anchor2_ids"),
+            py::arg("lookup_alt_deltas"),
+            py::arg("grad_main"),
+            py::arg("grad_alt"),
+            py::arg("B"),
+            py::arg("C"),
+            py::arg("H"),
+            py::arg("W"),
+            py::arg("H_out"),
+            py::arg("W_out"),
+            py::arg("kH"),
+            py::arg("kW"),
+            py::arg("sH"),
+            py::arg("sW"),
+            py::arg("pH"),
+            py::arg("pW"),
+            py::arg("n_tables"),
+            py::arg("inv_l1")
         )
         #endif
         .def("get_profiling_stats", &LUTorchManager::get_profiling_stats)

--- a/src/spiky/lutorch/conv2d_lut_fused.py
+++ b/src/spiky/lutorch/conv2d_lut_fused.py
@@ -1,0 +1,417 @@
+"""
+Conv2DLutFused — fused version of Conv2DLut that avoids the F.unfold
+intermediate tensor.
+
+Instead of materialising a [B, C*kH*kW, n_patches] unfolded tensor,
+new CUDA kernels read directly from the 4D input [B, C, H, W] by
+decoding anchor flat indices on-the-fly:
+    anchor_flat ∈ [0, C*kH*kW)
+    c  = anchor_flat // (kH*kW)
+    kr = (anchor_flat % (kH*kW)) // kW
+    kc = anchor_flat % kW
+    h_in = h_out*sH + kr - pH
+    w_in = w_out*sW + kc - pW
+
+Only n_alternatives=3 and smooth_mode=True are implemented (the only
+combination used in practice).  For other configs the module falls back
+to the reference Conv2DLut transparently.
+"""
+
+import os
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional, Tuple, Union
+
+from spiky.lutorch.multi_head_lut import Conv2DLut, UnfoldConfiguration
+from spiky.lutorch.l_projection import LProjection
+from spiky.lutorch.lut_helpers import UncertaintyMode, get_balanced_anchor_pairs
+
+
+# Honour the same env-var knob as the rest of LUTorch.
+_USE_LUTORCH_CUSTOM_CUDA_KERNELS = (
+    os.environ.get("SPIKY_LUTORCH_NO_CUSTOM_CUDA_KERNELS", "0") != "1"
+)
+_LUTORCH_CUDA_THREADS_PER_BLOCK = int(os.environ.get("SPIKY_LUTORCH_CUDA_THREADS_PER_BLOCK", "256"))
+
+
+def _get_native_lutorch_manager():
+    try:
+        from lutorch_cuda import get_lutorch_manager  # type: ignore[import]
+        return get_lutorch_manager()
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Autograd function for the fused conv2d anchor-pairs lookup (na3)
+# ---------------------------------------------------------------------------
+
+class Conv2DAnchorPairsLookupFunctionNa3(torch.autograd.Function):
+    """
+    Fused forward+backward for conv2d anchor pairs lookup with na3.
+
+    Forward outputs five tensors that are consumed by LProjection:
+        lookup_indices         [B*H_out*W_out, n_tables]
+        lookup_alt_indices     [B*H_out*W_out, n_tables, 3]
+        lookup_alt_deltas      [B*H_out*W_out, n_tables, 3]
+        lookup_indices_grad_c  [B*H_out*W_out, n_tables]         (zero carrier)
+        lookup_alt_indices_grad_c [B*H_out*W_out, n_tables, 3]  (zero carrier)
+    """
+
+    @staticmethod
+    def forward(ctx, x, anchors_a, anchors_b,
+                B, C, H, W, H_out, W_out,
+                kH, kW, sH, sW, pH, pW,
+                cmp_eps, inv_l1):
+        """
+        Args:
+            x:         [B, C, H, W] float32, contiguous, CUDA
+            anchors_a: [n_tables, nap] int64
+            anchors_b: [n_tables, nap] int64
+        """
+        native = _get_native_lutorch_manager()
+        (
+            lookup_indices,
+            lookup_alt_indices,
+            lookup_alt_deltas,
+            anchor1_ids,
+            anchor2_ids,
+        ) = native.conv2d_anchor_pairs_lookup_na3_forward(
+            x, anchors_a, anchors_b,
+            H_out, W_out,
+            kH, kW, sH, sW, pH, pW,
+            float(cmp_eps),
+        )
+
+        n_patches = B * H_out * W_out
+        n_tables  = anchors_a.shape[0]
+
+        # Zero-value gradient carriers (same pattern as AnchorPairsLookupFunction)
+        z = x.sum() * 0
+        lookup_indices_grad_c     = z.expand(n_patches, n_tables)
+        lookup_alt_indices_grad_c = z.expand(n_patches, n_tables, 3)
+
+        ctx.inv_l1 = inv_l1
+        ctx.B, ctx.C, ctx.H, ctx.W = B, C, H, W
+        ctx.H_out, ctx.W_out = H_out, W_out
+        ctx.kH, ctx.kW = kH, kW
+        ctx.sH, ctx.sW = sH, sW
+        ctx.pH, ctx.pW = pH, pW
+        ctx.n_tables = n_tables
+        ctx.save_for_backward(anchor1_ids, anchor2_ids, lookup_alt_deltas)
+
+        return (
+            lookup_indices,
+            lookup_alt_indices,
+            lookup_alt_deltas,
+            lookup_indices_grad_c,
+            lookup_alt_indices_grad_c,
+        )
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        (
+            _,                             # grad for lookup_indices (not used here)
+            _,                             # grad for lookup_alt_indices
+            _,                             # grad for lookup_alt_deltas
+            grad_main,                     # [B*H_out*W_out, n_tables]
+            grad_alt,                      # [B*H_out*W_out, n_tables, 3]
+        ) = grad_outputs
+
+        anchor1_ids, anchor2_ids, lookup_alt_deltas = ctx.saved_tensors
+        native = _get_native_lutorch_manager()
+
+        grad_input = native.conv2d_anchor_pairs_lookup_na3_backward(
+            anchor1_ids.reshape(-1).contiguous(),
+            anchor2_ids.reshape(-1).contiguous(),
+            lookup_alt_deltas.reshape(-1).contiguous(),
+            grad_main.contiguous(),
+            grad_alt.reshape(-1).contiguous(),
+            ctx.B, ctx.C, ctx.H, ctx.W,
+            ctx.H_out, ctx.W_out,
+            ctx.kH, ctx.kW,
+            ctx.sH, ctx.sW,
+            ctx.pH, ctx.pW,
+            ctx.n_tables,
+            ctx.inv_l1,
+        )
+
+        # 17 inputs to forward → 17 gradients (None for non-tensor/int args)
+        return (
+            grad_input,  # x
+            None,        # anchors_a
+            None,        # anchors_b
+            None, None, None, None, None, None,  # B,C,H,W,H_out,W_out
+            None, None, None, None, None, None,  # kH,kW,sH,sW,pH,pW
+            None,        # cmp_eps
+            None,        # inv_l1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conv2DLutFused module
+# ---------------------------------------------------------------------------
+
+class Conv2DLutFused(nn.Module):
+    """
+    Drop-in replacement for Conv2DLut that fuses spatial unfolding into
+    the CUDA anchor-pairs lookup kernel (na3, smooth_mode=True only).
+
+    Falls back to the reference Conv2DLut for any unsupported configuration
+    (CPU, non-na3, non-smooth, or when native CUDA is unavailable).
+
+    Args: identical to Conv2DLut.
+    """
+
+    def __init__(
+        self,
+        unfold_config: UnfoldConfiguration,
+        in_channels: int,
+        out_channels: int,
+        n_anchor_pairs: int,
+        n_heads: int = 1,
+        tables_per_head: int = 1,
+        device: Optional[torch.device] = None,
+        **multi_head_lut_kwargs,
+    ):
+        super().__init__()
+
+        if out_channels % n_heads != 0:
+            raise ValueError(
+                f"out_channels must be divisible by n_heads; "
+                f"got out_channels={out_channels}, n_heads={n_heads}"
+            )
+
+        self.unfold_config  = unfold_config
+        self.in_channels    = in_channels
+        self.out_channels   = out_channels
+        self.n_heads        = n_heads
+        self.tables_per_head = tables_per_head
+
+        (kH, kW), (sH, sW), (pH, pW) = unfold_config.normalized()
+        self.kH, self.kW = kH, kW
+        self.sH, self.sW = sH, sW
+        self.pH, self.pW = pH, pW
+
+        H_p, W_p = unfold_config.output_spatial_shape()
+        if H_p <= 0 or W_p <= 0:
+            raise ValueError(
+                f"Invalid patch grid from H={unfold_config.H}, W={unfold_config.W}, "
+                f"kernel_size={unfold_config.kernel_size}, stride={unfold_config.stride}"
+            )
+        self.H_p, self.W_p = H_p, W_p
+        self.n_patches = H_p * W_p
+
+        patch_dim = in_channels * kH * kW
+        self.patch_dim = patch_dim
+        per_head_outputs = out_channels // n_heads
+        self.per_head_outputs = per_head_outputs
+
+        n_lookup_tables   = n_heads * tables_per_head
+        n_entries_per_table = 2 ** n_anchor_pairs
+        self.n_lookup_tables = n_lookup_tables
+        self.n_anchor_pairs  = n_anchor_pairs
+
+        # Pull out the parameters we need directly.
+        n_alternatives  = int(multi_head_lut_kwargs.get("n_alternatives", 1))
+        smooth_mode     = bool(multi_head_lut_kwargs.get("smooth_mode", False))
+        cmp_eps         = float(multi_head_lut_kwargs.get("cmp_eps", 0.0))
+        uncertainty_mode = multi_head_lut_kwargs.get(
+            "uncertainty_mode", UncertaintyMode.INVERSE_L1
+        )
+        random_seed     = multi_head_lut_kwargs.get("random_seed", None)
+        connected_anchors_mode = bool(multi_head_lut_kwargs.get("connected_anchors_mode", False))
+        initial_weights_noise  = float(multi_head_lut_kwargs.get("initial_weights_noise", 0.001))
+
+        self.n_alternatives  = n_alternatives
+        self.smooth_mode     = smooth_mode
+        self.cmp_eps         = cmp_eps
+        self.uncertainty_mode = uncertainty_mode
+        self.inv_l1          = (uncertainty_mode == UncertaintyMode.INVERSE_L1)
+
+        # Determine if we can use the fused path.
+        self._can_fuse = (
+            n_alternatives == 3
+            and smooth_mode
+            and _USE_LUTORCH_CUSTOM_CUDA_KERNELS
+            and _get_native_lutorch_manager() is not None
+        )
+
+        dev = device or torch.device("cpu")
+
+        # Build anchor pairs (same as AnchorPairsLookup does internally).
+        anchor_pairs_a, anchor_pairs_b = get_balanced_anchor_pairs(
+            n_lookup_tables,
+            n_anchor_pairs,
+            patch_dim,
+            dev,
+            random_seed=random_seed,
+            connected_mode=connected_anchors_mode,
+            anchor_candidates=None,
+        )
+        self.register_buffer("anchor_pairs_a", anchor_pairs_a.contiguous())
+        self.register_buffer("anchor_pairs_b", anchor_pairs_b.contiguous())
+
+        # LProjection handles weight lookup and weight gradients.
+        self.projection = LProjection(
+            n_lookup_tables=n_lookup_tables,
+            n_entries_per_table=n_entries_per_table,
+            n_outputs=per_head_outputs,
+            n_alternatives=n_alternatives,
+            smooth_mode=smooth_mode,
+            device=device,
+            uncertainty_mode=uncertainty_mode,
+        )
+        if initial_weights_noise != 0.0:
+            with torch.no_grad():
+                rng_kwargs: dict = {"device": dev}
+                if random_seed is not None:
+                    rng_kwargs["generator"] = torch.Generator(device=dev).manual_seed(random_seed)
+                self.projection.weights.add_(
+                    torch.randn(self.projection.weights.shape, **rng_kwargs) * initial_weights_noise
+                )
+
+        # Fallback reference module — built only when fused path is unavailable.
+        self._fallback: Optional[Conv2DLut] = None
+        if not self._can_fuse:
+            self._fallback = Conv2DLut(
+                unfold_config=unfold_config,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                n_anchor_pairs=n_anchor_pairs,
+                n_heads=n_heads,
+                tables_per_head=tables_per_head,
+                device=device,
+                **multi_head_lut_kwargs,
+            )
+
+        # Cached table index tensors for LProjection.
+        self._cached_table_indices_flat     = None
+        self._cached_table_indices_alt_flat = None
+        self._cached_n_patches              = None
+
+    def _prepare_table_indices(self, n_patches: int, device: torch.device) -> None:
+        if (
+            self._cached_n_patches != n_patches
+            or self._cached_table_indices_flat is None
+            or self._cached_table_indices_flat.device != device
+        ):
+            table_idx = torch.arange(
+                self.n_lookup_tables, dtype=torch.long, device=device
+            ).view(1, self.n_lookup_tables)
+            ti_expanded = table_idx.expand(n_patches, self.n_lookup_tables)
+            self._cached_table_indices_flat = ti_expanded.flatten().contiguous()
+            ti_alt = ti_expanded.unsqueeze(2).expand(
+                n_patches, self.n_lookup_tables, self.n_alternatives
+            )
+            self._cached_table_indices_alt_flat = ti_alt.flatten().contiguous()
+            self._cached_n_patches = n_patches
+
+    def _forward_fused(self, x: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = x.shape
+        n_patches   = B * self.H_p * self.W_p
+
+        self._prepare_table_indices(n_patches, x.device)
+        self.projection._prepare_table_indices(n_patches, x.device)
+
+        x_c = x.contiguous()
+
+        if self.training:
+            (
+                lookup_indices,
+                lookup_alt_indices,
+                lookup_alt_deltas,
+                lookup_indices_grad_c,
+                lookup_alt_indices_grad_c,
+            ) = Conv2DAnchorPairsLookupFunctionNa3.apply(
+                x_c,
+                self.anchor_pairs_a,
+                self.anchor_pairs_b,
+                B, C, H, W,
+                self.H_p, self.W_p,
+                self.kH, self.kW,
+                self.sH, self.sW,
+                self.pH, self.pW,
+                self.cmp_eps,
+                self.inv_l1,
+            )
+        else:
+            # Eval: call CUDA kernel directly (no autograd), no grad carriers needed.
+            native = _get_native_lutorch_manager()
+            (
+                lookup_indices,
+                lookup_alt_indices,
+                lookup_alt_deltas,
+                _,
+                _,
+            ) = native.conv2d_anchor_pairs_lookup_na3_forward(
+                x_c,
+                self.anchor_pairs_a,
+                self.anchor_pairs_b,
+                self.H_p, self.W_p,
+                self.kH, self.kW,
+                self.sH, self.sW,
+                self.pH, self.pW,
+                float(self.cmp_eps),
+            )
+            lookup_indices_grad_c     = None
+            lookup_alt_indices_grad_c = None
+
+        # LProjection forward: [n_patches, n_lookup_tables, per_head_outputs]
+        lut_out = self.projection(
+            lookup_indices=lookup_indices,
+            lookup_alt_indices=lookup_alt_indices,
+            lookup_alt_deltas=lookup_alt_deltas,
+            lookup_indices_grad_c=lookup_indices_grad_c,
+            lookup_alt_indices_grad_c=lookup_alt_indices_grad_c,
+        )
+
+        # Reshape to [B, out_channels, H_p, W_p]
+        # lut_out: [n_patches, n_lookup_tables, per_head_outputs]
+        # = [B*H_p*W_p, n_heads*tables_per_head, per_head_outputs]
+        total_outputs = self.n_heads * self.per_head_outputs  # == out_channels
+        lut_out = lut_out.view(B * self.n_patches, self.n_heads, self.tables_per_head, self.per_head_outputs)
+        lut_out = lut_out.sum(dim=2)  # [B*n_patches, n_heads, per_head_outputs]
+        lut_out = lut_out.view(B * self.n_patches, total_outputs)
+        lut_out = lut_out.view(B, self.n_patches, total_outputs)
+        lut_out = lut_out.view(B, self.H_p, self.W_p, total_outputs)
+        return lut_out.permute(0, 3, 1, 2).contiguous()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: [B, C, H, W]
+        Returns:
+            [B, out_channels, H_p, W_p]
+        """
+        if x.dim() != 4:
+            raise ValueError(f"Expected 4D input [B, C, H, W], got {x.shape}")
+
+        B, C, H, W = x.shape
+        if C != self.in_channels:
+            raise ValueError(
+                f"in_channels mismatch: expected {self.in_channels}, got {C}"
+            )
+        if (H, W) != (self.unfold_config.H, self.unfold_config.W):
+            raise ValueError(
+                f"Spatial size {(H, W)} does not match config "
+                f"({self.unfold_config.H}, {self.unfold_config.W})"
+            )
+
+        use_fused = (
+            self._can_fuse
+            and x.is_cuda
+            and x.dtype in (torch.float32, torch.float64)
+        )
+        if use_fused:
+            return self._forward_fused(x)
+
+        # Fallback: build a reference Conv2DLut on-the-fly if needed.
+        if self._fallback is None:
+            # Create fallback sharing the same weights.
+            raise RuntimeError(
+                "Conv2DLutFused: fused path unavailable and no fallback was built. "
+                "This should not happen — please report a bug."
+            )
+        return self._fallback(x)

--- a/src/spiky/lutorch/conv2d_lut_fused.py
+++ b/src/spiky/lutorch/conv2d_lut_fused.py
@@ -61,14 +61,17 @@ class Conv2DAnchorPairsLookupFunctionNa3(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, x, anchors_a, anchors_b,
+                anc_a_c, anc_a_kr, anc_a_kc,
+                anc_b_c, anc_b_kr, anc_b_kc,
                 B, C, H, W, H_out, W_out,
                 kH, kW, sH, sW, pH, pW,
                 cmp_eps, inv_l1):
         """
         Args:
             x:         [B, C, H, W] float32, contiguous, CUDA
-            anchors_a: [n_tables, nap] int64
-            anchors_b: [n_tables, nap] int64
+            anchors_a: [n_tables, nap] int64 flat
+            anchors_b: [n_tables, nap] int64 flat
+            anc_a_c/kr/kc: [n_tables, nap] int32 decoded coords (no div in kernel)
         """
         native = _get_native_lutorch_manager()
         (
@@ -79,8 +82,10 @@ class Conv2DAnchorPairsLookupFunctionNa3(torch.autograd.Function):
             anchor2_ids,
         ) = native.conv2d_anchor_pairs_lookup_na3_forward(
             x, anchors_a, anchors_b,
+            anc_a_c, anc_a_kr, anc_a_kc,
+            anc_b_c, anc_b_kr, anc_b_kc,
             H_out, W_out,
-            kH, kW, sH, sW, pH, pW,
+            sH, sW, pH, pW,
             float(cmp_eps),
         )
 
@@ -137,15 +142,19 @@ class Conv2DAnchorPairsLookupFunctionNa3(torch.autograd.Function):
             ctx.inv_l1,
         )
 
-        # 17 inputs to forward → 17 gradients (None for non-tensor/int args)
+        # 22 inputs to forward → 22 gradients (None for non-tensor/int args)
         return (
             grad_input,  # x
             None,        # anchors_a
             None,        # anchors_b
-            None, None, None, None, None, None,  # B,C,H,W,H_out,W_out
-            None, None, None, None, None, None,  # kH,kW,sH,sW,pH,pW
-            None,        # cmp_eps
-            None,        # inv_l1
+            None, None, None,        # anc_a_c, anc_a_kr, anc_a_kc
+            None, None, None,        # anc_b_c, anc_b_kr, anc_b_kc
+            None, None, None, None,  # B, C, H, W
+            None, None,              # H_out, W_out
+            None, None,              # kH, kW
+            None, None, None, None,  # sH, sW, pH, pW
+            None,                    # cmp_eps
+            None,                    # inv_l1
         )
 
 
@@ -253,6 +262,22 @@ class Conv2DLutFused(nn.Module):
         self.register_buffer("anchor_pairs_a", anchor_pairs_a.contiguous())
         self.register_buffer("anchor_pairs_b", anchor_pairs_b.contiguous())
 
+        # Precompute decoded (c, kr, kc) for each anchor — avoids integer division in CUDA kernel.
+        kHkW = kH * kW
+        def _decode(flat):  # flat: [n_tables, nap] int64
+            c  = (flat // kHkW).to(torch.int32)
+            kr = ((flat % kHkW) // kW).to(torch.int32)
+            kc = (flat % kW).to(torch.int32)
+            return c.contiguous(), kr.contiguous(), kc.contiguous()
+        a_c, a_kr, a_kc = _decode(anchor_pairs_a)
+        b_c, b_kr, b_kc = _decode(anchor_pairs_b)
+        self.register_buffer("anc_a_c",  a_c)
+        self.register_buffer("anc_a_kr", a_kr)
+        self.register_buffer("anc_a_kc", a_kc)
+        self.register_buffer("anc_b_c",  b_c)
+        self.register_buffer("anc_b_kr", b_kr)
+        self.register_buffer("anc_b_kc", b_kc)
+
         # LProjection handles weight lookup and weight gradients.
         self.projection = LProjection(
             n_lookup_tables=n_lookup_tables,
@@ -328,6 +353,8 @@ class Conv2DLutFused(nn.Module):
                 x_c,
                 self.anchor_pairs_a,
                 self.anchor_pairs_b,
+                self.anc_a_c, self.anc_a_kr, self.anc_a_kc,
+                self.anc_b_c, self.anc_b_kr, self.anc_b_kc,
                 B, C, H, W,
                 self.H_p, self.W_p,
                 self.kH, self.kW,
@@ -349,8 +376,9 @@ class Conv2DLutFused(nn.Module):
                 x_c,
                 self.anchor_pairs_a,
                 self.anchor_pairs_b,
+                self.anc_a_c, self.anc_a_kr, self.anc_a_kc,
+                self.anc_b_c, self.anc_b_kr, self.anc_b_kc,
                 self.H_p, self.W_p,
-                self.kH, self.kW,
                 self.sH, self.sW,
                 self.pH, self.pW,
                 float(self.cmp_eps),

--- a/src/spiky/lutorch/tests/test_conv2d_lut_fused.py
+++ b/src/spiky/lutorch/tests/test_conv2d_lut_fused.py
@@ -1,0 +1,270 @@
+"""
+Tests for Conv2DLutFused: compare against reference Conv2DLut.
+"""
+import os
+import time
+
+os.environ["SPIKY_LUTORCH_NO_COMPILE"] = "1"
+
+import pytest
+import torch
+import torch.nn as nn
+
+from spiky.lutorch.multi_head_lut import Conv2DLut, UnfoldConfiguration
+from spiky.lutorch.conv2d_lut_fused import Conv2DLutFused
+from spiky.lutorch.lut_helpers import UncertaintyMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+# Realistic shared params
+IN_CH   = 32
+OUT_CH  = 24
+N_HEADS = 4
+NAP     = 5       # n_anchor_pairs
+TPH     = 12      # tables_per_head
+N_ALT   = 3
+SEED    = 7
+
+
+def _make_pair(unfold_cfg, device=DEVICE, seed=SEED):
+    """Return (ref, fused) with identical weights on `device`."""
+    common_kwargs = dict(
+        n_alternatives=N_ALT,
+        smooth_mode=True,
+        cmp_eps=0.0,
+        uncertainty_mode=UncertaintyMode.INVERSE_L1,
+        random_seed=seed,
+        initial_weights_noise=0.001,
+    )
+    ref = Conv2DLut(
+        unfold_config=unfold_cfg,
+        in_channels=IN_CH,
+        out_channels=OUT_CH,
+        n_anchor_pairs=NAP,
+        n_heads=N_HEADS,
+        tables_per_head=TPH,
+        device=torch.device(device),
+        **common_kwargs,
+    ).to(device)
+
+    fused = Conv2DLutFused(
+        unfold_config=unfold_cfg,
+        in_channels=IN_CH,
+        out_channels=OUT_CH,
+        n_anchor_pairs=NAP,
+        n_heads=N_HEADS,
+        tables_per_head=TPH,
+        device=torch.device(device),
+        **common_kwargs,
+    ).to(device)
+
+    # Synchronise anchor pairs and weights.
+    with torch.no_grad():
+        fused.anchor_pairs_a.copy_(ref.lut.lookup.anchor_pairs_a)
+        fused.anchor_pairs_b.copy_(ref.lut.lookup.anchor_pairs_b)
+        fused.projection.weights.copy_(ref.lut.projection.weights)
+
+    return ref, fused
+
+
+def _make_input(B, H, W, device=DEVICE, requires_grad=False):
+    torch.manual_seed(42)
+    return torch.randn(B, IN_CH, H, W, device=device, requires_grad=requires_grad)
+
+
+# ---------------------------------------------------------------------------
+# 1. Forward match
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(DEVICE == "cpu", reason="Fused kernels require CUDA")
+@pytest.mark.parametrize("k,s,p,H,W", [
+    (3, 1, 0, 16, 16),
+    (4, 2, 0, 16, 16),
+    (3, 1, 1, 16, 16),
+    (4, 2, 0, 32, 32),
+])
+def test_conv2d_lut_fused_forward_matches_conv2dlut(k, s, p, H, W):
+    """Fused forward must match reference Conv2DLut output within 1e-4."""
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=k, stride=s, padding=p)
+    ref, fused = _make_pair(cfg)
+    ref.eval()
+    fused.eval()
+
+    x = _make_input(4, H, W)
+    with torch.no_grad():
+        out_ref   = ref(x)
+        out_fused = fused(x)
+
+    assert out_ref.shape == out_fused.shape, (
+        f"Shape mismatch: ref={out_ref.shape}, fused={out_fused.shape}"
+    )
+    max_diff = (out_ref - out_fused).abs().max().item()
+    assert max_diff < 1e-4, (
+        f"k={k},s={s},p={p},H={H},W={W}: max forward diff = {max_diff:.2e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Backward match
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(DEVICE == "cpu", reason="Fused kernels require CUDA")
+@pytest.mark.parametrize("k,s,p,H,W", [
+    (3, 1, 0, 16, 16),
+    (4, 2, 0, 16, 16),
+    (3, 1, 1, 16, 16),
+])
+def test_conv2d_lut_fused_backward_matches_conv2dlut(k, s, p, H, W):
+    """Fused grad_input and weight grads must match reference within 1e-4."""
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=k, stride=s, padding=p)
+
+    B = 4
+    common_kwargs = dict(
+        n_alternatives=N_ALT,
+        smooth_mode=True,
+        cmp_eps=0.0,
+        uncertainty_mode=UncertaintyMode.INVERSE_L1,
+        random_seed=SEED,
+        initial_weights_noise=0.001,
+    )
+
+    ref = Conv2DLut(
+        unfold_config=cfg,
+        in_channels=IN_CH,
+        out_channels=OUT_CH,
+        n_anchor_pairs=NAP,
+        n_heads=N_HEADS,
+        tables_per_head=TPH,
+        device=torch.device(DEVICE),
+        **common_kwargs,
+    ).to(DEVICE).train()
+
+    fused = Conv2DLutFused(
+        unfold_config=cfg,
+        in_channels=IN_CH,
+        out_channels=OUT_CH,
+        n_anchor_pairs=NAP,
+        n_heads=N_HEADS,
+        tables_per_head=TPH,
+        device=torch.device(DEVICE),
+        **common_kwargs,
+    ).to(DEVICE).train()
+
+    with torch.no_grad():
+        fused.anchor_pairs_a.copy_(ref.lut.lookup.anchor_pairs_a)
+        fused.anchor_pairs_b.copy_(ref.lut.lookup.anchor_pairs_b)
+        fused.projection.weights.copy_(ref.lut.projection.weights)
+
+    torch.manual_seed(42)
+    x_ref   = torch.randn(B, IN_CH, H, W, device=DEVICE, requires_grad=True)
+    x_fused = x_ref.detach().clone().requires_grad_(True)
+
+    out_ref   = ref(x_ref)
+    out_fused = fused(x_fused)
+
+    # Same upstream gradient
+    torch.manual_seed(99)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    out_fused.backward(grad_out)
+
+    # Input gradient
+    max_diff_input = (x_ref.grad - x_fused.grad).abs().max().item()
+    assert max_diff_input < 1e-4, (
+        f"k={k},s={s},p={p}: max grad_input diff = {max_diff_input:.2e}"
+    )
+
+    # Weight gradient
+    max_diff_w = (
+        ref.lut.projection.weights.grad - fused.projection.weights.grad
+    ).abs().max().item()
+    assert max_diff_w < 1e-4, (
+        f"k={k},s={s},p={p}: max weight_grad diff = {max_diff_w:.2e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Training step (loss decreases)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(DEVICE == "cpu", reason="Fused kernels require CUDA")
+def test_conv2d_lut_fused_training_step():
+    """Loss should stay finite and decrease when fitting a fixed batch (overfit test)."""
+    H, W = 16, 16
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=4, stride=2, padding=0)
+    _, fused = _make_pair(cfg)
+    fused.train()
+
+    optimizer = torch.optim.SGD(fused.parameters(), lr=1.0)
+    torch.manual_seed(1)
+    # Fix input and target so the model can overfit.
+    x_fixed      = torch.randn(4, IN_CH, H, W, device=DEVICE)
+    target_fixed = torch.randn(4, OUT_CH, fused.H_p, fused.W_p, device=DEVICE)
+
+    losses = []
+    for _ in range(20):
+        out  = fused(x_fixed)
+        loss = ((out - target_fixed) ** 2).mean()
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.item())
+        assert torch.isfinite(torch.tensor(loss.item())), "Loss became non-finite"
+
+    # The model must be able to decrease loss when fitting the same batch repeatedly.
+    assert losses[-1] < losses[0], (
+        f"Loss did not decrease over 20 steps on fixed batch: "
+        f"first={losses[0]:.4f}, last={losses[-1]:.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Benchmark (optional, prints timing)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(DEVICE == "cpu", reason="Fused kernels require CUDA")
+def test_conv2d_lut_fused_benchmark():
+    """Compare wall-clock time: Conv2DLut vs Conv2DLutFused."""
+    H, W  = 32, 32
+    B     = 16
+    cfg   = UnfoldConfiguration(H=H, W=W, kernel_size=4, stride=2, padding=0)
+    ref, fused = _make_pair(cfg)
+
+    def _time_fn(mod, n_warmup=10, n_trials=30):
+        mod.train()
+        losses = []
+        for i in range(n_warmup + n_trials):
+            x = torch.randn(B, IN_CH, H, W, device=DEVICE)
+            t0 = time.perf_counter()
+            out = mod(x)
+            loss = out.sum()
+            loss.backward()
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            if i >= n_warmup:
+                losses.append(t1 - t0)
+        return sum(losses) / len(losses) * 1000  # ms
+
+    t_ref   = _time_fn(ref)
+    t_fused = _time_fn(fused)
+
+    mem_ref   = torch.cuda.max_memory_allocated() // (1024 ** 2)
+    print(
+        f"\n[Benchmark] B={B} H={H} W={W}: "
+        f"Conv2DLut={t_ref:.2f}ms  Conv2DLutFused={t_fused:.2f}ms  "
+        f"Speedup={t_ref/t_fused:.2f}x  peak_mem={mem_ref}MB"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+    pytest.main([__file__, "-v"] + sys.argv[1:])

--- a/src/spiky/lutorch/tests/test_conv2d_lut_fused_benchmark.py
+++ b/src/spiky/lutorch/tests/test_conv2d_lut_fused_benchmark.py
@@ -1,0 +1,219 @@
+"""
+Detailed benchmark: Conv2DLut vs Conv2DLutFused.
+
+Measures per-component timing to identify bottlenecks.
+Run with: SPIKY_LUTORCH_NO_COMPILE=1 python -m pytest test_conv2d_lut_fused_benchmark.py -v -s
+"""
+import time
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytest
+
+from spiky.lutorch.multi_head_lut import Conv2DLut, UnfoldConfiguration
+from spiky.lutorch.conv2d_lut_fused import Conv2DLutFused
+
+DEVICE = torch.device("cuda:0")
+N_BATCHES = 50
+WARMUP    = 10
+
+
+def cuda_time(fn, warmup=WARMUP, n=N_BATCHES):
+    """Return median ms over n runs using CUDA events."""
+    start = torch.cuda.Event(enable_timing=True)
+    end   = torch.cuda.Event(enable_timing=True)
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(n):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+    times.sort()
+    return times[len(times)//2]  # median
+
+
+def make_layer(cls, H, k, s, ic, oc, nap=5, nh=4):
+    tph = ic * k * k * 12 // (nap * 2)
+    return cls(
+        UnfoldConfiguration(H=H, W=H, kernel_size=k, stride=s, padding=1),
+        in_channels=ic, out_channels=oc,
+        n_anchor_pairs=nap, tables_per_head=tph,
+        n_heads=nh, n_alternatives=3, smooth_mode=True,
+        connected_anchors_mode=False, initial_weights_noise=0.001,
+        device=DEVICE,
+    ).to(DEVICE)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_benchmark_per_layer():
+    """Time each layer individually, forward+backward, batch=64."""
+    B = 64
+    configs = [
+        # (label, H, k, s, ic, oc)
+        ("32x32 k=3 s=1 ic=32", 32, 3, 1, 32, 24),
+        ("32x32 k=4 s=2 ic=24", 32, 4, 2, 24, 24),
+        ("16x16 k=4 s=2 ic=24", 16, 4, 2, 24, 48),
+        (" 8x8  k=3 s=1 ic=48", 8,  3, 1, 48, 24),
+        (" 8x8  k=4 s=2 ic=24", 8,  4, 2, 24, 24),
+    ]
+
+    print("\n\n=== Per-layer benchmark (forward+backward, B=64, median of 50 runs) ===")
+    print(f"{'Layer':<26} {'Ref ms':>8} {'Fused ms':>10} {'Speedup':>9}")
+    print("-" * 58)
+
+    for label, H, k, s, ic, oc in configs:
+        x = torch.randn(B, ic, H, H, device=DEVICE, requires_grad=True)
+
+        ref   = make_layer(Conv2DLut,      H, k, s, ic, oc)
+        fused = make_layer(Conv2DLutFused, H, k, s, ic, oc)
+
+        # copy weights
+        fused.projection.weights.data.copy_(ref.lut.projection.weights.data)
+
+        def run_ref():
+            xi = x.detach().requires_grad_(True)
+            out = ref(xi)
+            out.sum().backward()
+
+        def run_fused():
+            xi = x.detach().requires_grad_(True)
+            out = fused(xi)
+            out.sum().backward()
+
+        t_ref   = cuda_time(run_ref)
+        t_fused = cuda_time(run_fused)
+        speedup = t_ref / t_fused
+        print(f"{label:<26} {t_ref:>8.2f} {t_fused:>10.2f} {speedup:>8.2f}x")
+
+    print()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_benchmark_unfold_vs_kernel():
+    """Isolate: how much time does F.unfold take vs the fused kernel?"""
+    B = 64
+    configs = [
+        ("32x32 k=3 ic=32", 32, 3, 1, 32),
+        ("32x32 k=4 ic=24", 32, 4, 2, 24),
+        ("16x16 k=4 ic=24", 16, 4, 2, 24),
+    ]
+
+    print("\n\n=== F.unfold cost isolation (forward only, B=64) ===")
+    print(f"{'Config':<22} {'unfold ms':>10} {'unfold+gather %':>16}")
+    print("-" * 52)
+
+    for label, H, k, s, ic in configs:
+        x = torch.randn(B, ic, H, H, device=DEVICE)
+
+        def do_unfold():
+            patches = F.unfold(x, kernel_size=k, padding=1, stride=s)
+            patches.transpose(1, 2).contiguous()
+
+        t_unfold = cuda_time(do_unfold)
+        print(f"{label:<22} {t_unfold:>10.3f}")
+
+    print()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_benchmark_full_model():
+    """Full exp149-style model: ref vs fused, different batch sizes."""
+    CH_CONV, CH, NH, NAP = 32, 24, 4, 5
+
+    def make_model(cls):
+        def lut(H, k, s, ic, oc):
+            tph = ic * k * k * 12 // (NAP * 2)
+            return cls(
+                UnfoldConfiguration(H=H, W=H, kernel_size=k, stride=s, padding=1),
+                in_channels=ic, out_channels=oc,
+                n_anchor_pairs=NAP, tables_per_head=tph,
+                n_heads=NH, n_alternatives=3, smooth_mode=True,
+                connected_anchors_mode=False, initial_weights_noise=0.001,
+                device=DEVICE,
+            )
+        m = nn.Sequential(
+            nn.Conv2d(3, CH_CONV, 3, padding=1),
+            nn.BatchNorm2d(CH_CONV),
+        )
+        # store lut layers separately so we can time them
+        return m, [
+            lut(32, 3, 1, CH_CONV, CH),
+            lut(32, 4, 2, CH,      CH),
+            lut(16, 4, 2, CH,      CH*2),
+            lut( 8, 3, 1, CH*2,    CH),
+            lut( 8, 4, 2, CH,      CH),
+        ]
+
+    print("\n\n=== Full model benchmark (forward+backward, median of 50 runs) ===")
+    print(f"{'Batch':>6} {'Ref ms':>9} {'Fused ms':>10} {'Speedup':>9} {'Memory saved':>14}")
+    print("-" * 55)
+
+    criterion = nn.CrossEntropyLoss()
+
+    for B in [16, 32, 64, 128]:
+        x   = torch.randn(B, 3, 32, 32, device=DEVICE)
+        y   = torch.randint(0, 10, (B,), device=DEVICE)
+
+        stem_ref,   luts_ref   = make_model(Conv2DLut)
+        stem_fused, luts_fused = make_model(Conv2DLutFused)
+
+        # Copy weights from ref to fused
+        for lr, lf in zip(luts_ref, luts_fused):
+            lf.projection.weights.data.copy_(lr.lut.projection.weights.data)
+
+        classifier = nn.Sequential(
+            nn.Flatten(), nn.Linear(CH * 4 * 4, 1024),
+            nn.BatchNorm1d(1024), nn.ReLU(inplace=True),
+            nn.Dropout(0.5), nn.Linear(1024, 10),
+        ).to(DEVICE)
+
+        def run(stem, luts):
+            h = stem(x)
+            for l in luts:
+                h = l(h)
+            return criterion(classifier(h), y)
+
+        torch.cuda.reset_peak_memory_stats()
+        def run_ref():
+            loss = run(stem_ref.to(DEVICE), [l.to(DEVICE) for l in luts_ref])
+            loss.backward()
+
+        def run_fused():
+            loss = run(stem_fused.to(DEVICE), [l.to(DEVICE) for l in luts_fused])
+            loss.backward()
+
+        t_ref   = cuda_time(run_ref)
+        t_fused = cuda_time(run_fused)
+
+        # Measure peak memory for one forward pass
+        torch.cuda.reset_peak_memory_stats()
+        with torch.no_grad():
+            run(stem_ref.to(DEVICE), [l.to(DEVICE) for l in luts_ref])
+        mem_ref = torch.cuda.max_memory_allocated() / 1e6
+
+        torch.cuda.reset_peak_memory_stats()
+        with torch.no_grad():
+            run(stem_fused.to(DEVICE), [l.to(DEVICE) for l in luts_fused])
+        mem_fused = torch.cuda.max_memory_allocated() / 1e6
+
+        speedup = t_ref / t_fused
+        mem_saved = mem_ref - mem_fused
+        print(f"{B:>6} {t_ref:>9.1f} {t_fused:>10.1f} {speedup:>8.2f}x {mem_saved:>+12.1f} MB")
+
+    print()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_verify_fused_path_taken():
+    """Confirm Conv2DLutFused actually uses the fused kernel (not the fallback)."""
+    layer = make_layer(Conv2DLutFused, 32, 3, 1, 32, 24)
+    assert layer._can_fuse, "Fused path NOT available — check CUDA/n_alternatives/smooth_mode"
+    x = torch.randn(4, 32, 32, 32, device=DEVICE)
+    assert x.is_cuda
+    out = layer(x)
+    assert out.shape == (4, 24, 32, 32)
+    print("\nFused path: ACTIVE")


### PR DESCRIPTION
## Summary

- Adds `Conv2DLutFused` — a drop-in replacement for `Conv2DLut` that avoids the `F.unfold` intermediate tensor (which has k² data duplication for overlapping patches)
- New CUDA kernels decode flat anchor indices to 4D spatial coordinates on-the-fly, reading directly from `[B, C, H, W]` input
- Reuses existing `LProjection` for all weight operations
- Transparent fallback to reference `Conv2DLut` when CUDA is unavailable or n_alternatives≠3

## New files

- `src/spiky/lutorch/conv2d_lut_fused.py` — `Conv2DLutFused` class + custom autograd function
- `src/spiky/lutorch/tests/test_conv2d_lut_fused.py` — 9 tests

## Modified files

- `native/lutorch/lutorch.cu` — two new CUDA kernels + manager methods:
  - `conv2d_anchor_pairs_lookup_forward_na3_kernel`
  - `conv2d_anchor_pairs_lookup_backward_na3_kernel`

## Test plan

- [x] Forward output matches `Conv2DLut` within 1e-4 (k=3/4, s=1/2, p=0/1, 16×16 and 32×32)
- [x] Backward grad_input and weight gradients match within 1e-4
- [x] Training step: loss decreases over 20 steps
- [x] Existing `test_multi_head_lut.py` tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)