### PR TITLE
Add WTALookup module and consolidate anchor_pairs backward kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.ssh/
 .idea/
 **/tests/**/*.png
 **/tests/mnist

--- a/native/lutorch/lutorch.cu
+++ b/native/lutorch/lutorch.cu
@@ -445,6 +445,9 @@ __global__ void anchor_pairs_lookup_backward_all_kernel(
 template <typename scalar_t>
 __global__ void wta_lookup_forward_na1_kernel(
     const scalar_t* x_ptr,
+    int64_t x_stride0,
+    int64_t x_stride1,
+    int64_t x_stride2,
     int64_t n_channels,
     int64_t n_inputs,
     int64_t total,
@@ -455,14 +458,16 @@ __global__ void wta_lookup_forward_na1_kernel(
     int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (linear_tid >= total) return;
 
-    const int64_t base = linear_tid * n_inputs;
+    int64_t b = linear_tid / n_channels;
+    int64_t c = linear_tid - b * n_channels;
+    int64_t x_base = b * x_stride0 + c * x_stride1;
     scalar_t neg_big = -static_cast<scalar_t>(1e30);
 
-    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
-    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
+    scalar_t max1_val = x_ptr[x_base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;       int64_t max2_idx = 0;
 
     for (int64_t n = 1; n < n_inputs; ++n) {
-        scalar_t val = x_ptr[base + n];
+        scalar_t val = x_ptr[x_base + n * x_stride2];
         if (val > max1_val) {
             max2_val = max1_val; max2_idx = max1_idx;
             max1_val = val;      max1_idx = n;
@@ -479,6 +484,9 @@ __global__ void wta_lookup_forward_na1_kernel(
 template <typename scalar_t>
 __global__ void wta_lookup_forward_na2_kernel(
     const scalar_t* x_ptr,
+    int64_t x_stride0,
+    int64_t x_stride1,
+    int64_t x_stride2,
     int64_t n_channels,
     int64_t n_inputs,
     int64_t total,
@@ -489,15 +497,17 @@ __global__ void wta_lookup_forward_na2_kernel(
     int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (linear_tid >= total) return;
 
-    const int64_t base = linear_tid * n_inputs;
+    int64_t b = linear_tid / n_channels;
+    int64_t c = linear_tid - b * n_channels;
+    int64_t x_base = b * x_stride0 + c * x_stride1;
     scalar_t neg_big = -static_cast<scalar_t>(1e30);
 
-    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
-    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
-    scalar_t max3_val = neg_big;     int64_t max3_idx = 0;
+    scalar_t max1_val = x_ptr[x_base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;       int64_t max2_idx = 0;
+    scalar_t max3_val = neg_big;       int64_t max3_idx = 0;
 
     for (int64_t n = 1; n < n_inputs; ++n) {
-        scalar_t val = x_ptr[base + n];
+        scalar_t val = x_ptr[x_base + n * x_stride2];
         if (val > max1_val) {
             max3_val = max2_val; max3_idx = max2_idx;
             max2_val = max1_val; max2_idx = max1_idx;
@@ -521,6 +531,9 @@ __global__ void wta_lookup_forward_na2_kernel(
 template <typename scalar_t>
 __global__ void wta_lookup_forward_na3_kernel(
     const scalar_t* x_ptr,
+    int64_t x_stride0,
+    int64_t x_stride1,
+    int64_t x_stride2,
     int64_t n_channels,
     int64_t n_inputs,
     int64_t total,
@@ -531,16 +544,18 @@ __global__ void wta_lookup_forward_na3_kernel(
     int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (linear_tid >= total) return;
 
-    const int64_t base = linear_tid * n_inputs;
+    int64_t b = linear_tid / n_channels;
+    int64_t c = linear_tid - b * n_channels;
+    int64_t x_base = b * x_stride0 + c * x_stride1;
     scalar_t neg_big = -static_cast<scalar_t>(1e30);
 
-    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
-    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
-    scalar_t max3_val = neg_big;     int64_t max3_idx = 0;
-    scalar_t max4_val = neg_big;     int64_t max4_idx = 0;
+    scalar_t max1_val = x_ptr[x_base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;       int64_t max2_idx = 0;
+    scalar_t max3_val = neg_big;       int64_t max3_idx = 0;
+    scalar_t max4_val = neg_big;       int64_t max4_idx = 0;
 
     for (int64_t n = 1; n < n_inputs; ++n) {
-        scalar_t val = x_ptr[base + n];
+        scalar_t val = x_ptr[x_base + n * x_stride2];
         if (val > max1_val) {
             max4_val = max3_val; max4_idx = max3_idx;
             max3_val = max2_val; max3_idx = max2_idx;
@@ -1671,7 +1686,6 @@ public:
         if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
         if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
         if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
-        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
         if (x.size(2) < 2) throw py::value_error("n_inputs must be >= 2 for n_alternatives=1");
         if (threads_per_block <= 0 || threads_per_block > 1024)
             throw py::value_error("threads_per_block must be in range [1, 1024]");
@@ -1695,6 +1709,7 @@ public:
         AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na1_kernel", [&] {
             wta_lookup_forward_na1_kernel<scalar_t><<<blocks, threads>>>(
                 reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                x.stride(0), x.stride(1), x.stride(2),
                 n_channels, n_inputs, total,
                 reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
                 reinterpret_cast<int64_t*>(alt_inds.data_ptr()),
@@ -1718,7 +1733,6 @@ public:
         if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
         if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
         if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
-        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
         if (x.size(2) < 3) throw py::value_error("n_inputs must be >= 3 for n_alternatives=2");
         if (threads_per_block <= 0 || threads_per_block > 1024)
             throw py::value_error("threads_per_block must be in range [1, 1024]");
@@ -1742,6 +1756,7 @@ public:
         AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na2_kernel", [&] {
             wta_lookup_forward_na2_kernel<scalar_t><<<blocks, threads>>>(
                 reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                x.stride(0), x.stride(1), x.stride(2),
                 n_channels, n_inputs, total,
                 reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
                 reinterpret_cast<int64_t*>(alt_inds.data_ptr()),
@@ -1765,7 +1780,6 @@ public:
         if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
         if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
         if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
-        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
         if (x.size(2) < 4) throw py::value_error("n_inputs must be >= 4 for n_alternatives=3");
         if (threads_per_block <= 0 || threads_per_block > 1024)
             throw py::value_error("threads_per_block must be in range [1, 1024]");
@@ -1789,6 +1803,7 @@ public:
         AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na3_kernel", [&] {
             wta_lookup_forward_na3_kernel<scalar_t><<<blocks, threads>>>(
                 reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                x.stride(0), x.stride(1), x.stride(2),
                 n_channels, n_inputs, total,
                 reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
                 reinterpret_cast<int64_t*>(alt_inds.data_ptr()),

--- a/native/lutorch/lutorch.cu
+++ b/native/lutorch/lutorch.cu
@@ -134,51 +134,6 @@ __global__ void anchor_pairs_lookup_eval_forward_kernel(
     lookup_indices_ptr[linear_tid] = lookup_idx;
 }
 
-template <typename scalar_t>
-__global__ void anchor_pairs_lookup_backward_na1_kernel(
-    int64_t total,
-    const int64_t* anchor1_ids_ptr,
-    const int64_t* anchor2_ids_ptr,
-    const scalar_t* lookup_alt_deltas_ptr,
-    const int64_t* batch_offset_ptr,
-    const scalar_t* grad_main_ptr,
-    const scalar_t* grad_alt_ptr,
-    int64_t grad_main_stride0,
-    int64_t grad_main_stride1,
-    int64_t batch_size,
-    int64_t n_tables,
-    bool inv_l1,
-    scalar_t* x_grad_flat_ptr
-) {
-    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (linear_tid >= total) {
-        return;
-    }
-
-    int64_t bt = linear_tid;
-    int64_t b = bt / n_tables;
-    int64_t t = bt - b * n_tables;
-
-    scalar_t delta = lookup_alt_deltas_ptr[linear_tid];
-    scalar_t minus_uncertainty_derivative = static_cast<scalar_t>(0);
-    if (inv_l1) {
-        scalar_t one_plus_abs = static_cast<scalar_t>(1) + lutorch_abs(delta);
-        minus_uncertainty_derivative =
-            static_cast<scalar_t>(0.5) * lutorch_sign(delta) / (one_plus_abs * one_plus_abs);
-    } else {
-        scalar_t one_plus_sq = static_cast<scalar_t>(1) + delta * delta;
-        minus_uncertainty_derivative = delta / (one_plus_sq * one_plus_sq);
-    }
-
-    scalar_t grad_main = grad_main_ptr[b * grad_main_stride0 + t * grad_main_stride1];
-    scalar_t grad_alt = grad_alt_ptr[linear_tid];
-    scalar_t du = (grad_main - grad_alt) * minus_uncertainty_derivative;
-
-    int64_t idx1 = batch_offset_ptr[linear_tid] + anchor1_ids_ptr[linear_tid];
-    int64_t idx2 = batch_offset_ptr[linear_tid] + anchor2_ids_ptr[linear_tid];
-    atomicAdd(x_grad_flat_ptr + idx1, du);
-    atomicAdd(x_grad_flat_ptr + idx2, -du);
-}
 
 template <typename scalar_t>
 __global__ void anchor_pairs_lookup_forward_na2_kernel(
@@ -265,50 +220,6 @@ __global__ void anchor_pairs_lookup_forward_na2_kernel(
     }
 }
 
-template <typename scalar_t>
-__global__ void anchor_pairs_lookup_backward_na2_kernel(
-    int64_t total,
-    const int64_t* anchor1_ids_ptr,
-    const int64_t* anchor2_ids_ptr,
-    const scalar_t* lookup_alt_deltas_ptr,
-    const int64_t* batch_offset_ptr,
-    const scalar_t* grad_main_ptr,
-    const scalar_t* grad_alt_ptr,
-    int64_t grad_main_stride0,
-    int64_t grad_main_stride1,
-    int64_t n_tables,
-    bool inv_l1,
-    scalar_t* x_grad_flat_ptr
-) {
-    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (linear_tid >= total) {
-        return;
-    }
-
-    int64_t bt = linear_tid / 2;
-    int64_t b = bt / n_tables;
-    int64_t t = bt - b * n_tables;
-
-    scalar_t delta = lookup_alt_deltas_ptr[linear_tid];
-    scalar_t minus_uncertainty_derivative = static_cast<scalar_t>(0);
-    if (inv_l1) {
-        scalar_t one_plus_abs = static_cast<scalar_t>(1) + lutorch_abs(delta);
-        minus_uncertainty_derivative =
-            static_cast<scalar_t>(0.5) * lutorch_sign(delta) / (one_plus_abs * one_plus_abs);
-    } else {
-        scalar_t one_plus_sq = static_cast<scalar_t>(1) + delta * delta;
-        minus_uncertainty_derivative = delta / (one_plus_sq * one_plus_sq);
-    }
-
-    scalar_t grad_main = grad_main_ptr[b * grad_main_stride0 + t * grad_main_stride1];
-    scalar_t grad_alt = grad_alt_ptr[linear_tid];
-    scalar_t du = (grad_main - grad_alt) * minus_uncertainty_derivative * static_cast<scalar_t>(0.5);
-
-    int64_t idx1 = batch_offset_ptr[linear_tid] + anchor1_ids_ptr[linear_tid];
-    int64_t idx2 = batch_offset_ptr[linear_tid] + anchor2_ids_ptr[linear_tid];
-    atomicAdd(x_grad_flat_ptr + idx1, du);
-    atomicAdd(x_grad_flat_ptr + idx2, -du);
-}
 
 template <typename scalar_t>
 __global__ void anchor_pairs_lookup_forward_na3_kernel(
@@ -422,50 +333,6 @@ __global__ void anchor_pairs_lookup_forward_na3_kernel(
     }
 }
 
-template <typename scalar_t>
-__global__ void anchor_pairs_lookup_backward_na3_kernel(
-    int64_t total,
-    const int64_t* anchor1_ids_ptr,
-    const int64_t* anchor2_ids_ptr,
-    const scalar_t* lookup_alt_deltas_ptr,
-    const int64_t* batch_offset_ptr,
-    const scalar_t* grad_main_ptr,
-    const scalar_t* grad_alt_ptr,
-    int64_t grad_main_stride0,
-    int64_t grad_main_stride1,
-    int64_t n_tables,
-    bool inv_l1,
-    scalar_t* x_grad_flat_ptr
-) {
-    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (linear_tid >= total) {
-        return;
-    }
-
-    int64_t bt = linear_tid / 3;
-    int64_t b = bt / n_tables;
-    int64_t t = bt - b * n_tables;
-
-    scalar_t delta = lookup_alt_deltas_ptr[linear_tid];
-    scalar_t minus_uncertainty_derivative = static_cast<scalar_t>(0);
-    if (inv_l1) {
-        scalar_t one_plus_abs = static_cast<scalar_t>(1) + lutorch_abs(delta);
-        minus_uncertainty_derivative =
-            static_cast<scalar_t>(0.5) * lutorch_sign(delta) / (one_plus_abs * one_plus_abs);
-    } else {
-        scalar_t one_plus_sq = static_cast<scalar_t>(1) + delta * delta;
-        minus_uncertainty_derivative = delta / (one_plus_sq * one_plus_sq);
-    }
-
-    scalar_t grad_main = grad_main_ptr[b * grad_main_stride0 + t * grad_main_stride1];
-    scalar_t grad_alt = grad_alt_ptr[linear_tid];
-    scalar_t du = (grad_main - grad_alt) * minus_uncertainty_derivative / static_cast<scalar_t>(3.0);
-
-    int64_t idx1 = batch_offset_ptr[linear_tid] + anchor1_ids_ptr[linear_tid];
-    int64_t idx2 = batch_offset_ptr[linear_tid] + anchor2_ids_ptr[linear_tid];
-    atomicAdd(x_grad_flat_ptr + idx1, du);
-    atomicAdd(x_grad_flat_ptr + idx2, -du);
-}
 
 // Generic forward kernel for n_alternatives == n_anchor_pairs.
 // Produces all alternatives by flipping each bit position once, without sorting.
@@ -568,6 +435,182 @@ __global__ void anchor_pairs_lookup_backward_all_kernel(
     int64_t idx2 = batch_offset_ptr[linear_tid] + anchor2_ids_ptr[linear_tid];
     atomicAdd(x_grad_flat_ptr + idx1, du);
     atomicAdd(x_grad_flat_ptr + idx2, -du);
+}
+
+// WTA (Winner-Take-All) Lookup Kernels
+// Input x is contiguous [B, C, N]. One thread per (b, c) pair.
+// Forward kernels find the winner (argmax) and n_alternatives runner-ups in a single pass.
+// Backward kernels scatter gradients to the winner and alt positions using the uncertainty function.
+
+template <typename scalar_t>
+__global__ void wta_lookup_forward_na1_kernel(
+    const scalar_t* x_ptr,
+    int64_t n_channels,
+    int64_t n_inputs,
+    int64_t total,
+    int64_t* winner_inds_ptr,   // [B, C] flat
+    int64_t* alt_inds_ptr,      // [B, C, 1] flat
+    scalar_t* alt_deltas_ptr    // [B, C, 1] flat  (winner_val - alt_val)
+) {
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (linear_tid >= total) return;
+
+    const int64_t base = linear_tid * n_inputs;
+    scalar_t neg_big = -static_cast<scalar_t>(1e30);
+
+    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
+
+    for (int64_t n = 1; n < n_inputs; ++n) {
+        scalar_t val = x_ptr[base + n];
+        if (val > max1_val) {
+            max2_val = max1_val; max2_idx = max1_idx;
+            max1_val = val;      max1_idx = n;
+        } else if (val > max2_val) {
+            max2_val = val; max2_idx = n;
+        }
+    }
+
+    winner_inds_ptr[linear_tid] = max1_idx;
+    alt_inds_ptr[linear_tid]    = max2_idx;
+    alt_deltas_ptr[linear_tid]  = max1_val - max2_val;
+}
+
+template <typename scalar_t>
+__global__ void wta_lookup_forward_na2_kernel(
+    const scalar_t* x_ptr,
+    int64_t n_channels,
+    int64_t n_inputs,
+    int64_t total,
+    int64_t* winner_inds_ptr,   // [B, C] flat
+    int64_t* alt_inds_ptr,      // [B, C, 2] flat
+    scalar_t* alt_deltas_ptr    // [B, C, 2] flat
+) {
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (linear_tid >= total) return;
+
+    const int64_t base = linear_tid * n_inputs;
+    scalar_t neg_big = -static_cast<scalar_t>(1e30);
+
+    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
+    scalar_t max3_val = neg_big;     int64_t max3_idx = 0;
+
+    for (int64_t n = 1; n < n_inputs; ++n) {
+        scalar_t val = x_ptr[base + n];
+        if (val > max1_val) {
+            max3_val = max2_val; max3_idx = max2_idx;
+            max2_val = max1_val; max2_idx = max1_idx;
+            max1_val = val;      max1_idx = n;
+        } else if (val > max2_val) {
+            max3_val = max2_val; max3_idx = max2_idx;
+            max2_val = val;      max2_idx = n;
+        } else if (val > max3_val) {
+            max3_val = val; max3_idx = n;
+        }
+    }
+
+    int64_t base_alt = linear_tid * 2;
+    winner_inds_ptr[linear_tid]  = max1_idx;
+    alt_inds_ptr[base_alt]       = max2_idx;
+    alt_inds_ptr[base_alt + 1]   = max3_idx;
+    alt_deltas_ptr[base_alt]     = max1_val - max2_val;
+    alt_deltas_ptr[base_alt + 1] = max1_val - max3_val;
+}
+
+template <typename scalar_t>
+__global__ void wta_lookup_forward_na3_kernel(
+    const scalar_t* x_ptr,
+    int64_t n_channels,
+    int64_t n_inputs,
+    int64_t total,
+    int64_t* winner_inds_ptr,   // [B, C] flat
+    int64_t* alt_inds_ptr,      // [B, C, 3] flat
+    scalar_t* alt_deltas_ptr    // [B, C, 3] flat
+) {
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (linear_tid >= total) return;
+
+    const int64_t base = linear_tid * n_inputs;
+    scalar_t neg_big = -static_cast<scalar_t>(1e30);
+
+    scalar_t max1_val = x_ptr[base]; int64_t max1_idx = 0;
+    scalar_t max2_val = neg_big;     int64_t max2_idx = 0;
+    scalar_t max3_val = neg_big;     int64_t max3_idx = 0;
+    scalar_t max4_val = neg_big;     int64_t max4_idx = 0;
+
+    for (int64_t n = 1; n < n_inputs; ++n) {
+        scalar_t val = x_ptr[base + n];
+        if (val > max1_val) {
+            max4_val = max3_val; max4_idx = max3_idx;
+            max3_val = max2_val; max3_idx = max2_idx;
+            max2_val = max1_val; max2_idx = max1_idx;
+            max1_val = val;      max1_idx = n;
+        } else if (val > max2_val) {
+            max4_val = max3_val; max4_idx = max3_idx;
+            max3_val = max2_val; max3_idx = max2_idx;
+            max2_val = val;      max2_idx = n;
+        } else if (val > max3_val) {
+            max4_val = max3_val; max4_idx = max3_idx;
+            max3_val = val;      max3_idx = n;
+        } else if (val > max4_val) {
+            max4_val = val; max4_idx = n;
+        }
+    }
+
+    int64_t base_alt = linear_tid * 3;
+    winner_inds_ptr[linear_tid]  = max1_idx;
+    alt_inds_ptr[base_alt]       = max2_idx;
+    alt_inds_ptr[base_alt + 1]   = max3_idx;
+    alt_inds_ptr[base_alt + 2]   = max4_idx;
+    alt_deltas_ptr[base_alt]     = max1_val - max2_val;
+    alt_deltas_ptr[base_alt + 1] = max1_val - max3_val;
+    alt_deltas_ptr[base_alt + 2] = max1_val - max4_val;
+}
+
+template <typename scalar_t>
+__global__ void wta_lookup_backward_kernel(
+    int64_t total,
+    const int64_t* winner_ids_ptr,
+    const int64_t* alt_ids_ptr,
+    const scalar_t* alt_deltas_ptr,
+    const int64_t* batch_offset_ptr,
+    const scalar_t* grad_main_ptr,
+    const scalar_t* grad_alt_ptr,
+    int64_t grad_main_stride0,
+    int64_t grad_main_stride1,
+    int64_t n_channels,
+    int64_t n_alternatives,
+    bool inv_l1,
+    scalar_t* x_grad_flat_ptr
+) {
+    int64_t linear_tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (linear_tid >= total) return;
+
+    int64_t bc = linear_tid / n_alternatives;
+    int64_t b  = bc / n_channels;
+    int64_t c  = bc - b * n_channels;
+
+    scalar_t delta = alt_deltas_ptr[linear_tid];
+    scalar_t minus_uncertainty_derivative;
+    if (inv_l1) {
+        scalar_t one_plus_abs = static_cast<scalar_t>(1) + lutorch_abs(delta);
+        minus_uncertainty_derivative =
+            static_cast<scalar_t>(0.5) * lutorch_sign(delta) / (one_plus_abs * one_plus_abs);
+    } else {
+        scalar_t one_plus_sq = static_cast<scalar_t>(1) + delta * delta;
+        minus_uncertainty_derivative = delta / (one_plus_sq * one_plus_sq);
+    }
+
+    scalar_t grad_main = grad_main_ptr[b * grad_main_stride0 + c * grad_main_stride1];
+    scalar_t grad_alt  = grad_alt_ptr[linear_tid];
+    scalar_t du = (grad_main - grad_alt) * minus_uncertainty_derivative
+                  / static_cast<scalar_t>(n_alternatives);
+
+    int64_t idx_winner = batch_offset_ptr[linear_tid] + winner_ids_ptr[linear_tid];
+    int64_t idx_alt    = batch_offset_ptr[linear_tid] + alt_ids_ptr[linear_tid];
+    atomicAdd(x_grad_flat_ptr + idx_winner,  du);
+    atomicAdd(x_grad_flat_ptr + idx_alt,    -du);
 }
 
 template <typename scalar_t>
@@ -1521,289 +1564,6 @@ public:
         return py::make_tuple(output, main_weight, alt_weight);
     }
 
-    torch::Tensor
-    anchor_pairs_lookup_backward_na1(
-        const torch::Tensor& x,
-        const torch::Tensor& anchor1_ids,
-        const torch::Tensor& anchor2_ids,
-        const torch::Tensor& lookup_alt_deltas,
-        const torch::Tensor& batch_offset,
-        const torch::Tensor& grad_main,
-        const torch::Tensor& grad_alt,
-        bool inv_l1,
-        int64_t threads_per_block = 256
-    ) {
-        PROF_START(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-
-        if (x.dim() != 2) {
-            throw py::value_error("x must be 2D [batch_size, input_dim]");
-        }
-        if (!x.is_cuda()) {
-            throw py::value_error("x must be CUDA tensor");
-        }
-        if (!x.is_floating_point()) {
-            throw py::value_error("x must be floating point tensor");
-        }
-        if (anchor1_ids.dtype() != torch::kInt64 || anchor2_ids.dtype() != torch::kInt64) {
-            throw py::value_error("anchor1_ids and anchor2_ids must be int64");
-        }
-        if (batch_offset.dtype() != torch::kInt64) {
-            throw py::value_error("batch_offset must be int64");
-        }
-        if (grad_main.dtype() != x.dtype() || grad_alt.dtype() != x.dtype()) {
-            throw py::value_error("grad_main and grad_alt must have the same dtype as x");
-        }
-        if (lookup_alt_deltas.dtype() != x.dtype()) {
-            throw py::value_error("lookup_alt_deltas must have the same dtype as x");
-        }
-        if (anchor1_ids.device() != x.device() || anchor2_ids.device() != x.device() ||
-            lookup_alt_deltas.device() != x.device() || batch_offset.device() != x.device() ||
-            grad_main.device() != x.device() || grad_alt.device() != x.device()) {
-            throw py::value_error("All tensors must be on the same CUDA device");
-        }
-        if (anchor1_ids.numel() != anchor2_ids.numel() ||
-            anchor1_ids.numel() != lookup_alt_deltas.numel() ||
-            anchor1_ids.numel() != batch_offset.numel() ||
-            anchor1_ids.numel() != grad_alt.numel()) {
-            throw py::value_error("anchor1_ids, anchor2_ids, lookup_alt_deltas, batch_offset, grad_alt must have equal numel");
-        }
-        if (threads_per_block <= 0 || threads_per_block > 1024) {
-            throw py::value_error("threads_per_block must be in range [1, 1024]");
-        }
-
-        int64_t batch_size = x.size(0);
-        int64_t input_dim = x.size(1);
-        int64_t n_tables = grad_main.size(1);
-        if (grad_main.size(0) != batch_size) {
-            throw py::value_error("grad_main first dimension must match x batch size");
-        }
-        if (grad_alt.numel() != batch_size * n_tables) {
-            throw py::value_error("grad_alt numel must be batch_size * n_tables for n_alternatives=1");
-        }
-
-        auto opts_x = torch::TensorOptions().dtype(x.dtype()).device(x.device());
-        torch::Tensor x_grad_flat = torch::zeros({batch_size * input_dim}, opts_x);
-
-        int device = x.device().index();
-        c10::cuda::CUDAGuard guard(device);
-        int64_t total = batch_size * n_tables;
-        int threads = static_cast<int>(threads_per_block);
-        int blocks = static_cast<int>((total + threads - 1) / threads);
-
-        int64_t grad_main_stride0 = grad_main.stride(0);
-        int64_t grad_main_stride1 = grad_main.stride(1);
-
-        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "anchor_pairs_lookup_backward_na1_kernel", [&] {
-            anchor_pairs_lookup_backward_na1_kernel<scalar_t><<<blocks, threads>>>(
-                total,
-                reinterpret_cast<const int64_t*>(anchor1_ids.data_ptr()),
-                reinterpret_cast<const int64_t*>(anchor2_ids.data_ptr()),
-                reinterpret_cast<const scalar_t*>(lookup_alt_deltas.data_ptr()),
-                reinterpret_cast<const int64_t*>(batch_offset.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_main.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_alt.data_ptr()),
-                grad_main_stride0,
-                grad_main_stride1,
-                batch_size,
-                n_tables,
-                inv_l1,
-                reinterpret_cast<scalar_t*>(x_grad_flat.data_ptr())
-            );
-        });
-        CU_CHECK(cudaGetLastError());
-
-        PROF_END(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-        return x_grad_flat;
-    }
-
-    torch::Tensor
-    anchor_pairs_lookup_backward_na2(
-        const torch::Tensor& x,
-        const torch::Tensor& anchor1_ids,
-        const torch::Tensor& anchor2_ids,
-        const torch::Tensor& lookup_alt_deltas,
-        const torch::Tensor& batch_offset,
-        const torch::Tensor& grad_main,
-        const torch::Tensor& grad_alt,
-        bool inv_l1,
-        int64_t threads_per_block = 256
-    ) {
-        PROF_START(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-
-        if (x.dim() != 2) {
-            throw py::value_error("x must be 2D [batch_size, input_dim]");
-        }
-        if (!x.is_cuda()) {
-            throw py::value_error("x must be CUDA tensor");
-        }
-        if (!x.is_floating_point()) {
-            throw py::value_error("x must be floating point tensor");
-        }
-        if (anchor1_ids.dtype() != torch::kInt64 || anchor2_ids.dtype() != torch::kInt64) {
-            throw py::value_error("anchor1_ids and anchor2_ids must be int64");
-        }
-        if (batch_offset.dtype() != torch::kInt64) {
-            throw py::value_error("batch_offset must be int64");
-        }
-        if (grad_main.dtype() != x.dtype() || grad_alt.dtype() != x.dtype()) {
-            throw py::value_error("grad_main and grad_alt must have the same dtype as x");
-        }
-        if (lookup_alt_deltas.dtype() != x.dtype()) {
-            throw py::value_error("lookup_alt_deltas must have the same dtype as x");
-        }
-        if (anchor1_ids.device() != x.device() || anchor2_ids.device() != x.device() ||
-            lookup_alt_deltas.device() != x.device() || batch_offset.device() != x.device() ||
-            grad_main.device() != x.device() || grad_alt.device() != x.device()) {
-            throw py::value_error("All tensors must be on the same CUDA device");
-        }
-        if (anchor1_ids.numel() != anchor2_ids.numel() ||
-            anchor1_ids.numel() != lookup_alt_deltas.numel() ||
-            anchor1_ids.numel() != batch_offset.numel() ||
-            anchor1_ids.numel() != grad_alt.numel()) {
-            throw py::value_error("anchor1_ids, anchor2_ids, lookup_alt_deltas, batch_offset, grad_alt must have equal numel");
-        }
-        if (threads_per_block <= 0 || threads_per_block > 1024) {
-            throw py::value_error("threads_per_block must be in range [1, 1024]");
-        }
-
-        int64_t batch_size = x.size(0);
-        int64_t input_dim = x.size(1);
-        int64_t n_tables = grad_main.size(1);
-        if (grad_main.size(0) != batch_size) {
-            throw py::value_error("grad_main first dimension must match x batch size");
-        }
-        if (grad_alt.numel() != batch_size * n_tables * 2) {
-            throw py::value_error("grad_alt numel must be batch_size * n_tables * 2 for n_alternatives=2");
-        }
-
-        auto opts_x = torch::TensorOptions().dtype(x.dtype()).device(x.device());
-        torch::Tensor x_grad_flat = torch::zeros({batch_size * input_dim}, opts_x);
-
-        int device = x.device().index();
-        c10::cuda::CUDAGuard guard(device);
-        int64_t total = batch_size * n_tables * 2;
-        int threads = static_cast<int>(threads_per_block);
-        int blocks = static_cast<int>((total + threads - 1) / threads);
-
-        int64_t grad_main_stride0 = grad_main.stride(0);
-        int64_t grad_main_stride1 = grad_main.stride(1);
-
-        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "anchor_pairs_lookup_backward_na2_kernel", [&] {
-            anchor_pairs_lookup_backward_na2_kernel<scalar_t><<<blocks, threads>>>(
-                total,
-                reinterpret_cast<const int64_t*>(anchor1_ids.data_ptr()),
-                reinterpret_cast<const int64_t*>(anchor2_ids.data_ptr()),
-                reinterpret_cast<const scalar_t*>(lookup_alt_deltas.data_ptr()),
-                reinterpret_cast<const int64_t*>(batch_offset.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_main.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_alt.data_ptr()),
-                grad_main_stride0,
-                grad_main_stride1,
-                n_tables,
-                inv_l1,
-                reinterpret_cast<scalar_t*>(x_grad_flat.data_ptr())
-            );
-        });
-        CU_CHECK(cudaGetLastError());
-
-        PROF_END(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-        return x_grad_flat;
-    }
-
-    torch::Tensor
-    anchor_pairs_lookup_backward_na3(
-        const torch::Tensor& x,
-        const torch::Tensor& anchor1_ids,
-        const torch::Tensor& anchor2_ids,
-        const torch::Tensor& lookup_alt_deltas,
-        const torch::Tensor& batch_offset,
-        const torch::Tensor& grad_main,
-        const torch::Tensor& grad_alt,
-        bool inv_l1,
-        int64_t threads_per_block = 256
-    ) {
-        PROF_START(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-
-        if (x.dim() != 2) {
-            throw py::value_error("x must be 2D [batch_size, input_dim]");
-        }
-        if (!x.is_cuda()) {
-            throw py::value_error("x must be CUDA tensor");
-        }
-        if (!x.is_floating_point()) {
-            throw py::value_error("x must be floating point tensor");
-        }
-        if (anchor1_ids.dtype() != torch::kInt64 || anchor2_ids.dtype() != torch::kInt64) {
-            throw py::value_error("anchor1_ids and anchor2_ids must be int64");
-        }
-        if (batch_offset.dtype() != torch::kInt64) {
-            throw py::value_error("batch_offset must be int64");
-        }
-        if (grad_main.dtype() != x.dtype() || grad_alt.dtype() != x.dtype()) {
-            throw py::value_error("grad_main and grad_alt must have the same dtype as x");
-        }
-        if (lookup_alt_deltas.dtype() != x.dtype()) {
-            throw py::value_error("lookup_alt_deltas must have the same dtype as x");
-        }
-        if (anchor1_ids.device() != x.device() || anchor2_ids.device() != x.device() ||
-            lookup_alt_deltas.device() != x.device() || batch_offset.device() != x.device() ||
-            grad_main.device() != x.device() || grad_alt.device() != x.device()) {
-            throw py::value_error("All tensors must be on the same CUDA device");
-        }
-        if (anchor1_ids.numel() != anchor2_ids.numel() ||
-            anchor1_ids.numel() != lookup_alt_deltas.numel() ||
-            anchor1_ids.numel() != batch_offset.numel() ||
-            anchor1_ids.numel() != grad_alt.numel()) {
-            throw py::value_error("anchor1_ids, anchor2_ids, lookup_alt_deltas, batch_offset, grad_alt must have equal numel");
-        }
-        if (threads_per_block <= 0 || threads_per_block > 1024) {
-            throw py::value_error("threads_per_block must be in range [1, 1024]");
-        }
-
-        int64_t batch_size = x.size(0);
-        int64_t input_dim = x.size(1);
-        int64_t n_tables = grad_main.size(1);
-        if (grad_main.size(0) != batch_size) {
-            throw py::value_error("grad_main first dimension must match x batch size");
-        }
-        if (grad_alt.numel() != batch_size * n_tables * 3) {
-            throw py::value_error("grad_alt numel must be batch_size * n_tables * 3 for n_alternatives=3");
-        }
-
-        auto opts_x = torch::TensorOptions().dtype(x.dtype()).device(x.device());
-        torch::Tensor x_grad_flat = torch::zeros({batch_size * input_dim}, opts_x);
-
-        int device = x.device().index();
-        c10::cuda::CUDAGuard guard(device);
-        int64_t total = batch_size * n_tables * 3;
-        int threads = static_cast<int>(threads_per_block);
-        int blocks = static_cast<int>((total + threads - 1) / threads);
-
-        int64_t grad_main_stride0 = grad_main.stride(0);
-        int64_t grad_main_stride1 = grad_main.stride(1);
-
-        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "anchor_pairs_lookup_backward_na3_kernel", [&] {
-            anchor_pairs_lookup_backward_na3_kernel<scalar_t><<<blocks, threads>>>(
-                total,
-                reinterpret_cast<const int64_t*>(anchor1_ids.data_ptr()),
-                reinterpret_cast<const int64_t*>(anchor2_ids.data_ptr()),
-                reinterpret_cast<const scalar_t*>(lookup_alt_deltas.data_ptr()),
-                reinterpret_cast<const int64_t*>(batch_offset.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_main.data_ptr()),
-                reinterpret_cast<const scalar_t*>(grad_alt.data_ptr()),
-                grad_main_stride0,
-                grad_main_stride1,
-                n_tables,
-                inv_l1,
-                reinterpret_cast<scalar_t*>(x_grad_flat.data_ptr())
-            );
-        });
-        CU_CHECK(cudaGetLastError());
-
-        PROF_END(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
-        return x_grad_flat;
-    }
-
     // Backward for generic n_alternatives (matching Python fallback semantics).
     torch::Tensor
     anchor_pairs_lookup_backward_all(
@@ -1898,6 +1658,211 @@ public:
         CU_CHECK(cudaGetLastError());
 
         PROF_END(LUTORCH_MANAGER_ANCHOR_PAIRS_BACKWARD_PROFILER_OP);
+        return x_grad_flat;
+    }
+
+    // ---- WTA Lookup ----
+
+    py::tuple
+    wta_lookup_forward_na1(
+        const torch::Tensor& x,
+        int64_t threads_per_block = 256
+    ) {
+        if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
+        if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
+        if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
+        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
+        if (x.size(2) < 2) throw py::value_error("n_inputs must be >= 2 for n_alternatives=1");
+        if (threads_per_block <= 0 || threads_per_block > 1024)
+            throw py::value_error("threads_per_block must be in range [1, 1024]");
+
+        const int64_t batch_size = x.size(0);
+        const int64_t n_channels = x.size(1);
+        const int64_t n_inputs   = x.size(2);
+        auto opts_i64 = torch::TensorOptions().dtype(torch::kInt64).device(x.device());
+        auto opts_x   = torch::TensorOptions().dtype(x.dtype()).device(x.device());
+
+        torch::Tensor winner_inds = torch::empty({batch_size, n_channels},    opts_i64);
+        torch::Tensor alt_inds    = torch::empty({batch_size, n_channels, 1}, opts_i64);
+        torch::Tensor alt_deltas  = torch::empty({batch_size, n_channels, 1}, opts_x);
+
+        int device = x.device().index();
+        c10::cuda::CUDAGuard guard(device);
+        int64_t total = batch_size * n_channels;
+        int threads = static_cast<int>(threads_per_block);
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na1_kernel", [&] {
+            wta_lookup_forward_na1_kernel<scalar_t><<<blocks, threads>>>(
+                reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                n_channels, n_inputs, total,
+                reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
+                reinterpret_cast<int64_t*>(alt_inds.data_ptr()),
+                reinterpret_cast<scalar_t*>(alt_deltas.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
+
+        py::tuple out(3);
+        out[0] = winner_inds;
+        out[1] = alt_inds;
+        out[2] = alt_deltas;
+        return out;
+    }
+
+    py::tuple
+    wta_lookup_forward_na2(
+        const torch::Tensor& x,
+        int64_t threads_per_block = 256
+    ) {
+        if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
+        if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
+        if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
+        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
+        if (x.size(2) < 3) throw py::value_error("n_inputs must be >= 3 for n_alternatives=2");
+        if (threads_per_block <= 0 || threads_per_block > 1024)
+            throw py::value_error("threads_per_block must be in range [1, 1024]");
+
+        const int64_t batch_size = x.size(0);
+        const int64_t n_channels = x.size(1);
+        const int64_t n_inputs   = x.size(2);
+        auto opts_i64 = torch::TensorOptions().dtype(torch::kInt64).device(x.device());
+        auto opts_x   = torch::TensorOptions().dtype(x.dtype()).device(x.device());
+
+        torch::Tensor winner_inds = torch::empty({batch_size, n_channels},    opts_i64);
+        torch::Tensor alt_inds    = torch::empty({batch_size, n_channels, 2}, opts_i64);
+        torch::Tensor alt_deltas  = torch::empty({batch_size, n_channels, 2}, opts_x);
+
+        int device = x.device().index();
+        c10::cuda::CUDAGuard guard(device);
+        int64_t total = batch_size * n_channels;
+        int threads = static_cast<int>(threads_per_block);
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na2_kernel", [&] {
+            wta_lookup_forward_na2_kernel<scalar_t><<<blocks, threads>>>(
+                reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                n_channels, n_inputs, total,
+                reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
+                reinterpret_cast<int64_t*>(alt_inds.data_ptr()),
+                reinterpret_cast<scalar_t*>(alt_deltas.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
+
+        py::tuple out(3);
+        out[0] = winner_inds;
+        out[1] = alt_inds;
+        out[2] = alt_deltas;
+        return out;
+    }
+
+    py::tuple
+    wta_lookup_forward_na3(
+        const torch::Tensor& x,
+        int64_t threads_per_block = 256
+    ) {
+        if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
+        if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
+        if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
+        if (!x.is_contiguous()) throw py::value_error("x must be contiguous");
+        if (x.size(2) < 4) throw py::value_error("n_inputs must be >= 4 for n_alternatives=3");
+        if (threads_per_block <= 0 || threads_per_block > 1024)
+            throw py::value_error("threads_per_block must be in range [1, 1024]");
+
+        const int64_t batch_size = x.size(0);
+        const int64_t n_channels = x.size(1);
+        const int64_t n_inputs   = x.size(2);
+        auto opts_i64 = torch::TensorOptions().dtype(torch::kInt64).device(x.device());
+        auto opts_x   = torch::TensorOptions().dtype(x.dtype()).device(x.device());
+
+        torch::Tensor winner_inds = torch::empty({batch_size, n_channels},    opts_i64);
+        torch::Tensor alt_inds    = torch::empty({batch_size, n_channels, 3}, opts_i64);
+        torch::Tensor alt_deltas  = torch::empty({batch_size, n_channels, 3}, opts_x);
+
+        int device = x.device().index();
+        c10::cuda::CUDAGuard guard(device);
+        int64_t total = batch_size * n_channels;
+        int threads = static_cast<int>(threads_per_block);
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_forward_na3_kernel", [&] {
+            wta_lookup_forward_na3_kernel<scalar_t><<<blocks, threads>>>(
+                reinterpret_cast<const scalar_t*>(x.data_ptr()),
+                n_channels, n_inputs, total,
+                reinterpret_cast<int64_t*>(winner_inds.data_ptr()),
+                reinterpret_cast<int64_t*>(alt_inds.data_ptr()),
+                reinterpret_cast<scalar_t*>(alt_deltas.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
+
+        py::tuple out(3);
+        out[0] = winner_inds;
+        out[1] = alt_inds;
+        out[2] = alt_deltas;
+        return out;
+    }
+
+    torch::Tensor
+    wta_lookup_backward(
+        const torch::Tensor& x,
+        const torch::Tensor& winner_ids,
+        const torch::Tensor& alt_ids,
+        const torch::Tensor& alt_deltas,
+        const torch::Tensor& batch_offset,
+        const torch::Tensor& grad_main,
+        const torch::Tensor& grad_alt,
+        int64_t n_alternatives,
+        bool inv_l1,
+        int64_t threads_per_block = 256
+    ) {
+        if (x.dim() != 3) throw py::value_error("x must be 3D [batch_size, n_channels, n_inputs]");
+        if (!x.is_cuda()) throw py::value_error("x must be CUDA tensor");
+        if (!x.is_floating_point()) throw py::value_error("x must be floating point tensor");
+        if (winner_ids.dtype() != torch::kInt64 || alt_ids.dtype() != torch::kInt64)
+            throw py::value_error("winner_ids and alt_ids must be int64");
+        if (batch_offset.dtype() != torch::kInt64)
+            throw py::value_error("batch_offset must be int64");
+        if (grad_main.dtype() != x.dtype() || grad_alt.dtype() != x.dtype() || alt_deltas.dtype() != x.dtype())
+            throw py::value_error("grad_main, grad_alt, alt_deltas must have the same dtype as x");
+        if (winner_ids.numel() != alt_ids.numel() ||
+            winner_ids.numel() != alt_deltas.numel() ||
+            winner_ids.numel() != batch_offset.numel() ||
+            winner_ids.numel() != grad_alt.numel())
+            throw py::value_error("winner_ids, alt_ids, alt_deltas, batch_offset, grad_alt must have equal numel");
+        if (n_alternatives < 1 || n_alternatives > 3)
+            throw py::value_error("n_alternatives must be 1, 2, or 3");
+        if (threads_per_block <= 0 || threads_per_block > 1024)
+            throw py::value_error("threads_per_block must be in range [1, 1024]");
+
+        const int64_t batch_size = x.size(0);
+        const int64_t n_channels = x.size(1);
+        const int64_t n_inputs   = x.size(2);
+        auto opts_x = torch::TensorOptions().dtype(x.dtype()).device(x.device());
+        torch::Tensor x_grad_flat = torch::zeros({batch_size * n_channels * n_inputs}, opts_x);
+
+        int device = x.device().index();
+        c10::cuda::CUDAGuard guard(device);
+        int64_t total = batch_size * n_channels * n_alternatives;
+        int threads = static_cast<int>(threads_per_block);
+        int blocks  = static_cast<int>((total + threads - 1) / threads);
+
+        AT_DISPATCH_FLOATING_TYPES(x.scalar_type(), "wta_lookup_backward_kernel", [&] {
+            wta_lookup_backward_kernel<scalar_t><<<blocks, threads>>>(
+                total,
+                reinterpret_cast<const int64_t*>(winner_ids.data_ptr()),
+                reinterpret_cast<const int64_t*>(alt_ids.data_ptr()),
+                reinterpret_cast<const scalar_t*>(alt_deltas.data_ptr()),
+                reinterpret_cast<const int64_t*>(batch_offset.data_ptr()),
+                reinterpret_cast<const scalar_t*>(grad_main.data_ptr()),
+                reinterpret_cast<const scalar_t*>(grad_alt.data_ptr()),
+                grad_main.stride(0), grad_main.stride(1),
+                n_channels, n_alternatives, inv_l1,
+                reinterpret_cast<scalar_t*>(x_grad_flat.data_ptr())
+            );
+        });
+        CU_CHECK(cudaGetLastError());
         return x_grad_flat;
     }
 
@@ -2442,45 +2407,6 @@ void PB_LUTorchManager(py::module& m) {
             py::arg("threads_per_block") = 256
         )
         .def(
-            "anchor_pairs_lookup_backward_na1",
-            &LUTorchManager::anchor_pairs_lookup_backward_na1,
-            py::arg("x"),
-            py::arg("anchor1_ids"),
-            py::arg("anchor2_ids"),
-            py::arg("lookup_alt_deltas"),
-            py::arg("batch_offset"),
-            py::arg("grad_main"),
-            py::arg("grad_alt"),
-            py::arg("inv_l1"),
-            py::arg("threads_per_block") = 256
-        )
-        .def(
-            "anchor_pairs_lookup_backward_na2",
-            &LUTorchManager::anchor_pairs_lookup_backward_na2,
-            py::arg("x"),
-            py::arg("anchor1_ids"),
-            py::arg("anchor2_ids"),
-            py::arg("lookup_alt_deltas"),
-            py::arg("batch_offset"),
-            py::arg("grad_main"),
-            py::arg("grad_alt"),
-            py::arg("inv_l1"),
-            py::arg("threads_per_block") = 256
-        )
-        .def(
-            "anchor_pairs_lookup_backward_na3",
-            &LUTorchManager::anchor_pairs_lookup_backward_na3,
-            py::arg("x"),
-            py::arg("anchor1_ids"),
-            py::arg("anchor2_ids"),
-            py::arg("lookup_alt_deltas"),
-            py::arg("batch_offset"),
-            py::arg("grad_main"),
-            py::arg("grad_alt"),
-            py::arg("inv_l1"),
-            py::arg("threads_per_block") = 256
-        )
-        .def(
             "anchor_pairs_lookup_backward_all",
             &LUTorchManager::anchor_pairs_lookup_backward_all,
             py::arg("x"),
@@ -2490,6 +2416,38 @@ void PB_LUTorchManager(py::module& m) {
             py::arg("batch_offset"),
             py::arg("grad_main"),
             py::arg("grad_alt"),
+            py::arg("inv_l1"),
+            py::arg("threads_per_block") = 256
+        )
+        .def(
+            "wta_lookup_forward_na1",
+            &LUTorchManager::wta_lookup_forward_na1,
+            py::arg("x"),
+            py::arg("threads_per_block") = 256
+        )
+        .def(
+            "wta_lookup_forward_na2",
+            &LUTorchManager::wta_lookup_forward_na2,
+            py::arg("x"),
+            py::arg("threads_per_block") = 256
+        )
+        .def(
+            "wta_lookup_forward_na3",
+            &LUTorchManager::wta_lookup_forward_na3,
+            py::arg("x"),
+            py::arg("threads_per_block") = 256
+        )
+        .def(
+            "wta_lookup_backward",
+            &LUTorchManager::wta_lookup_backward,
+            py::arg("x"),
+            py::arg("winner_ids"),
+            py::arg("alt_ids"),
+            py::arg("alt_deltas"),
+            py::arg("batch_offset"),
+            py::arg("grad_main"),
+            py::arg("grad_alt"),
+            py::arg("n_alternatives"),
             py::arg("inv_l1"),
             py::arg("threads_per_block") = 256
         )

--- a/src/spiky/lutorch/anchor_pairs_lookup.py
+++ b/src/spiky/lutorch/anchor_pairs_lookup.py
@@ -539,8 +539,6 @@ class AnchorPairsLookupFunction(torch.autograd.Function):
         x, anchor1_ids, anchor2_ids, lookup_alt_deltas = ctx.saved_tensors
 
         n_alternatives = lookup_alt_deltas.shape[-1]
-        # For n_alternatives == n_anchor_pairs ("all"), we prefer the PyTorch fallback;
-        # native CUDA is only used for the small specialized cases 1, 2, 3.
         use_native_backward_cuda = (
             _USE_LUTORCH_CUSTOM_CUDA_KERNELS
             and x.is_cuda
@@ -548,7 +546,6 @@ class AnchorPairsLookupFunction(torch.autograd.Function):
             and _get_native_lutorch_manager() is not None
             and anchor1_ids.numel() > 0
             and anchor2_ids.numel() > 0
-            and n_alternatives in (1, 2, 3)
         )
         if use_native_backward_cuda:
             native = _get_native_lutorch_manager()
@@ -556,57 +553,17 @@ class AnchorPairsLookupFunction(torch.autograd.Function):
             flat_anchor2 = anchor2_ids.reshape(-1).contiguous()
             flat_batch_offset = ctx.batch_offset.reshape(-1).contiguous()
             flat_grad_alt = grad_lookup_alt_indices_grad_c.reshape(-1).contiguous()
-
-            if n_alternatives == 1:
-                x_grad_flat = native.anchor_pairs_lookup_backward_na1(
-                    x,
-                    flat_anchor1,
-                    flat_anchor2,
-                    lookup_alt_deltas.reshape(-1).contiguous(),
-                    flat_batch_offset,
-                    grad_lookup_indices_grad_c,
-                    flat_grad_alt,
-                    ctx.inv_l1,
-                    _LUTORCH_CUDA_THREADS_PER_BLOCK,
-                )
-            elif n_alternatives == 2:
-                x_grad_flat = native.anchor_pairs_lookup_backward_na2(
-                    x,
-                    flat_anchor1,
-                    flat_anchor2,
-                    lookup_alt_deltas.reshape(-1).contiguous(),
-                    flat_batch_offset,
-                    grad_lookup_indices_grad_c,
-                    flat_grad_alt,
-                    ctx.inv_l1,
-                    _LUTORCH_CUDA_THREADS_PER_BLOCK,
-                )
-            elif n_alternatives == 3:
-                x_grad_flat = native.anchor_pairs_lookup_backward_na3(
-                    x,
-                    flat_anchor1,
-                    flat_anchor2,
-                    lookup_alt_deltas.reshape(-1).contiguous(),
-                    flat_batch_offset,
-                    grad_lookup_indices_grad_c,
-                    flat_grad_alt,
-                    ctx.inv_l1,
-                    _LUTORCH_CUDA_THREADS_PER_BLOCK,
-                )
-            else:
-                # Generic CUDA backward path expects lookup_alt_deltas with shape [B, T, A],
-                # but flattened anchor ids / batch_offset / grad_alt.
-                x_grad_flat = native.anchor_pairs_lookup_backward_all(
-                    x,
-                    flat_anchor1,
-                    flat_anchor2,
-                    lookup_alt_deltas,
-                    flat_batch_offset,
-                    grad_lookup_indices_grad_c,
-                    flat_grad_alt,
-                    ctx.inv_l1,
-                    _LUTORCH_CUDA_THREADS_PER_BLOCK,
-                )
+            x_grad_flat = native.anchor_pairs_lookup_backward_all(
+                x,
+                flat_anchor1,
+                flat_anchor2,
+                lookup_alt_deltas,
+                flat_batch_offset,
+                grad_lookup_indices_grad_c,
+                flat_grad_alt,
+                ctx.inv_l1,
+                _LUTORCH_CUDA_THREADS_PER_BLOCK,
+            )
             return x_grad_flat.view(x.shape), None, None, None, None, None, None, None
 
         def _anchor_pairs_lookup_backward_impl(

--- a/src/spiky/lutorch/tests/test_wta_lookup.py
+++ b/src/spiky/lutorch/tests/test_wta_lookup.py
@@ -1,9 +1,21 @@
 """Tests for WTALookup module."""
+import contextlib
 import pytest
 import torch
 
 from spiky.lutorch.wta_lookup import WTALookup
+import spiky.lutorch.wta_lookup as wta_lookup_mod
 from spiky.lutorch.lut_helpers import UncertaintyMode
+
+
+@contextlib.contextmanager
+def _use_wta_custom_cuda_kernels(enabled: bool):
+    prev = wta_lookup_mod._USE_LUTORCH_CUSTOM_CUDA_KERNELS
+    wta_lookup_mod._USE_LUTORCH_CUSTOM_CUDA_KERNELS = enabled
+    try:
+        yield
+    finally:
+        wta_lookup_mod._USE_LUTORCH_CUSTOM_CUDA_KERNELS = prev
 
 SEED = 42
 
@@ -145,3 +157,69 @@ def test_wta_lookup_eval_shapes(device):
     assert lookup_indices.shape == (B, C)
     assert lookup_alt_indices.shape == (B, C, nalt)
     assert lookup_alt_deltas.shape == (B, C, nalt)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_alternatives", [1, 2, 3])
+def test_wta_lookup_cuda_matches_fallback_eval(n_alternatives):
+    """Native CUDA forward (eval) must exactly match the PyTorch fallback."""
+    torch.manual_seed(SEED)
+    B, C, N = 5, 7, 20
+    x = torch.randn(B, C, N, device="cuda")
+
+    wta = WTALookup(n_inputs=N, n_alternatives=n_alternatives).cuda().eval()
+    with _use_wta_custom_cuda_kernels(True):
+        wi_cuda, ai_cuda, ad_cuda = wta(x)
+    with _use_wta_custom_cuda_kernels(False):
+        wi_ref, ai_ref, ad_ref = wta(x)
+
+    assert (wi_cuda == wi_ref).all(), "winner indices mismatch"
+    assert (ai_cuda == ai_ref).all(), "alt indices mismatch"
+    torch.testing.assert_close(ad_cuda, ad_ref)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_alternatives", [1, 2, 3])
+def test_wta_lookup_cuda_matches_fallback_train(n_alternatives):
+    """Native CUDA forward+backward (train) must match the PyTorch fallback."""
+    torch.manual_seed(SEED)
+    B, C, N = 4, 6, 16
+    x_cuda = torch.randn(B, C, N, device="cuda", requires_grad=True)
+    x_ref  = x_cuda.detach().clone().requires_grad_(True)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=n_alternatives).cuda().train()
+
+    with _use_wta_custom_cuda_kernels(True):
+        wi_c, ai_c, ad_c, gc_c, gac_c = wta(x_cuda)
+    with _use_wta_custom_cuda_kernels(False):
+        wi_r, ai_r, ad_r, gc_r, gac_r = wta(x_ref)
+
+    assert (wi_c == wi_r).all(), "winner indices mismatch"
+    assert (ai_c == ai_r).all(), "alt indices mismatch"
+    torch.testing.assert_close(ad_c, ad_r)
+
+    (gc_c.sum()).backward()
+    (gc_r.sum()).backward()
+    torch.testing.assert_close(x_cuda.grad, x_ref.grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_alternatives", [1, 2, 3])
+def test_wta_lookup_cuda_strided_input(n_alternatives):
+    """Native CUDA kernels must handle non-contiguous (strided) input correctly."""
+    torch.manual_seed(SEED)
+    B, C, N = 3, 5, 16
+    # Create a strided view by transposing a [C, B, N] tensor → [B, C, N] non-contiguous
+    x_base = torch.randn(C, B, N, device="cuda")
+    x_strided = x_base.permute(1, 0, 2)  # [B, C, N], non-contiguous
+    assert not x_strided.is_contiguous()
+
+    wta = WTALookup(n_inputs=N, n_alternatives=n_alternatives).cuda().eval()
+    with _use_wta_custom_cuda_kernels(True):
+        wi_cuda, ai_cuda, ad_cuda = wta(x_strided)
+    with _use_wta_custom_cuda_kernels(False):
+        wi_ref, ai_ref, ad_ref = wta(x_strided)
+
+    assert (wi_cuda == wi_ref).all(), "winner indices mismatch on strided input"
+    assert (ai_cuda == ai_ref).all(), "alt indices mismatch on strided input"
+    torch.testing.assert_close(ad_cuda, ad_ref)

--- a/src/spiky/lutorch/tests/test_wta_lookup.py
+++ b/src/spiky/lutorch/tests/test_wta_lookup.py
@@ -1,0 +1,147 @@
+"""Tests for WTALookup module."""
+import pytest
+import torch
+
+from spiky.lutorch.wta_lookup import WTALookup
+from spiky.lutorch.lut_helpers import UncertaintyMode
+
+SEED = 42
+
+
+def test_wta_lookup_output_shapes(device):
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 4, 8, 32, 3
+    x = torch.randn(B, C, N, device=device)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).train()
+    lookup_indices, lookup_alt_indices, lookup_alt_deltas, grad_c, grad_alt_c = wta(x)
+
+    assert lookup_indices.shape == (B, C)
+    assert lookup_alt_indices.shape == (B, C, nalt)
+    assert lookup_alt_deltas.shape == (B, C, nalt)
+    assert grad_c.shape == (B, C)
+    assert grad_alt_c.shape == (B, C, nalt)
+
+    assert lookup_indices.dtype == torch.long
+    assert lookup_alt_indices.dtype == torch.long
+    assert lookup_alt_deltas.dtype == x.dtype
+
+
+def test_wta_lookup_winner_is_argmax(device):
+    """lookup_indices must equal argmax over the N dimension."""
+    torch.manual_seed(SEED)
+    B, C, N = 3, 5, 16
+    x = torch.randn(B, C, N, device=device)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=2).to(device).eval()
+    lookup_indices, _, _ = wta(x)
+
+    expected = x.argmax(dim=-1)
+    assert (lookup_indices == expected).all()
+
+
+def test_wta_lookup_alt_deltas_nonneg(device):
+    """winner_val - alt_val must be >= 0 for all alternatives."""
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 4, 6, 20, 4
+    x = torch.randn(B, C, N, device=device)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).train()
+    _, _, lookup_alt_deltas, _, _ = wta(x)
+
+    assert (lookup_alt_deltas >= 0).all()
+
+
+def test_wta_lookup_alt_indices_are_topk(device):
+    """Alt indices must be top-k runner-ups (not the winner itself)."""
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 2, 4, 12, 3
+    x = torch.randn(B, C, N, device=device)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).eval()
+    lookup_indices, lookup_alt_indices, _ = wta(x)
+
+    # Winner must not appear in alternatives
+    winner_in_alts = (lookup_alt_indices == lookup_indices.unsqueeze(-1)).any(dim=-1)
+    assert not winner_in_alts.any()
+
+    # Gathered alt values must be <= winner values
+    winner_vals = x.gather(2, lookup_indices.unsqueeze(-1))           # [B, C, 1]
+    alt_vals = x.gather(2, lookup_alt_indices)                        # [B, C, nalt]
+    assert (winner_vals >= alt_vals).all()
+
+
+def test_wta_lookup_gradient_flows(device):
+    """Gradient carriers must route non-zero gradients back to x."""
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 3, 4, 16, 3
+    x = torch.randn(B, C, N, device=device, requires_grad=True)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).train()
+    _, _, _, grad_c, grad_alt_c = wta(x)
+
+    # grad_diff = grad_main - grad_alt must be non-zero for gradient to flow.
+    # Backprop only through grad_c (grad_main=1, grad_alt=0 → grad_diff=1).
+    loss = grad_c.sum()
+    loss.backward()
+
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert x.grad.abs().sum() > 0, "Expected non-zero gradients on x"
+
+
+def test_wta_lookup_gradient_only_at_winner_and_alts(device):
+    """Gradient must be non-zero only at the winner and alt positions."""
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 2, 3, 10, 2
+    x = torch.randn(B, C, N, device=device, requires_grad=True)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).train()
+    lookup_indices, lookup_alt_indices, _, grad_c, grad_alt_c = wta(x)
+
+    loss = grad_c.sum() + grad_alt_c.sum()
+    loss.backward()
+
+    grad = x.grad                                                   # [B, C, N]
+
+    # Build mask of positions that should receive gradient
+    active = torch.zeros(B, C, N, dtype=torch.bool, device=device)
+    active.scatter_(2, lookup_indices.unsqueeze(-1), True)           # winner
+    active.scatter_(2, lookup_alt_indices, True)                     # alternatives
+
+    # No gradient must flow to non-active positions
+    assert grad[~active].abs().sum() == 0
+
+
+@pytest.mark.parametrize("uncertainty_mode", [
+    UncertaintyMode.INVERSE_L1,
+    UncertaintyMode.INVERSE_QUADRATIC,
+])
+def test_wta_lookup_uncertainty_modes(device, uncertainty_mode):
+    """Both uncertainty modes must produce finite, non-zero gradients."""
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 3, 4, 16, 2
+    x = torch.randn(B, C, N, device=device, requires_grad=True)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt, uncertainty_mode=uncertainty_mode).to(device).train()
+    _, _, _, grad_c, grad_alt_c = wta(x)
+
+    # Backprop only through grad_c so grad_diff = grad_main - grad_alt = 1 - 0 = 1.
+    loss = grad_c.sum()
+    loss.backward()
+
+    assert torch.isfinite(x.grad).all()
+    assert x.grad.abs().sum() > 0
+
+
+def test_wta_lookup_eval_shapes(device):
+    torch.manual_seed(SEED)
+    B, C, N, nalt = 4, 6, 24, 3
+    x = torch.randn(B, C, N, device=device)
+
+    wta = WTALookup(n_inputs=N, n_alternatives=nalt).to(device).eval()
+    lookup_indices, lookup_alt_indices, lookup_alt_deltas = wta(x)
+
+    assert lookup_indices.shape == (B, C)
+    assert lookup_alt_indices.shape == (B, C, nalt)
+    assert lookup_alt_deltas.shape == (B, C, nalt)

--- a/src/spiky/lutorch/wta_lookup.py
+++ b/src/spiky/lutorch/wta_lookup.py
@@ -1,0 +1,299 @@
+"""
+Winner-Take-All lookup implementation.
+"""
+import os
+import torch
+import torch.nn as nn
+from typing import Optional, Tuple
+
+from spiky.lutorch.lut_helpers import UncertaintyMode
+
+_USE_LUTORCH_CUSTOM_CUDA_KERNELS = os.environ.get("SPIKY_LUTORCH_NO_CUSTOM_CUDA_KERNELS", "0") != "1"
+_LUTORCH_CUDA_THREADS_PER_BLOCK = int(os.environ.get("SPIKY_LUTORCH_CUDA_THREADS_PER_BLOCK", "256"))
+if _LUTORCH_CUDA_THREADS_PER_BLOCK < 1 or _LUTORCH_CUDA_THREADS_PER_BLOCK > 1024:
+    raise ValueError(
+        "SPIKY_LUTORCH_CUDA_THREADS_PER_BLOCK must be in range [1, 1024], "
+        f"got {_LUTORCH_CUDA_THREADS_PER_BLOCK}"
+    )
+
+
+def _get_native_lutorch_manager():
+    try:
+        from lutorch_cuda import get_lutorch_manager  # type: ignore[import]
+        return get_lutorch_manager()
+    except Exception:
+        return None
+
+
+class WTALookup(nn.Module):
+    """
+    Winner-Take-All lookup for channeled input.
+
+    Processes input of shape [B, C, n_inputs]. Within each channel, finds the
+    winner (argmax) index and n_alternatives runner-up indices via topk.
+    Returns integer index tensors and gradient carriers that allow smooth
+    gradient propagation back to the input.
+
+    Args:
+        n_inputs: Size of the N dimension (number of candidates per channel).
+        n_alternatives: Number of runner-up indices per channel.
+        uncertainty_mode: Uncertainty function for gradient weighting.
+    """
+
+    def __init__(
+        self,
+        n_inputs: int,
+        n_alternatives: int = 1,
+        uncertainty_mode: UncertaintyMode = UncertaintyMode.INVERSE_L1,
+    ):
+        super().__init__()
+        if n_alternatives < 1:
+            raise ValueError(f"n_alternatives must be >= 1, got {n_alternatives}")
+        self.n_inputs = n_inputs
+        self.n_alternatives = n_alternatives
+        self.uncertainty_mode = uncertainty_mode
+        self._cached_batch_offset: Optional[torch.Tensor] = None
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+        """
+        Forward pass.
+
+        Args:
+            x: Input tensor of shape [B, C, n_inputs].
+
+        Returns:
+            In training mode:
+                - lookup_indices: int64 [B, C]
+                - lookup_alt_indices: int64 [B, C, n_alternatives]
+                - lookup_alt_deltas: float [B, C, n_alternatives]
+                - lookup_indices_grad_c: float [B, C]
+                - lookup_alt_indices_grad_c: float [B, C, n_alternatives]
+            In eval mode:
+                - lookup_indices: int64 [B, C]
+                - lookup_alt_indices: int64 [B, C, n_alternatives]
+                - lookup_alt_deltas: float [B, C, n_alternatives]
+        """
+        if self.training:
+            return self._forward_train(x)
+        return self._forward_eval(x)
+
+    def _forward_eval(
+        self, x: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        use_native = (
+            _USE_LUTORCH_CUSTOM_CUDA_KERNELS
+            and x.is_cuda
+            and x.dtype in (torch.float32, torch.float64)
+            and _get_native_lutorch_manager() is not None
+            and self.n_alternatives in (1, 2, 3)
+        )
+        if use_native:
+            return self._native_forward(x)
+        return self._fallback_forward(x)
+
+    def _forward_train(
+        self, x: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        B, C, _ = x.shape
+        expected_len = B * C * self.n_alternatives
+        if (
+            self._cached_batch_offset is None
+            or self._cached_batch_offset.numel() != expected_len
+            or self._cached_batch_offset.device != x.device
+        ):
+            # offset[bc * n_alternatives + k] = bc * n_inputs, for bc in range(B*C)
+            self._cached_batch_offset = (
+                torch.arange(B * C, device=x.device, dtype=torch.long)
+                .repeat_interleave(self.n_alternatives) * self.n_inputs
+            ).contiguous()
+
+        uncertainty_mode_int = 0 if self.uncertainty_mode == UncertaintyMode.INVERSE_L1 else 1
+        return WTALookupFunction.apply(
+            x, self.n_alternatives, uncertainty_mode_int, self._cached_batch_offset
+        )
+
+    def _native_forward(self, x: torch.Tensor):
+        """Call the native CUDA kernel for forward pass (na1/na2/na3)."""
+        x_c = x.contiguous()
+        native = _get_native_lutorch_manager()
+        if self.n_alternatives == 1:
+            winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na1(
+                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+            )
+        elif self.n_alternatives == 2:
+            winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na2(
+                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+            )
+        else:
+            winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na3(
+                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+            )
+        return winner_inds, alt_inds, alt_deltas
+
+    def _fallback_forward(self, x: torch.Tensor):
+        topk_vals, topk_inds = torch.topk(x, k=self.n_alternatives + 1, dim=-1, largest=True)
+        return topk_inds[:, :, 0], topk_inds[:, :, 1:], topk_vals[:, :, 0:1] - topk_vals[:, :, 1:]
+
+
+class WTALookupFunction(torch.autograd.Function):
+    """Custom autograd function for WTA lookup with smooth gradient propagation."""
+
+    @staticmethod
+    def forward(ctx, x, n_alternatives, uncertainty_mode_int, batch_offset):
+        """
+        Args:
+            x: float [B, C, N]
+            n_alternatives: int
+            uncertainty_mode_int: 0 = INVERSE_L1, 1 = INVERSE_QUADRATIC
+            batch_offset: int64 [B*C*n_alternatives]
+
+        Returns:
+            lookup_indices: int64 [B, C]
+            lookup_alt_indices: int64 [B, C, n_alternatives]
+            lookup_alt_deltas: float [B, C, n_alternatives]  (winner_val - alt_val, always >= 0)
+            lookup_indices_grad_c: float [B, C]
+            lookup_alt_indices_grad_c: float [B, C, n_alternatives]
+        """
+        B, C, N = x.shape
+        BC = B * C
+
+        use_native = (
+            _USE_LUTORCH_CUSTOM_CUDA_KERNELS
+            and x.is_cuda
+            and x.dtype in (torch.float32, torch.float64)
+            and _get_native_lutorch_manager() is not None
+            and n_alternatives in (1, 2, 3)
+        )
+        if use_native:
+            x_c = x.contiguous()
+            native = _get_native_lutorch_manager()
+            if n_alternatives == 1:
+                winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na1(
+                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                )
+            elif n_alternatives == 2:
+                winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na2(
+                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                )
+            else:
+                winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na3(
+                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                )
+            # winner_inds: [B, C]; alt_inds: [B, C, n_alt]; alt_deltas: [B, C, n_alt]
+            # Flatten to [BC] / [BC, n_alt] for save_for_backward
+            winner_inds_flat = winner_inds.view(BC).contiguous()
+            alt_inds_flat    = alt_inds.view(BC, n_alternatives).contiguous()
+            alt_deltas_flat  = alt_deltas.view(BC, n_alternatives).contiguous()
+        else:
+            topk_vals, topk_inds = torch.topk(
+                x.view(BC, N), k=n_alternatives + 1, dim=-1, largest=True
+            )
+            winner_inds_flat = topk_inds[:, 0].contiguous()                        # [BC]
+            alt_inds_flat    = topk_inds[:, 1:].contiguous()                       # [BC, n_alt]
+            alt_deltas_flat  = (topk_vals[:, 0:1] - topk_vals[:, 1:]).contiguous() # [BC, n_alt]
+            winner_inds = winner_inds_flat.view(B, C)
+            alt_inds    = alt_inds_flat.view(B, C, n_alternatives)
+            alt_deltas  = alt_deltas_flat.view(B, C, n_alternatives)
+
+        z = x.sum() * 0
+        lookup_indices_grad_c     = z.expand(B, C)
+        lookup_alt_indices_grad_c = z.expand(B, C, n_alternatives)
+
+        ctx.inv_l1          = (uncertainty_mode_int == 0)
+        ctx.batch_offset    = batch_offset
+        ctx.B               = B
+        ctx.C               = C
+        ctx.N               = N
+        ctx.n_alternatives  = n_alternatives
+        ctx.save_for_backward(x, winner_inds_flat, alt_inds_flat, alt_deltas_flat)
+
+        return (
+            winner_inds,
+            alt_inds,
+            alt_deltas,
+            lookup_indices_grad_c,
+            lookup_alt_indices_grad_c,
+        )
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        """
+        Propagates gradients back to x via the uncertainty function.
+
+        Only grad_lookup_indices_grad_c and grad_lookup_alt_indices_grad_c carry
+        meaningful gradients (the integer index outputs have no gradient path).
+
+        Gradient rule mirrors AnchorPairsLookup:
+            du[b,c,k] = grad_diff[b,c,k] * d(uncertainty)/d(delta[b,c,k])
+            x_grad[b, c, winner_idx]  +=  du[b,c,k]  (summed over k)
+            x_grad[b, c, alt_idx[k]] -=  du[b,c,k]
+        """
+        (
+            _,
+            _,
+            _,
+            grad_lookup_indices_grad_c,
+            grad_lookup_alt_indices_grad_c,
+        ) = grad_outputs
+
+        x, winner_inds_flat, alt_inds_flat, alt_deltas_flat = ctx.saved_tensors
+        B, C, N = ctx.B, ctx.C, ctx.N
+        BC = B * C
+        n_alternatives = ctx.n_alternatives
+
+        use_native = (
+            _USE_LUTORCH_CUSTOM_CUDA_KERNELS
+            and x.is_cuda
+            and x.dtype in (torch.float32, torch.float64)
+            and _get_native_lutorch_manager() is not None
+            and n_alternatives in (1, 2, 3)
+        )
+        if use_native:
+            native = _get_native_lutorch_manager()
+            # winner_ids: [BC*n_alt] — winner index repeated once per alternative
+            winner_ids_flat = winner_inds_flat.repeat_interleave(n_alternatives).contiguous()
+            alt_ids_flat    = alt_inds_flat.reshape(-1).contiguous()
+            alt_deltas_bc   = alt_deltas_flat.reshape(-1).contiguous()
+            grad_alt_flat   = grad_lookup_alt_indices_grad_c.reshape(-1).contiguous()
+
+            x_grad_flat = native.wta_lookup_backward(
+                x.contiguous(),
+                winner_ids_flat, alt_ids_flat, alt_deltas_bc,
+                ctx.batch_offset,
+                grad_lookup_indices_grad_c.contiguous(),
+                grad_alt_flat,
+                n_alternatives, ctx.inv_l1, _LUTORCH_CUDA_THREADS_PER_BLOCK,
+            )
+            return x_grad_flat.view(B, C, N), None, None, None
+
+        alt_deltas_bca = alt_deltas_flat.view(B, C, n_alternatives)
+        grad_main = grad_lookup_indices_grad_c          # [B, C]
+        grad_alt  = grad_lookup_alt_indices_grad_c      # [B, C, n_alternatives]
+
+        grad_diff = grad_main.unsqueeze(2) - grad_alt   # [B, C, n_alternatives]
+
+        if ctx.inv_l1:
+            abs_delta = alt_deltas_bca.abs()
+            one_plus_abs = 1.0 + abs_delta
+            minus_uncertainty_derivative = (
+                0.5 * alt_deltas_bca.sign() / (one_plus_abs * one_plus_abs)
+            )
+        else:
+            delta_sq = alt_deltas_bca * alt_deltas_bca
+            one_plus_sq = 1.0 + delta_sq
+            minus_uncertainty_derivative = alt_deltas_bca / (one_plus_sq * one_plus_sq)
+
+        du = grad_diff * minus_uncertainty_derivative   # [B, C, n_alternatives]
+        if n_alternatives > 1:
+            du = du / n_alternatives
+
+        batch_offset  = ctx.batch_offset
+        winner_repeated = winner_inds_flat.repeat_interleave(n_alternatives)
+        alt_flat      = alt_inds_flat.reshape(-1)
+        du_flat       = du.reshape(-1)
+
+        x_grad_flat = torch.zeros(BC * N, device=x.device, dtype=x.dtype)
+        x_grad_flat.scatter_add_(0, batch_offset + winner_repeated, du_flat)
+        x_grad_flat.scatter_add_(0, batch_offset + alt_flat, -du_flat)
+
+        return x_grad_flat.view(B, C, N), None, None, None

--- a/src/spiky/lutorch/wta_lookup.py
+++ b/src/spiky/lutorch/wta_lookup.py
@@ -114,19 +114,18 @@ class WTALookup(nn.Module):
 
     def _native_forward(self, x: torch.Tensor):
         """Call the native CUDA kernel for forward pass (na1/na2/na3)."""
-        x_c = x.contiguous()
         native = _get_native_lutorch_manager()
         if self.n_alternatives == 1:
             winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na1(
-                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                x, _LUTORCH_CUDA_THREADS_PER_BLOCK
             )
         elif self.n_alternatives == 2:
             winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na2(
-                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                x, _LUTORCH_CUDA_THREADS_PER_BLOCK
             )
         else:
             winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na3(
-                x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                x, _LUTORCH_CUDA_THREADS_PER_BLOCK
             )
         return winner_inds, alt_inds, alt_deltas
 
@@ -165,19 +164,18 @@ class WTALookupFunction(torch.autograd.Function):
             and n_alternatives in (1, 2, 3)
         )
         if use_native:
-            x_c = x.contiguous()
             native = _get_native_lutorch_manager()
             if n_alternatives == 1:
                 winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na1(
-                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                    x, _LUTORCH_CUDA_THREADS_PER_BLOCK
                 )
             elif n_alternatives == 2:
                 winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na2(
-                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                    x, _LUTORCH_CUDA_THREADS_PER_BLOCK
                 )
             else:
                 winner_inds, alt_inds, alt_deltas = native.wta_lookup_forward_na3(
-                    x_c, _LUTORCH_CUDA_THREADS_PER_BLOCK
+                    x, _LUTORCH_CUDA_THREADS_PER_BLOCK
                 )
             # winner_inds: [B, C]; alt_inds: [B, C, n_alt]; alt_deltas: [B, C, n_alt]
             # Flatten to [BC] / [BC, n_alt] for save_for_backward


### PR DESCRIPTION
## Summary

- **WTALookup**: new `nn.Module` that processes `[B, C, N]` input, finds the winner (argmax) and `n_alternatives` runner-up indices per channel, and returns gradient carriers for smooth backprop via the uncertainty function (`INVERSE_L1` or `INVERSE_QUADRATIC`)
- **Native CUDA**: `wta_lookup_forward_na1/na2/na3` kernels (single-pass top-k scan) and a unified `wta_lookup_backward_kernel` (controlled by `SPIKY_LUTORCH_NO_CUSTOM_CUDA_KERNELS`)
- **Pytest tests**: 9 tests covering shapes, argmax correctness, non-negative deltas, top-k runner-ups, gradient flow, gradient sparsity, and both uncertainty modes (50 total including CPU+CUDA)
- **Backward consolidation**: removed the redundant `anchor_pairs_lookup_backward_na1/na2/na3` CUDA kernels, C++ wrappers, and pybind bindings — Python backward now always calls the generic `anchor_pairs_lookup_backward_all` path

## Test plan
- [x] `pytest src/spiky/lutorch/tests/` — all 50 tests pass (CPU + CUDA)
- [x] Rebuild `native/lutorch` and confirm no compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)