### PR TITLE
Test torch.compile on/off for CUDA in all lutorch tests

### DIFF
--- a/src/spiky/lutorch/anchor_pairs_lookup.py
+++ b/src/spiky/lutorch/anchor_pairs_lookup.py
@@ -57,7 +57,7 @@ def _maybe_compile(fn):
 
     def wrapper(*args, **kwargs):
         device = _first_tensor_device(args, kwargs)
-        if device is not None and device.type == "cuda" and compiled_fn is not None:
+        if device is not None and device.type == "cuda" and compiled_fn is not None and _USE_LUTORCH_COMPILE:
             return compiled_fn(*args, **kwargs)
         return fn(*args, **kwargs)
 

--- a/src/spiky/lutorch/l_projection.py
+++ b/src/spiky/lutorch/l_projection.py
@@ -67,7 +67,7 @@ def _maybe_compile(fn):
 
     def wrapper(*args, **kwargs):
         device = _first_tensor_device(args, kwargs)
-        if device is not None and device.type == "cuda" and compiled_fn is not None:
+        if device is not None and device.type == "cuda" and compiled_fn is not None and _USE_LUTORCH_COMPILE:
             return compiled_fn(*args, **kwargs)
         return fn(*args, **kwargs)
 

--- a/src/spiky/lutorch/tests/conftest.py
+++ b/src/spiky/lutorch/tests/conftest.py
@@ -1,22 +1,34 @@
 import os
 
 # Must be set before lutorch modules are imported.
-os.environ.setdefault("SPIKY_LUTORCH_NO_COMPILE", "1")
 os.environ.setdefault("SPIKY_GT_NO_COMPILE", "1")
 
 import pytest
 import torch
 
+_CUDA_AVAILABLE = torch.cuda.is_available()
+_CUDA_MARK = pytest.mark.skipif(not _CUDA_AVAILABLE, reason="CUDA required")
+
+_LUTORCH_COMPILE_MODULES = [
+    "spiky.lutorch.anchor_pairs_lookup",
+    "spiky.lutorch.wta_lookup",
+    "spiky.lutorch.l_projection",
+]
+
+
 @pytest.fixture(
     params=[
         "cpu",
-        pytest.param(
-            "cuda",
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available(), reason="CUDA required"
-            ),
-        ),
+        pytest.param("cuda", marks=_CUDA_MARK),
+        pytest.param("cuda-no-compile", marks=_CUDA_MARK),
     ]
 )
-def device(request):
-    return request.param
+def device(request, monkeypatch):
+    d = request.param
+    if d == "cuda-no-compile":
+        import importlib
+        for mod_name in _LUTORCH_COMPILE_MODULES:
+            mod = importlib.import_module(mod_name)
+            monkeypatch.setattr(mod, "_USE_LUTORCH_COMPILE", False)
+        return "cuda"
+    return d

--- a/src/spiky/lutorch/wta_lookup.py
+++ b/src/spiky/lutorch/wta_lookup.py
@@ -48,7 +48,7 @@ def _maybe_compile(fn):
 
     def wrapper(*args, **kwargs):
         device = _first_tensor_device(args, kwargs)
-        if device is not None and device.type == "cuda" and compiled_fn is not None:
+        if device is not None and device.type == "cuda" and compiled_fn is not None and _USE_LUTORCH_COMPILE:
             return compiled_fn(*args, **kwargs)
         return fn(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

- `_maybe_compile` wrapper in all three modules now re-checks `_USE_LUTORCH_COMPILE` at call time (module-global lookup), enabling per-test monkeypatching
- `conftest.py`: drop `SPIKY_LUTORCH_NO_COMPILE=1`; add `cuda-no-compile` device variant that patches `_USE_LUTORCH_COMPILE=False` in `anchor_pairs_lookup`, `wta_lookup`, and `l_projection`
- CUDA tests now run twice: once with `torch.compile` active, once without
- CPU tests unaffected (wrapper already skips the compiled path for non-CUDA tensors)
- 84 tests pass (up from 59)

## Test plan
- [ ] `pytest src/spiky/lutorch/tests/` — 84 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)