### PR TITLE
claude: add scientific knowledge base (claude/ folder)

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -1,0 +1,41 @@
+# `claude/` — scientific knowledge base for the spiky project
+
+This folder is the **shared, version-controlled memory** for AI assistants (Claude and
+others) working on **spiky**. Historically this knowledge lived only in each assistant's
+private per-machine memory; as the project spreads across multiple machines it belongs
+here, in the repo, so any assistant on any host inherits the same understanding.
+
+**Audience:** a capable coding/research assistant who has just been pointed at this repo
+and needs to understand *what spiky is trying to do*, *what has already been learned*, and
+*what not to re-try*. It is written to be read top-to-bottom on first contact.
+
+## What's here (read in this order)
+
+1. **[thesis.md](thesis.md)** — the *why*. The scientific thesis behind spiky/LUTGPT:
+   differentiable lookup tables as a permutation-coded, (nearly) matmul-free transformer.
+   Start here.
+2. **[experiment-journey.md](experiment-journey.md)** — the *what we tried*. The arc of
+   ~250 experiments that produced LUTGPT: the eras, the durable mechanistic lessons (the
+   load-bearing knowledge), the dead-ends that are already falsified, and the gotchas.
+   Read this before designing a new experiment so you don't repeat settled work.
+3. **[experiment-archive.md](experiment-archive.md)** — *where the data is*. How to find
+   the full historical experimental record (configs / metrics / summaries for ~1,366 runs)
+   and how to verify any specific experiment number or figure.
+
+## Scope and boundaries
+
+- **This is the scientific record only** — the settled findings and the reasoning behind
+  them. The *methodology* for how experiments are conducted (branching, launching runs,
+  and — going forward — coordinating work across multiple machines) is deliberately **not**
+  in this first cut; it is being defined separately and will be added here later.
+- **Anchor of truth:** the single most authoritative scientific document is the **LUTGPT
+  research report** (`doc/lutorch/lutgpt_research_report.pdf` in this repo). Where these
+  notes and the report disagree, the report wins. These notes are a distilled, navigable
+  companion to it — not a replacement.
+- **Epistemic caveat:** these are distilled observations, accurate as of when they were
+  written. Trust the *lessons*; verify a specific experiment id, bpb figure, or code
+  citation against the report and the archive ([experiment-archive.md](experiment-archive.md))
+  before quoting it as fact. Code moves; the mechanistic conclusions have been stable.
+
+This folder is meant to grow. When you learn something durable and general about the
+science, add it here (in a PR) rather than leaving it in a single assistant's private memory.

--- a/claude/experiment-archive.md
+++ b/claude/experiment-archive.md
@@ -1,0 +1,66 @@
+# Where the historical experiment data lives
+
+*How to find and verify the full experimental record behind [thesis.md](thesis.md) and
+[experiment-journey.md](experiment-journey.md).*
+
+## The archive branch
+
+The complete pre-2026-07 experimental record lives on **one non-obvious branch** of this
+repo:
+
+```
+feature/lutorch-calibrate-output-normalize-weights
+```
+
+The name looks like a stray feature branch, but it is actually **the archive** — the sole
+surviving copy of the experimental record from the earlier (Nebius-era) work. It is kept
+**read-only as history**; do not add new work to it.
+
+## What's on it
+
+- **~1,366 experiment directories** under `nanochat_exps/`, `transformer_exps/`,
+  `transformer_paper_exps/`, and `lut_lm/` — each with `config.json`, `metrics.csv`,
+  `summary.json` (and plots). These are the source of truth for any experiment number or bpb
+  figure quoted in the thesis / journey notes.
+- The experiment **journals** — `.../experiments.md`, `nanochat_exps/EXPERIMENTS.md`,
+  `research_report_draft.md` — plus the top-level `eval_*` / `bench_*` / `diag_*` / `probe_*`
+  scripts.
+- `doc/`, `docs/`, and the code as it stood at that point in history.
+
+## The one exception: no checkpoints
+
+**Model checkpoints are NOT in git** (no `.pt` / `.pth` / `.safetensors` / `.ckpt` tracked —
+too large). The original checkpoints are effectively gone; only configs, metrics, and
+summaries survive. **To reproduce a result, re-run from its `config.json`** — not from a
+saved checkpoint.
+
+## How to look things up
+
+You do not need to check the whole branch out. From inside a clone of this repo:
+
+```bash
+# make sure you have the branch
+git fetch origin feature/lutorch-calibrate-output-normalize-weights
+
+# find an experiment by number/name
+git ls-tree -r --name-only \
+  origin/feature/lutorch-calibrate-output-normalize-weights | grep <exp>
+
+# read a single file without checking out
+git show \
+  'origin/feature/lutorch-calibrate-output-normalize-weights:<path>'
+
+# or, if you need the whole tree at once, use a worktree:
+git worktree add ../spiky-archive \
+  origin/feature/lutorch-calibrate-output-normalize-weights
+```
+
+Note: `main` does **not** contain this data — the archive is only on that branch. Verify any
+specific experiment id or figure here before quoting it as established fact.
+
+## Going forward
+
+This branch is the **old** archive. New research does not append to it; going forward each
+idea is developed on its own branch and only decisive results are curated into `main`. The
+exact multi-machine workflow is being defined separately and will be documented alongside
+these notes.

--- a/claude/experiment-journey.md
+++ b/claude/experiment-journey.md
@@ -1,0 +1,95 @@
+# The experiment journey behind LUTGPT
+
+*What was tried, the lineage of results, the durable mechanistic lessons, and the dead-ends
+already falsified. The science/why is in [thesis.md](thesis.md); this is the "what we tried."
+Distilled from ~90 project notes plus the experiment journals.*
+
+> **Caveat on experiment ids.** Numbering is era-local and partly reused across eras. Trust
+> the *lessons* below; verify any specific experiment number or figure against the historical
+> record ([experiment-archive.md](experiment-archive.md)) and the LUTGPT research report
+> before quoting it.
+
+## Eras (the arc)
+
+1. **Byte-level FineWeb** (V = 257, T = 32; metric val CE; vanilla 4.87M = 1.356).
+   Brute-force LUT attention → discovered the NAP/tph tradeoff, full-coverage anchor
+   sampling, concat positional encoding, the **V3 softmax** breakthrough (separate "what to
+   attend to" from "how to combine"), then **Ranking Attention** (Kendall-τ ≡ cosine of ±1
+   dominance signatures → SDPA) and **HyperLUT**. Best LUT within ~0.025 CE of vanilla but at
+   26× params. The gap was diagnosed as **representational, not optimizational**.
+2. **Nanochat BPE** (ClimbMix, V = 32,768, T = 512; metric val **bpb**). Port + scale. A big
+   unembedder MLP was found dominant, then dropped in favor of the dual-stream design. RoPE
+   resets the baseline.
+3. **Dual-stream LUT-LM + RoPE** (the workhorse). E-stream rank backbone + D-stream Euclidean
+   readout + linear unembedder; the E-stream **pre-norm identity skip** gave a discontinuous
+   ~−60 mb jump; fused qkv; no FFN. Batch size emerges as *the* lever → the first decisive
+   beats of vanilla.
+4. **FastMHL deployment era** (16k–24k steps): shift to **native hard-forward** training
+   (single lookup at inference — the real product goal), dense-K backward, kernel wgrad /
+   dispatch tuning → the report's exp709 / 754 / 755 / 760 lineup (the headline table is in
+   [thesis.md](thesis.md)).
+
+## Durable mechanistic lessons (the load-bearing knowledge)
+
+- **Gradient sparsity is THE bottleneck.** Each LUT row is updated by only ~tens of tokens
+  per microbatch (dense vanilla weights see every token). This is fixed at 1/K by the
+  architecture itself. Everything below follows from it.
+- **Batch size is the dominant lever**, and it acts as pure gradient-variance reduction:
+  `grad_accum` reproduces native big-batch training to within ±0.01 bpb. No cheap
+  optimizer/LUT trick beats the baseline by more than ±0.01; only more *effective batch*
+  (or distillation) moves the needle. Moderate **NAP ∈ {4,5,6}** are within 0.002 of each
+  other (>6 needs a bigger batch). Coverage rule of thumb: keep ≥ ~200 tokens per row.
+- **Two convergence regimes.** The LUT model is *more* token-efficient than vanilla early
+  (~first 3k steps), then vanilla descends ~1.4–1.7× faster late. The real research target
+  is the **late slope**.
+- **Soft vs. hard forward.** A soft/blended forward is a *better function* (~−16 mb) but is
+  not matmul-free and **not hardenable** (post-hoc hardening of a soft model adds ~+0.25).
+  The win is the soft *forward* (representational); dense soft *weight-grad* coverage alone is
+  exactly neutral. The answer: **train natively hard with a rich (dense-K) backward**;
+  **hybrid_smooth** (exact top-2 softmax over the main row + its best Hamming-1 alternative)
+  is the deployable middle that recovers most of the soft gap at 2 reads. Note
+  `softmax = exp-Hamming kernel` — every non-normalized / non-peaked gate (relu, gelu,
+  layernorm, signed) loses.
+- **Optimizer: LION β = (0.9, 0.95)** matches AdamW at *half* the state (Adam's √v̂ magnitude
+  normalization is not the lever on LUT tables); **β2 = 0.95 is the sweet spot** (LION's
+  default 0.99 costs +0.04); effective lut_lr ≈ 2e-4.
+- **RoPE ≫ learned positions**, and *more so* for a LUT-LM (a learned additive position must
+  survive the qk argmax quantization; RoPE injects position *after* the LUT into smooth SDPA
+  space, zero-param).
+- **Pre-LUT MeanAbsNorm = per-token magnitude calibration** (keeps the pairwise differences
+  in T_soft's regime); any positive scale is equivalent, mean-abs is cheapest, a learnable
+  affine is inert.
+- **Architecture wins that stuck:** the dual E/D stream; the **E-stream identity skip**
+  (the biggest single architectural jump); fused **qkv_lut** + a shallow V-branch + a
+  separate `v_lut`; **no FFN** (out_proj absorbs it); concentrating readout in ONE
+  end-of-stack `read_out_lut` (per-layer D-injections were redundant); **per-head routing is
+  structurally load-bearing** (collapsing to H = 1 costs mb); **don't mix LUT and dense in
+  the same block** (be fully-LUT or fully-vanilla — LUT composition only emerges when all
+  trunk modules are LUT). **Lever ranking:** batch ≫ tph > NAP > D-width > E/d_v; heads,
+  anchor-learning, multi-NAP-at-scale, and dual-heads all lost. The **linear unembedder is
+  irreplaceable** — pure-LUT vocab heads floor at ~2.12 bpb vs. ~1.5 (sparse K-vote logits
+  are a weaker output distribution). Per-module NAP rule: qk wants wide-shallow (NAP ≈ 4),
+  decoders (v / out / residual) want deeper (NAP ≈ 6), read_out NAP ≈ 5.
+
+## Dead-ends / falsified (do NOT re-run without a genuinely new reason)
+
+Probabilistic forward (sample a row); soft-winner forward (**diverges** — never couple
+output magnitude to selection confidence); STE hard-sign + softmax (the soft apparatus is an
+inseparable package); soft weight-grad (neutral); windowed-grad smoothing (Adam β1 already
+does it); inter-table cosine contrastive (init is already orthogonal); **qkv trainable
+anchors** (random anchors are already near-optimal); big-head MLP; dual heads (don't stack);
+hard-example mining / inverse-freq loss / per-row LR / Lookahead / β1 = 0.99 (all within
+±0.01 or worse); LUT / tied-LUT unembedder; half-LUT hybrid (vanilla-attn + LUT-FFN); custom
+triton wgrad (can't beat torch.compile's fusion ceiling); bf16 LUT weights *in training*
+(slower, no tensor-core win — inference-only).
+
+## Gotchas
+
+- **Bit-packing convention.** hybrid_smooth / soft packs bits MSB-first; STE / hard packs
+  LSB-first. Naively hard-evaluating a hybrid_smooth checkpoint reads the wrong rows
+  (+1.73 bpb). Either bit-reverse the weight tensor on axis 1, or just use `FastMultiHeadLut`
+  (which is internally consistent) for deployment-targeted runs.
+- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` roughly halves the reserved footprint of
+  soft runs.
+- **The fair baseline is UNtied vanilla.** A LUT-LM is structurally forced to be untied;
+  comparing against a *tied* vanilla inflates the apparent gap.

--- a/claude/thesis.md
+++ b/claude/thesis.md
@@ -1,0 +1,120 @@
+# The thesis behind spiky / LUTGPT
+
+*The scientific "why" of the project. The single most authoritative source is the **LUTGPT
+research report** (`doc/lutorch/lutgpt_research_report.pdf`). The experimental arc that
+tested all of this is in [experiment-journey.md](experiment-journey.md).*
+
+## The premise (Izhikevich's "Spiking Manifesto", arXiv:2512.11843, Dec 2025)
+
+Brains are ~1000× more energy-efficient than ANNs, attributed to two gaps: **sparsity**
+(spiking neurons stay silent unless activated; ANNs run dense matmuls) and **encoding**.
+The key idea: **ANNs encode information in the *magnitudes* of a vector; spiking nets encode
+it in the *relative ordering (permutation)* of elements** (spike timings).
+
+Ordering capacity is factorial (n elements → n! distinguishable patterns; 16! ≈ 2×10¹³) and
+is invariant to scaling, shifting, and monotone transforms — exactly where magnitude
+capacity collapses under normalization, quantization, and noise. Hence **"Permutations Are
+All You Need"**: rebuild the transformer so every learned projection depends only on the
+input's *ordering*, computed by comparators + table reads — **no multiply-accumulate**.
+The biological ancestor is spike **polychronization** / polychronous groups
+(Izhikevich, 2006).
+
+## The primitive: differentiable lookup table (LUT)
+
+A layer maps x → y in two steps:
+
+1. **Encode.** N fixed "anchor pairs" (aⱼ, bⱼ); bitⱼ = 𝟙[x_{aⱼ} > x_{bⱼ}]; pack the N bits
+   into a row index b\* ∈ {0 … 2ᴺ−1}. This index is **rank-coded and magnitude-blind** — it
+   depends only on which of each pair is larger.
+2. **Decode.** Gather a learned row y = W[b\*] from a table W ∈ ℝ^{2ᴺ × D_out}. Sum over
+   `tph` tables per head.
+
+Key parameters and design facts:
+
+- **NAP (n_c)** = anchor pairs per table → K = 2^NAP rows. Controls per-table discrimination
+  at *exponential* cost.
+- **tph** = tables per head, summed. Adds capacity at *linear* cost.
+- **Anchors are FIXED at init** (balanced full-coverage sampling), never learned — learning
+  them was tried and refuted.
+- **Hard forward** = one sign-pack + gather, zero multiplies. This is the manifesto-pure,
+  deployable operation.
+- **Soft / hybrid-smooth forward** = blend the main row with its least-confident Hamming-1
+  neighbor (lower loss, 2 reads — the deployable approximation of a full softmax over rows).
+- **Backward is the load-bearing trick:** an *honest* weight gradient (only the rows the
+  forward actually touched) combined with a *soft surrogate* gradient for the input and
+  temperature (backprop as if the forward were the full-K softmax y = Σ π(b)·W[b], through
+  two learned temperatures T_soft, T_sel). A naive one-row straight-through backward still
+  trains, but converges materially worse — the **full-K soft backward is a necessary
+  condition**, not an optimization.
+- **MeanAbsNorm before each LUT** pins mean(|x|) ≈ 1 so the pairwise differences stay in
+  T_soft's calibrated regime. It is a training stabilizer; the hard forward is scale-invariant,
+  so it does not change decoding.
+
+## LUTGPT (the report's model)
+
+A 6-layer transformer with a **dual residual stream**:
+
+- an **E-stream** — the rank-coded backbone; every consumer is a LUT + MeanAbsNorm; mutated
+  by `out_proj`;
+- a **D-stream** — an ordinary Euclidean residual (width D = 384), read out by
+  LayerNorm + a **linear unembedder** → logits.
+
+Four LUT roles: `qk_lut` → SDPA (the one operation that genuinely needs magnitudes; RoPE on
+top), `v_lut` → the attention convex sum, `out_proj` → E-stream (it **absorbs the FFN** —
+there is no separate FFN), and `emb_resid_lut` / `residual_lut` → D-stream. Two real matmuls
+remain (SDPA and the linear unembedder), so **LUTGPT is a hybrid, not fully matmul-free**.
+Core primitive: `FastMultiHeadLut` in `src/spiky/lutorch/fast_multi_head_lut.py`; the narrow
+config lives under `examples/lutgpt/`.
+
+## Headline result
+
+Setup: nanochat scale — ClimbMix, T = 512, V = 32,768, ~3.93×10⁸ tokens, single H100.
+Metric = **validation bits-per-byte (bpb)**, lower is better, token-matched to a vanilla RoPE
+transformer.
+
+| model | params | val bpb |
+|-------|--------|---------|
+| vanilla (exp709) | 35.79M | **1.1922** ← baseline |
+| LUTGPT full-width (exp754, hybrid_smooth) | 276.8M (7.7×) | **1.1842** ← beats vanilla by 8 mb |
+| LUTGPT narrow (exp755) | 176.2M (4.9×) | 1.2044 |
+| LUTGPT native-hard, 24K steps (exp760) | — | 1.2048 (ships hard) |
+
+So the LUT family **lands on vanilla's side of the loss curve at matched data and token
+budget** — an *existence proof*, **not** a parameter win. A parameter win is impossible by
+construction (a K·tph table vs. one dense matrix). Soft → hard-eval costs +65–73 mb; native
+hard training plus ~50% more steps closes that gap.
+
+## Efficiency thesis (why bother, given it is slower on GPUs)
+
+LUTGPT is **slower in wall-clock on every GPU** (5–8× params, a dense soft-surrogate
+backward, gathers that don't use tensor cores). The bet is on future **rank-coded /
+sparse-lookup / in-memory-compute hardware**, where its real properties matter:
+
+- **~3–3.8× less HBM read per token** (a layer reads H·tph·D_out bytes, *independent of K*);
+- **~20× higher compression density** (parameters stored per byte fetched);
+- a **bounded, data-independent sparse active set** (<5% of parameters per token, decided by
+  sign comparisons at compile time).
+
+It is explicitly *not* claimed that such hardware exists yet.
+
+## Companion papers (same "Permutations Are All You Need" line of work)
+
+- **article v1 (Izhikevich / Kluchnikov / Starostin):** byte-level FineWeb, T = 32.
+  Introduces **Ranking Attention** (Kendall-τ ≡ cosine of ±1 dominance signatures → standard
+  SDPA on rank features) and **HyperLUT** (Kluchnikov: replace the 2^NAP table with a small
+  MLP on the comparison bits; GPU-matmul-friendly, avoids table blowup). Best LUT within 0.025
+  CE of vanilla, but at 26× params.
+- **article v2 (Izhikevich / Starostin):** the sharpest result — make the transformer
+  **purely combinatorial** (sum → concat, cosine → Kendall-τ, matmul → aggregated LUT reads
+  via Borda counting on a dominance matrix), then **BitPermutationLUT** quantizes every weight
+  to a **single bit** and reaches val CE **1.203 = vanilla exactly** (~25.6 MB bit-packed).
+  The reading: the combinatorial reformulation finds the right representation, and once found,
+  the precision requirement collapses to 1 bit with no quality loss.
+
+## Open frontier (unsolved)
+
+- LUT-based **attention** — reproduce softmax's data-dependent resolution inside a rank
+  primitive.
+- LUT-based **unembedder** — produce magnitude logits over a 32k vocab from a rank
+  representation (the reason the D-stream exists today).
+- HyperLUT → discrete-LUT distillation; MultiBitPermutationLUT (K-bit); longer context.


### PR DESCRIPTION
## What

Adds a top-level `claude/` folder holding the **scientific knowledge base** for the spiky project — the settled findings that used to live only in an assistant's private, per-machine memory. As the project spreads across multiple machines, this knowledge belongs in the repo so any assistant on any host inherits it.

## Contents (this first cut = science only)

- **`README.md`** — orientation + read order; scope/boundaries; epistemic caveat.
- **`thesis.md`** — the *why*: permutation/rank-coded, (nearly) matmul-free transformer; the LUT primitive; LUTGPT; the headline result; the efficiency thesis; companion papers; open frontier.
- **`experiment-journey.md`** — the *what we tried*: the eras, the durable mechanistic lessons, the falsified dead-ends (do-not-re-run), and gotchas.
- **`experiment-archive.md`** — *where the data is*: the historical `feature/lutorch-calibrate-output-normalize-weights` archive branch (~1366 experiment dirs) and how to verify a figure.

All content is distilled from the LUTGPT research report (`doc/lutorch/lutgpt_research_report.pdf`, the anchor of truth) and the experiment journals.

## Scope / boundaries

- **Science only.** The *experiment-conduct methodology* — branching, launching runs, and coordinating work across multiple machines — is deliberately **out of scope** here and will be added separately.
- **Excludes** all host-specific and credential material (box setup, git identity, bridges) — that stays in per-machine memory, not the repo.
- Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)