### PR TITLE
native: build CUDA extensions with -std=c++20 for torch>=2.9

### DIFF
--- a/native/lutorch/setup.py
+++ b/native/lutorch/setup.py
@@ -86,12 +86,14 @@ def _get_ext_modules():
                 sources_cuda,
                 extra_compile_args={
                     "cxx": [
+                        "-std=c++20",
                         "-I",
                         "/usr/local/cuda/include",
                         "-Ofast",
                     ]
                     + BUILD_INTEGERS_COMPILE_ARGS,
                     "nvcc": [
+                        "-std=c++20",
                         "-I",
                         "/usr/local/cuda/include",
                         f"--compiler-bindir={gpp_dir}",

--- a/native/spiky/setup.py
+++ b/native/spiky/setup.py
@@ -166,11 +166,13 @@ def _get_ext_modules():
                     sources_list_cuda,
                     extra_compile_args={
                         "cxx": [
+                            "-std=c++20",
                             "-I",
                             "/usr/local/cuda/include",
                             "-Ofast",
                         ] + BUILD_INTEGERS_COMPILE_ARGS,
                         "nvcc": [
+                            "-std=c++20",
                             "-I",
                             "/usr/local/cuda/include",
                             f"--compiler-bindir={gpp_dir}",


### PR DESCRIPTION
Build fix so the CUDA extensions compile against **torch ≥ 2.9** on the **CUDA 13 / Blackwell (sm_120)** toolchain.

`torch` 2.9 moved some ATen headers (`ATen/core/List_inl.h`) to C++20 optional-`typename` (P0634). Building the extensions at the default C++17 fails with:

```
error: need 'typename' before '...' because ... is a dependent scope
```

This adds `-std=c++20` to both the `cxx` and `nvcc` `extra_compile_args` for `lutorch_cuda` (`native/lutorch/setup.py`) and `spiky_cuda` (`native/spiky/setup.py`). torch then skips its own `-std=c++17`.

Verified on gpustar (Ubuntu 26.04, CUDA 13.3, torch 2.9.1+cu130, RTX 5090): both extensions build and all test suites pass.

_Opened by spikyclaudebot as a pipeline test._