### PR TITLE
Suppress torch.overrides deprecation warnings in pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pip install pytest
 # All tests (CPU + CUDA)
 .venv/bin/python -m pytest src/spiky/lutorch/tests/ -v
 
-# CPU only (fast, ~40 s)
+# CPU only
 .venv/bin/python -m pytest src/spiky/lutorch/tests/ -v -k cpu
 
 # Single file

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 filterwarnings =
     ignore::UserWarning:torch._inductor
+    ignore:'has_cuda' is deprecated:UserWarning:torch
+    ignore:'has_cudnn' is deprecated:UserWarning:torch
+    ignore:'has_mps' is deprecated:UserWarning:torch
+    ignore:'has_mkldnn' is deprecated:UserWarning:torch


### PR DESCRIPTION
## Summary

- `torch.compile` on older PyTorch versions triggers `UserWarning` from `torch/overrides.py` about deprecated `has_cuda`/`has_cudnn`/`has_mps`/`has_mkldnn`; filter them in `pytest.ini`
- Minor README fix: remove stale CPU test timing note

## Test plan
- [ ] `pytest src/spiky/lutorch/tests/ -W error::UserWarning` — 84 passed, no warnings leak through

🤖 Generated with [Claude Code](https://claude.com/claude-code)