### PR TITLE
Add WTA, ProjectionWTA, Conv2DWTA modules; rename Conv2DLut → Conv2DLUT

### DIFF
--- a/src/spiky/lutorch/multi_head_lut.py
+++ b/src/spiky/lutorch/multi_head_lut.py
@@ -484,7 +484,7 @@ class ProjectionLUT(nn.Module):
         return out_flat.view(B, self.H_out, self.W_out)
 
 
-class Conv2DLut(nn.Module):
+class Conv2DLUT(nn.Module):
     """
     2D convolution-style LUT built on top of ``MultiHeadLut`` for inputs
     of shape ``[B, C, H, W]``.
@@ -582,12 +582,12 @@ class Conv2DLut(nn.Module):
         B, C, H, W = x.shape
         if C != self.in_channels:
             raise ValueError(
-                f"Input channels C={C} do not match Conv2DLut configuration "
+                f"Input channels C={C} do not match Conv2DLUT configuration "
                 f"in_channels={self.in_channels}"
             )
         if (H, W) != (self.unfold_config.H, self.unfold_config.W):
             raise ValueError(
-                f"Input spatial size {(H, W)} does not match Conv2DLut configuration "
+                f"Input spatial size {(H, W)} does not match Conv2DLUT configuration "
                 f"({self.unfold_config.H}, {self.unfold_config.W})"
             )
 
@@ -617,3 +617,7 @@ class Conv2DLut(nn.Module):
         lut_out_patches = lut_out_flat.view(B, self.n_patches, total_outputs)
         lut_out_spatial = lut_out_patches.view(B, self.H_p, self.W_p, total_outputs)
         return lut_out_spatial.permute(0, 3, 1, 2).contiguous()
+
+
+# Backward-compatible alias.
+Conv2DLut = Conv2DLUT

--- a/src/spiky/lutorch/multi_head_wta.py
+++ b/src/spiky/lutorch/multi_head_wta.py
@@ -1,0 +1,383 @@
+"""
+WTA module combining WTALookup and LProjection, and spatial wrappers.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional
+
+from spiky.lutorch.wta_lookup import WTALookup
+from spiky.lutorch.l_projection import LProjection
+from spiky.lutorch.lut_helpers import UncertaintyMode
+from spiky.lutorch.multi_head_lut import UnfoldConfiguration
+
+
+class WTA(nn.Module):
+    """
+    WTA (Winner-Take-All) module combining WTALookup and LProjection.
+
+    Processes input of shape [B, n_channels, n_inputs]. Each channel runs an
+    independent WTA (argmax + n_alternatives runner-ups) over its n_inputs
+    values. LProjection maps the selected indices to output features.
+
+    Args:
+        n_channels: Number of independent WTA channels (C in [B, C, n_inputs]).
+        n_inputs: Number of candidates per channel
+        n_outputs: Number of output dimensions per channel.
+        n_alternatives: Number of runner-up indices per channel (default: 1).
+        smooth_mode: If True, use smooth interpolation in LProjection (default: False).
+        device: Device to place weight buffers on.
+        uncertainty_mode: Uncertainty function for gradient weighting.
+        initial_weights_noise: Std of Gaussian added to LProjection weights at init.
+        dropout: Dropout probability applied to the output (default: 0.0).
+        random_seed: Seed for weight initialisation noise.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        n_inputs: int,
+        n_outputs: int,
+        n_alternatives: int = 1,
+        smooth_mode: bool = False,
+        device: Optional[torch.device] = None,
+        uncertainty_mode: UncertaintyMode = UncertaintyMode.INVERSE_L1,
+        initial_weights_noise: float = 0.001,
+        dropout: float = 0.0,
+        random_seed: Optional[int] = None,
+    ):
+        super().__init__()
+        self.n_channels = n_channels
+        self.n_inputs = n_inputs
+        self.n_outputs = n_outputs
+        self.n_alternatives = n_alternatives
+        self.smooth_mode = smooth_mode
+        self.uncertainty_mode = uncertainty_mode
+        self.dropout = nn.Dropout(dropout) if dropout > 0.0 else None
+
+        self.wta_lookup = WTALookup(n_inputs, n_alternatives, uncertainty_mode)
+        self.projection = LProjection(
+            n_lookup_tables=n_channels,
+            n_entries_per_table=n_inputs,
+            n_outputs=n_outputs,
+            n_alternatives=n_alternatives,
+            smooth_mode=smooth_mode,
+            device=device,
+            uncertainty_mode=uncertainty_mode,
+        )
+        if initial_weights_noise != 0.0:
+            dev = device or torch.device("cpu")
+            with torch.no_grad():
+                rng_kwargs: dict = {"device": dev}
+                if random_seed is not None:
+                    rng_kwargs["generator"] = torch.Generator(device=dev).manual_seed(random_seed)
+                self.projection.weights.add_(
+                    torch.randn(self.projection.weights.shape, **rng_kwargs) * initial_weights_noise
+                )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass.
+
+        Args:
+            x: Input tensor of shape [B, n_channels, n_inputs].
+
+        Returns:
+            Output tensor of shape [B, n_channels, n_outputs].
+        """
+        if self.training:
+            (
+                lookup_indices,
+                lookup_alt_indices,
+                lookup_alt_deltas,
+                lookup_indices_grad_c,
+                lookup_alt_indices_grad_c,
+            ) = self.wta_lookup(x)
+        else:
+            lookup_indices, lookup_alt_indices, lookup_alt_deltas = self.wta_lookup(x)
+            lookup_indices_grad_c = None
+            lookup_alt_indices_grad_c = None
+
+        output = self.projection(
+            lookup_indices=lookup_indices,
+            lookup_alt_indices=lookup_alt_indices,
+            lookup_alt_deltas=lookup_alt_deltas,
+            lookup_indices_grad_c=lookup_indices_grad_c,
+            lookup_alt_indices_grad_c=lookup_alt_indices_grad_c,
+        )  # [B, n_channels, n_outputs]
+
+        if self.dropout is not None:
+            output = self.dropout(output)
+
+        return output
+
+
+class ProjectionWTA(nn.Module):
+    """
+    Projection WTA built on top of WTA using 2D unfold-style patching.
+
+    Takes a flat spatial input of shape [B, H, W], unfolds it into patches of
+    size kH * kW, and applies WTA independently to each patch. Each patch
+    position becomes one WTA channel; the WTA selects the strongest value
+    within the kernel window and maps it to n_outputs features.
+
+    Without fold_config, output shape is [B, H_p, W_p, n_outputs].
+
+    With fold_config, the per-patch outputs are scattered back into an output
+    spatial grid via scatter-add, producing shape [B, H_out, W_out]. This
+    mirrors the fold_config behaviour of ProjectionLUT.
+
+    Args:
+        unfold_config: UnfoldConfiguration describing input shape and patch
+            geometry. Padding must be 0.
+        n_outputs: Number of output dimensions per patch.
+        fold_config: Optional UnfoldConfiguration for the output grid. Must
+            produce the same number of patches as unfold_config.
+        device: Device for weight buffers.
+        **wta_kwargs: Forwarded to WTA (e.g. n_alternatives, smooth_mode, etc.).
+    """
+
+    def __init__(
+        self,
+        unfold_config: UnfoldConfiguration,
+        n_outputs: int,
+        fold_config: Optional[UnfoldConfiguration] = None,
+        device: Optional[torch.device] = None,
+        **wta_kwargs,
+    ):
+        super().__init__()
+        self.unfold_config = unfold_config
+        self.fold_config = fold_config
+        self.n_outputs = n_outputs
+
+        (kH, kW), (sH, sW), (pH, pW) = self.unfold_config.normalized()
+        if (pH, pW) != (0, 0):
+            raise ValueError(
+                f"ProjectionWTA requires unfold_config padding to be 0; got padding=({pH}, {pW})"
+            )
+
+        H_p, W_p = self.unfold_config.output_spatial_shape()
+        if H_p <= 0 or W_p <= 0:
+            raise ValueError(
+                f"Invalid patch grid size from H={self.unfold_config.H}, W={self.unfold_config.W}, "
+                f"kernel_size={self.unfold_config.kernel_size}, stride={self.unfold_config.stride}"
+            )
+
+        self.H_p = H_p
+        self.W_p = W_p
+        self.n_patches = H_p * W_p
+        self._kH = kH
+        self._kW = kW
+        self._sH = sH
+        self._sW = sW
+
+        dev = device or torch.device("cpu")
+
+        if self.fold_config is not None:
+            (kH_f, kW_f), (sH_f, sW_f), _ = self.fold_config.normalized()
+            H_p_f, W_p_f = self.fold_config.output_spatial_shape()
+            n_patches_f = H_p_f * W_p_f
+            if n_patches_f != self.n_patches:
+                raise ValueError(
+                    f"fold_config must produce the same number of patches as unfold_config "
+                    f"({n_patches_f} != {self.n_patches})"
+                )
+
+            self.H_out = self.fold_config.H
+            self.W_out = self.fold_config.W
+
+            index_grid_out = torch.arange(
+                self.H_out * self.W_out, device=dev, dtype=torch.long,
+            ).view(1, 1, self.H_out, self.W_out)
+
+            patches_out = F.unfold(
+                index_grid_out.to(dtype=torch.float32),
+                kernel_size=(kH_f, kW_f),
+                dilation=1,
+                stride=(sH_f, sW_f),
+            )  # [1, K_f, n_patches]
+            patches_out = (
+                patches_out.squeeze(0).to(dtype=torch.long).transpose(0, 1).contiguous()
+            )  # [n_patches, K_f]
+
+            K_f = patches_out.shape[1]
+            if K_f < self.n_outputs:
+                raise ValueError(
+                    f"Each fold patch must contain at least n_outputs indices; "
+                    f"got K_f={K_f} < n_outputs={self.n_outputs}"
+                )
+
+            rnd = torch.rand(self.n_patches, K_f, device=dev)
+            selected_cols = torch.topk(rnd, k=self.n_outputs, dim=1, largest=True).indices
+            fold_output_indices = patches_out.gather(1, selected_cols).contiguous()
+            self.register_buffer("fold_output_indices", fold_output_indices)
+            self.register_buffer("fold_output_indices_flat", fold_output_indices.view(1, -1))
+            self.register_buffer("_cached_batch_offsets", None)
+
+        self.wta = WTA(
+            n_channels=self.n_patches,
+            n_inputs=kH * kW,
+            n_outputs=n_outputs,
+            device=device,
+            **wta_kwargs,
+        )
+        self._cached_batch_offsets = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Input tensor of shape [B, H, W].
+
+        Returns:
+            - If fold_config is None: tensor of shape [B, H_p, W_p, n_outputs].
+            - If fold_config is set: tensor of shape [B, H_out, W_out].
+        """
+        if x.dim() != 3:
+            raise ValueError(f"Expected 3D input [B, H, W], got shape {x.shape}")
+
+        B, H, W = x.shape
+        if (H, W) != (self.unfold_config.H, self.unfold_config.W):
+            raise ValueError(
+                f"Input spatial size {(H, W)} does not match ProjectionWTA configuration "
+                f"({self.unfold_config.H}, {self.unfold_config.W})"
+            )
+
+        # [B, kH*kW, n_patches] -> [B, n_patches, kH*kW]
+        patches = F.unfold(
+            x.unsqueeze(1),
+            kernel_size=(self._kH, self._kW),
+            dilation=1,
+            padding=0,
+            stride=(self._sH, self._sW),
+        ).transpose(1, 2).contiguous()
+
+        # [B, n_patches, n_outputs]
+        out = self.wta(patches)
+
+        if self.fold_config is None:
+            return out.view(B, self.H_p, self.W_p, self.n_outputs)
+
+        P, O = self.n_patches, self.n_outputs
+        flat_out_dim = self.H_out * self.W_out
+
+        indices_exp = self.fold_output_indices.unsqueeze(0).expand(B, -1, -1)  # [B, P, O]
+        indices_flat = indices_exp.reshape(-1)
+        values_flat = out.reshape(-1)
+
+        expected_len = B * P * O
+        if (
+            self._cached_batch_offsets is None
+            or self._cached_batch_offsets.numel() != expected_len
+            or self._cached_batch_offsets.device != out.device
+        ):
+            self._cached_batch_offsets = (
+                torch.arange(B, device=out.device, dtype=torch.long)
+                .repeat_interleave(P * O) * flat_out_dim
+            )
+
+        scatter_indices = indices_flat + self._cached_batch_offsets
+
+        out_flat = torch.zeros(B * flat_out_dim, device=out.device, dtype=out.dtype)
+        out_flat.scatter_add_(0, scatter_indices, values_flat)
+
+        return out_flat.view(B, self.H_out, self.W_out)
+
+
+class Conv2DWTA(nn.Module):
+    """
+    2D convolution-style WTA built on top of WTA for inputs of shape [B, C, H, W].
+
+    Unfolds the input into spatial patches of size C * kH * kW. Each patch is
+    treated as a single WTA channel: WTA selects the winning feature position
+    within the flattened patch and maps it to out_channels output features via
+    LProjection. Weights are shared across all spatial locations.
+
+    Output shape: [B, out_channels, H_p, W_p].
+
+    Args:
+        unfold_config: UnfoldConfiguration describing input shape and patch geometry.
+        in_channels: Number of input channels C.
+        out_channels: Number of output channels.
+        device: Device for weight buffers.
+        **wta_kwargs: Forwarded to WTA.
+    """
+
+    def __init__(
+        self,
+        unfold_config: UnfoldConfiguration,
+        in_channels: int,
+        out_channels: int,
+        device: Optional[torch.device] = None,
+        **wta_kwargs,
+    ):
+        super().__init__()
+
+        self.unfold_config = unfold_config
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        (kH, kW), _, _ = self.unfold_config.normalized()
+
+        H_p, W_p = self.unfold_config.output_spatial_shape()
+        if H_p <= 0 or W_p <= 0:
+            raise ValueError(
+                f"Invalid patch grid size from H={self.unfold_config.H}, W={self.unfold_config.W}, "
+                f"kernel_size={self.unfold_config.kernel_size}, stride={self.unfold_config.stride}"
+            )
+
+        self.H_p = H_p
+        self.W_p = W_p
+        self.n_patches = H_p * W_p
+        self.patch_dim = in_channels * kH * kW
+
+        # One WTA channel per spatial location; weights shared across locations.
+        self.wta = WTA(
+            n_channels=1,
+            n_inputs=self.patch_dim,
+            n_outputs=out_channels,
+            device=device,
+            **wta_kwargs,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Input tensor of shape [B, C, H, W].
+
+        Returns:
+            Tensor of shape [B, out_channels, H_p, W_p].
+        """
+        if x.dim() != 4:
+            raise ValueError(f"Expected 4D input [B, C, H, W], got shape {x.shape}")
+
+        B, C, H, W = x.shape
+        if C != self.in_channels:
+            raise ValueError(
+                f"Input channels C={C} do not match Conv2DWTA in_channels={self.in_channels}"
+            )
+        if (H, W) != (self.unfold_config.H, self.unfold_config.W):
+            raise ValueError(
+                f"Input spatial size {(H, W)} does not match Conv2DWTA configuration "
+                f"({self.unfold_config.H}, {self.unfold_config.W})"
+            )
+
+        (kH, kW), (sH, sW), (pH, pW) = self.unfold_config.normalized()
+
+        # [B, patch_dim, n_patches] -> [B*n_patches, 1, patch_dim]
+        patches = F.unfold(
+            x,
+            kernel_size=(kH, kW),
+            dilation=1,
+            padding=(pH, pW),
+            stride=(sH, sW),
+        ).transpose(1, 2).contiguous().view(B * self.n_patches, 1, self.patch_dim)
+
+        # [B*n_patches, 1, out_channels] -> [B, out_channels, H_p, W_p]
+        wta_out = self.wta(patches)
+        return (
+            wta_out
+            .view(B, self.n_patches, self.out_channels)
+            .view(B, self.H_p, self.W_p, self.out_channels)
+            .permute(0, 3, 1, 2)
+            .contiguous()
+        )

--- a/src/spiky/lutorch/tests/test_multi_head_wta.py
+++ b/src/spiky/lutorch/tests/test_multi_head_wta.py
@@ -1,0 +1,360 @@
+"""Tests for WTA, ProjectionWTA, and Conv2DWTA modules."""
+import pytest
+import torch
+
+from spiky.lutorch.multi_head_wta import WTA, ProjectionWTA, Conv2DWTA
+from spiky.lutorch.multi_head_lut import UnfoldConfiguration
+from spiky.lutorch.lut_helpers import UncertaintyMode
+
+SEED = 42
+
+
+@pytest.mark.parametrize("n_alternatives", [1, 3])
+@pytest.mark.parametrize("smooth_mode", [False, True])
+def test_wta_modules_smoke(device, smooth_mode, n_alternatives):
+    """
+    Smoke test for all three WTA modules (WTA, ProjectionWTA, Conv2DWTA).
+    Checks output shapes in train and eval, finiteness, and gradient flow.
+    """
+    torch.manual_seed(SEED)
+    B = 3
+    dev = torch.device(device)
+    kwargs = dict(n_alternatives=n_alternatives, smooth_mode=smooth_mode,
+                  random_seed=SEED, device=dev)
+
+    # --- WTA: [B, n_channels, n_inputs] -> [B, n_channels, n_outputs] ---
+    n_channels, n_inputs, n_outputs = 6, 16, 8
+    wta = WTA(n_channels=n_channels, n_inputs=n_inputs, n_outputs=n_outputs, **kwargs)
+    x_wta = torch.randn(B, n_channels, n_inputs, device=device)
+
+    wta.train()
+    out = wta(x_wta)
+    assert out.shape == (B, n_channels, n_outputs) and torch.isfinite(out).all()
+    out.sum().backward()
+    assert torch.isfinite(wta.projection.weights.grad).all()
+
+    wta.eval()
+    with torch.no_grad():
+        out = wta(x_wta)
+    assert out.shape == (B, n_channels, n_outputs) and torch.isfinite(out).all()
+
+    # --- ProjectionWTA: [B, H, W] -> [B, H_p, W_p, n_outputs] ---
+    H, W, n_out_proj = 8, 8, 4
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=2)
+    H_p, W_p = cfg.output_spatial_shape()
+    pwta = ProjectionWTA(cfg, n_outputs=n_out_proj, **kwargs)
+    x_proj = torch.randn(B, H, W, device=device)
+
+    pwta.train()
+    out = pwta(x_proj)
+    assert out.shape == (B, H_p, W_p, n_out_proj) and torch.isfinite(out).all()
+    out.sum().backward()
+    assert torch.isfinite(pwta.wta.projection.weights.grad).all()
+
+    pwta.eval()
+    with torch.no_grad():
+        out = pwta(x_proj)
+    assert out.shape == (B, H_p, W_p, n_out_proj) and torch.isfinite(out).all()
+
+    # --- Conv2DWTA: [B, C, H, W] -> [B, out_channels, H_p, W_p] ---
+    C, out_channels = 4, 16
+    cfg2 = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=2)
+    H_p2, W_p2 = cfg2.output_spatial_shape()
+    cwta = Conv2DWTA(cfg2, in_channels=C, out_channels=out_channels, **kwargs)
+    x_conv = torch.randn(B, C, H, W, device=device)
+
+    cwta.train()
+    out = cwta(x_conv)
+    assert out.shape == (B, out_channels, H_p2, W_p2) and torch.isfinite(out).all()
+    out.sum().backward()
+    assert torch.isfinite(cwta.wta.projection.weights.grad).all()
+
+    cwta.eval()
+    with torch.no_grad():
+        out = cwta(x_conv)
+    assert out.shape == (B, out_channels, H_p2, W_p2) and torch.isfinite(out).all()
+
+
+# ---------------------------------------------------------------------------
+# WTA
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n_alternatives", [1, 3])
+@pytest.mark.parametrize("smooth_mode", [False, True])
+def test_wta_output_shape(device, n_alternatives, smooth_mode):
+    """Output shape is [B, n_channels, n_outputs] in both train and eval."""
+    torch.manual_seed(SEED)
+    B, n_channels, n_inputs, n_outputs = 4, 6, 16, 8
+
+    m = WTA(
+        n_channels=n_channels,
+        n_inputs=n_inputs,
+        n_outputs=n_outputs,
+        n_alternatives=n_alternatives,
+        smooth_mode=smooth_mode,
+        random_seed=SEED,
+        device=torch.device(device),
+    )
+    x = torch.randn(B, n_channels, n_inputs, device=device)
+
+    m.train()
+    out = m(x)
+    assert out.shape == (B, n_channels, n_outputs)
+    assert torch.isfinite(out).all()
+
+    m.eval()
+    with torch.no_grad():
+        out = m(x)
+    assert out.shape == (B, n_channels, n_outputs)
+    assert torch.isfinite(out).all()
+
+
+@pytest.mark.parametrize("smooth_mode", [False, True])
+def test_wta_backward(device, smooth_mode):
+    """Gradients flow to projection weights in both smooth and non-smooth modes."""
+    torch.manual_seed(SEED)
+    B, n_channels, n_inputs, n_outputs = 3, 4, 12, 6
+
+    m = WTA(
+        n_channels=n_channels,
+        n_inputs=n_inputs,
+        n_outputs=n_outputs,
+        n_alternatives=2,
+        smooth_mode=smooth_mode,
+        random_seed=SEED,
+        device=torch.device(device),
+    ).train()
+
+    m(torch.randn(B, n_channels, n_inputs, device=device)).sum().backward()
+
+    assert m.projection.weights.grad is not None
+    assert torch.isfinite(m.projection.weights.grad).all()
+
+
+def test_wta_training_stays_finite(device):
+    """Loss and parameters stay finite over 50 SGD iterations."""
+    torch.manual_seed(SEED)
+    B, n_channels, n_inputs, n_outputs = 4, 6, 16, 8
+
+    m = WTA(
+        n_channels=n_channels,
+        n_inputs=n_inputs,
+        n_outputs=n_outputs,
+        n_alternatives=3,
+        smooth_mode=True,
+        random_seed=SEED,
+        device=torch.device(device),
+    ).train()
+    opt = torch.optim.SGD(m.parameters(), lr=0.1)
+
+    for i in range(50):
+        x = torch.randn(B, n_channels, n_inputs, device=device)
+        loss = ((m(x) - torch.randn(B, n_channels, n_outputs, device=device)) ** 2).mean()
+        assert torch.isfinite(loss), f"iter {i}: non-finite loss"
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        for name, p in m.named_parameters():
+            assert torch.isfinite(p).all(), f"iter {i}: non-finite param {name}"
+
+
+@pytest.mark.parametrize("uncertainty_mode", [
+    UncertaintyMode.INVERSE_L1,
+    UncertaintyMode.INVERSE_QUADRATIC,
+])
+def test_wta_uncertainty_modes(device, uncertainty_mode):
+    """Both uncertainty modes produce finite outputs and gradients."""
+    torch.manual_seed(SEED)
+    B, n_channels, n_inputs, n_outputs = 2, 4, 10, 5
+
+    m = WTA(
+        n_channels=n_channels,
+        n_inputs=n_inputs,
+        n_outputs=n_outputs,
+        n_alternatives=2,
+        smooth_mode=True,
+        uncertainty_mode=uncertainty_mode,
+        device=torch.device(device),
+    ).train()
+
+    out = m(torch.randn(B, n_channels, n_inputs, device=device))
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+    assert torch.isfinite(m.projection.weights.grad).all()
+
+
+# ---------------------------------------------------------------------------
+# ProjectionWTA
+# ---------------------------------------------------------------------------
+
+def test_projection_wta_output_shape(device):
+    """Output shape is [B, H_p, W_p, n_outputs] in both train and eval."""
+    torch.manual_seed(SEED)
+    B, H, W, n_outputs = 3, 8, 8, 4
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=1)
+    H_p, W_p = cfg.output_spatial_shape()  # 6, 6
+
+    m = ProjectionWTA(
+        cfg,
+        n_outputs=n_outputs,
+        n_alternatives=2,
+        smooth_mode=True,
+        random_seed=SEED,
+        device=torch.device(device),
+    )
+    x = torch.randn(B, H, W, device=device)
+
+    m.train()
+    out = m(x)
+    assert out.shape == (B, H_p, W_p, n_outputs)
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+
+    m.eval()
+    with torch.no_grad():
+        out = m(x)
+    assert out.shape == (B, H_p, W_p, n_outputs)
+    assert torch.isfinite(out).all()
+
+
+def test_projection_wta_stride(device):
+    """Output spatial shape follows unfold formula with stride > 1."""
+    torch.manual_seed(SEED)
+    B, H, W = 2, 16, 16
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=4, stride=2)
+    H_p, W_p = cfg.output_spatial_shape()  # 7, 7
+
+    m = ProjectionWTA(cfg, n_outputs=8, n_alternatives=1, device=torch.device(device)).eval()
+    with torch.no_grad():
+        out = m(torch.randn(B, H, W, device=device))
+    assert out.shape == (B, H_p, W_p, 8)
+
+
+def test_projection_wta_wrong_input_shape(device):
+    """ValueError on wrong spatial input size."""
+    cfg = UnfoldConfiguration(H=8, W=8, kernel_size=3, stride=1)
+    m = ProjectionWTA(cfg, n_outputs=4, device=torch.device(device)).eval()
+    with pytest.raises(ValueError, match="does not match ProjectionWTA"):
+        m(torch.randn(2, 10, 10, device=device))
+
+
+def test_projection_wta_fold_config(device):
+    """With fold_config, output is [B, H_out, W_out] and gradients flow."""
+    torch.manual_seed(SEED)
+    B, H, W = 3, 8, 8
+    # unfold: (8, k=4, s=2) → (8+0-4)//2+1 = 3 → 3×3 = 9 patches
+    # fold:   (8, k=4, s=2) → same 3×3 = 9 patches, output grid 8×8
+    unfold_cfg = UnfoldConfiguration(H=H, W=W, kernel_size=4, stride=2)
+    fold_cfg = UnfoldConfiguration(H=H, W=W, kernel_size=4, stride=2)
+    assert unfold_cfg.output_spatial_shape() == fold_cfg.output_spatial_shape()
+
+    m = ProjectionWTA(
+        unfold_cfg,
+        n_outputs=4,
+        fold_config=fold_cfg,
+        n_alternatives=2,
+        smooth_mode=True,
+        random_seed=SEED,
+        device=torch.device(device),
+    )
+    x = torch.randn(B, H, W, device=device)
+
+    m.train()
+    out = m(x)
+    assert out.shape == (B, fold_cfg.H, fold_cfg.W)
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+
+    m.eval()
+    with torch.no_grad():
+        out = m(x)
+    assert out.shape == (B, fold_cfg.H, fold_cfg.W)
+    assert torch.isfinite(out).all()
+
+
+def test_projection_wta_backward(device):
+    """Gradients flow through ProjectionWTA."""
+    torch.manual_seed(SEED)
+    B, H, W = 2, 8, 8
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=1)
+    m = ProjectionWTA(
+        cfg, n_outputs=4, n_alternatives=2, smooth_mode=True,
+        device=torch.device(device),
+    ).train()
+
+    m(torch.randn(B, H, W, device=device)).sum().backward()
+    assert torch.isfinite(m.wta.projection.weights.grad).all()
+
+
+# ---------------------------------------------------------------------------
+# Conv2DWTA
+# ---------------------------------------------------------------------------
+
+def test_conv2d_wta_output_shape(device):
+    """Output shape is [B, out_channels, H_p, W_p] in both train and eval."""
+    torch.manual_seed(SEED)
+    B, C, H, W, out_channels = 3, 4, 8, 8, 16
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=2)
+    H_p, W_p = cfg.output_spatial_shape()  # 3, 3
+
+    m = Conv2DWTA(
+        cfg,
+        in_channels=C,
+        out_channels=out_channels,
+        n_alternatives=2,
+        smooth_mode=True,
+        random_seed=SEED,
+        device=torch.device(device),
+    )
+    x = torch.randn(B, C, H, W, device=device)
+
+    m.train()
+    out = m(x)
+    assert out.shape == (B, out_channels, H_p, W_p)
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+
+    m.eval()
+    with torch.no_grad():
+        out = m(x)
+    assert out.shape == (B, out_channels, H_p, W_p)
+    assert torch.isfinite(out).all()
+
+
+def test_conv2d_wta_with_padding(device):
+    """Conv2DWTA handles padding correctly (same-size output)."""
+    torch.manual_seed(SEED)
+    B, C, H, W = 2, 3, 8, 8
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=1, padding=1)
+    H_p, W_p = cfg.output_spatial_shape()  # 8, 8
+
+    m = Conv2DWTA(
+        cfg, in_channels=C, out_channels=4,
+        n_alternatives=1, device=torch.device(device),
+    ).eval()
+    with torch.no_grad():
+        out = m(torch.randn(B, C, H, W, device=device))
+    assert out.shape == (B, 4, H_p, W_p)
+
+
+def test_conv2d_wta_wrong_channels(device):
+    """ValueError on wrong number of input channels."""
+    cfg = UnfoldConfiguration(H=8, W=8, kernel_size=3, stride=1)
+    m = Conv2DWTA(cfg, in_channels=3, out_channels=4, device=torch.device(device)).eval()
+    with pytest.raises(ValueError, match="in_channels"):
+        m(torch.randn(2, 5, 8, 8, device=device))
+
+
+def test_conv2d_wta_backward(device):
+    """Gradients flow through Conv2DWTA."""
+    torch.manual_seed(SEED)
+    B, C, H, W = 2, 3, 8, 8
+    cfg = UnfoldConfiguration(H=H, W=W, kernel_size=3, stride=2)
+    m = Conv2DWTA(
+        cfg, in_channels=C, out_channels=8,
+        n_alternatives=3, smooth_mode=True,
+        device=torch.device(device),
+    ).train()
+
+    m(torch.randn(B, C, H, W, device=device)).sum().backward()
+    assert torch.isfinite(m.wta.projection.weights.grad).all()

--- a/src/spiky/lutorch/tests/test_multi_head_wta.py
+++ b/src/spiky/lutorch/tests/test_multi_head_wta.py
@@ -31,7 +31,7 @@ def test_wta_modules_smoke(device, smooth_mode, n_alternatives):
     out = wta(x_wta)
     assert out.shape == (B, n_channels, n_outputs) and torch.isfinite(out).all()
     out.sum().backward()
-    assert torch.isfinite(wta.projection.weights.grad).all()
+    assert wta.projection.weights.grad.norm() > 0
 
     wta.eval()
     with torch.no_grad():
@@ -49,7 +49,7 @@ def test_wta_modules_smoke(device, smooth_mode, n_alternatives):
     out = pwta(x_proj)
     assert out.shape == (B, H_p, W_p, n_out_proj) and torch.isfinite(out).all()
     out.sum().backward()
-    assert torch.isfinite(pwta.wta.projection.weights.grad).all()
+    assert pwta.wta.projection.weights.grad.norm() > 0
 
     pwta.eval()
     with torch.no_grad():
@@ -67,7 +67,7 @@ def test_wta_modules_smoke(device, smooth_mode, n_alternatives):
     out = cwta(x_conv)
     assert out.shape == (B, out_channels, H_p2, W_p2) and torch.isfinite(out).all()
     out.sum().backward()
-    assert torch.isfinite(cwta.wta.projection.weights.grad).all()
+    assert cwta.wta.projection.weights.grad.norm() > 0
 
     cwta.eval()
     with torch.no_grad():
@@ -128,7 +128,7 @@ def test_wta_backward(device, smooth_mode):
     m(torch.randn(B, n_channels, n_inputs, device=device)).sum().backward()
 
     assert m.projection.weights.grad is not None
-    assert torch.isfinite(m.projection.weights.grad).all()
+    assert m.projection.weights.grad.norm() > 0
 
 
 def test_wta_training_stays_finite(device):
@@ -180,7 +180,7 @@ def test_wta_uncertainty_modes(device, uncertainty_mode):
     out = m(torch.randn(B, n_channels, n_inputs, device=device))
     assert torch.isfinite(out).all()
     out.sum().backward()
-    assert torch.isfinite(m.projection.weights.grad).all()
+    assert m.projection.weights.grad.norm() > 0
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +283,7 @@ def test_projection_wta_backward(device):
     ).train()
 
     m(torch.randn(B, H, W, device=device)).sum().backward()
-    assert torch.isfinite(m.wta.projection.weights.grad).all()
+    assert m.wta.projection.weights.grad.norm() > 0
 
 
 # ---------------------------------------------------------------------------
@@ -357,4 +357,4 @@ def test_conv2d_wta_backward(device):
     ).train()
 
     m(torch.randn(B, C, H, W, device=device)).sum().backward()
-    assert torch.isfinite(m.wta.projection.weights.grad).all()
+    assert m.wta.projection.weights.grad.norm() > 0


### PR DESCRIPTION
## Summary
- **`WTA`**: base module combining `WTALookup` + `LProjection`; processes `[B, n_channels, n_inputs]` → `[B, n_channels, n_outputs]`
- **`ProjectionWTA`**: wraps `WTA` with 2D unfold patching on `[B, H, W]`; supports `fold_config` (same scatter-add pattern as `ProjectionLUT`) for `[B, H_out, W_out]` output
- **`Conv2DWTA`**: wraps `WTA` for `[B, C, H, W]` inputs; one shared WTA channel per spatial location, weights shared across locations
- **`Conv2DLUT`**: rename of `Conv2DLut` with backward-compat alias
- **Tests**: smoke test covering all three modules (train/eval shapes, finiteness, gradients) + focused tests for training stability, fold_config, padding, uncertainty modes, error handling

## Test plan
- [ ] `pytest src/spiky/lutorch/tests/` — 150 passed