### PR TITLE
Fix CUDA 13.0 cuCtxCreate API change

### DIFF
--- a/native/common/misc.cpp
+++ b/native/common/misc.cpp
@@ -17,7 +17,12 @@ TCudaContext::TCudaContext(int gpu, unsigned int flags) {
     CU_CHECK(cuDeviceGet(&cuDevice, gpu));
     char szDeviceName[80];
     CU_CHECK(cuDeviceGetName(szDeviceName, sizeof(szDeviceName), cuDevice));
+#if CUDA_VERSION >= 13000
+    CUctxCreateParams ctxParams = {};
+    CU_CHECK(cuCtxCreate(&Context_, &ctxParams, flags, cuDevice));
+#else
     CU_CHECK(cuCtxCreate(&Context_, flags, cuDevice));
+#endif
 }
 
 void TCudaContext::Reset() {

--- a/native/spiky/misc/misc.cpp
+++ b/native/spiky/misc/misc.cpp
@@ -17,7 +17,12 @@ TCudaContext::TCudaContext(int gpu, unsigned int flags) {
     CU_CHECK(cuDeviceGet(&cuDevice, gpu));
     char szDeviceName[80];
     CU_CHECK(cuDeviceGetName(szDeviceName, sizeof(szDeviceName), cuDevice));
+#if CUDA_VERSION >= 13000
+    CUctxCreateParams ctxParams = {};
+    CU_CHECK(cuCtxCreate(&Context_, &ctxParams, flags, cuDevice));
+#else
     CU_CHECK(cuCtxCreate(&Context_, flags, cuDevice));
+#endif
 }
 
 void TCudaContext::Reset() {


### PR DESCRIPTION
CUDA 13.0 changed cuCtxCreate to require a CUctxCreateParams struct and a 4-argument signature. Add version check to use the new API on CUDA >= 13.0 and fall back to the old 3-argument signature otherwise.

Affects both native/common and native/spiky context initialization.