### PR TITLE
agent-cage: add non-destructive pr-edit verb to gh_issue helper

### DIFF
--- a/claude/skills/agent-cage/gh_issue.py
+++ b/claude/skills/agent-cage/gh_issue.py
@@ -29,6 +29,7 @@ Usage:
   gh_issue.py pr-list   [--state open|closed|all] [--base B] [--head H] [--limit N]
   gh_issue.py pr-view   <N>
   gh_issue.py pr-diff   <N>
+  gh_issue.py pr-edit   <N> [--title T] [--body B | --body-file F] [--base BRANCH]
   gh_issue.py link-branch <N> --branch BRANCH
 
 view / comment / close / reopen / label also accept a PR number (PRs are issues).
@@ -237,6 +238,26 @@ def cmd_pr_diff(a):
                         "application/vnd.github.v3.diff"), end="")
 
 
+def cmd_pr_edit(a):
+    """Edit an existing PR's title / body / base (the `gh pr edit` surface).
+
+    Only the PR's own metadata is touched via PATCH /pulls/{n}; still no merge,
+    no api/gist/secret verbs — the same narrow, bounded capability as the rest of
+    this helper. Body comes via --body-file, so no heredoc rides the command line."""
+    payload = {}
+    if a.title is not None:
+        payload["title"] = a.title
+    body = _resolve_body(a.body, a.body_file, required=False)
+    if body is not None:
+        payload["body"] = body
+    if a.base is not None:
+        payload["base"] = a.base
+    if not payload:
+        sys.exit("error: pr-edit needs at least one of --title / --body / --body-file / --base")
+    pr = _api("PATCH", _rp(a.repo, f"/pulls/{a.number}"), payload)
+    print(f"#{pr['number']} edited -> {pr['html_url']}")
+
+
 def cmd_link_branch(a):
     """Create a real issue<->branch link (populates the issue's Development panel)
     via the GraphQL createLinkedBranch mutation, pointing at an EXISTING branch's tip."""
@@ -287,6 +308,10 @@ def main():
     s = sub.add_parser("pr-view"); s.add_argument("number"); s.set_defaults(func=cmd_pr_view)
 
     s = sub.add_parser("pr-diff"); s.add_argument("number"); s.set_defaults(func=cmd_pr_diff)
+
+    s = sub.add_parser("pr-edit"); s.add_argument("number")
+    s.add_argument("--title"); s.add_argument("--body"); s.add_argument("--body-file", dest="body_file")
+    s.add_argument("--base"); s.set_defaults(func=cmd_pr_edit)
 
     s = sub.add_parser("link-branch"); s.add_argument("number"); s.add_argument("--branch", required=True)
     s.set_defaults(func=cmd_link_branch)


### PR DESCRIPTION
## What

Adds a non-destructive **`pr-edit`** verb to the vetted `gh_issue.py` helper (`claude/skills/agent-cage/gh_issue.py`), so agents can edit an existing PR's title/body/base through the sanctioned surface instead of reaching for gated raw `gh pr edit`.

```
gh_issue.py pr-edit <N> [--title T] [--body B | --body-file F] [--base BRANCH]
```

- `cmd_pr_edit` → `PATCH /repos/{repo}/pulls/{n}` with any of `--title` / `--body` / `--body-file` / `--base`.
- Body is passed via `--body-file` (same discipline as `create`/`comment`/`pr-create`), so no heredoc or `$(...)` ever rides the command line — which is what keeps the invocation inside the cage green zone.
- Errors out if no field is given.

## Why here

The change already lives on nucstar's *deployed* copy (`~/work/gh-issue/gh_issue.py`); this lands the same edit in the **source** so it's durable and propagates fleet-wide (gpustar / nebius) on the next skill sync, rather than being a one-host drift.

## Safety / scope

- **No `cage_policy.py` change needed.** `is_safe_gh_issue` green-lists the helper by script *path* (verb-agnostic), so `pr-edit` is auto-allowed exactly like the existing verbs — verified locally: `gh_issue.py pr-edit --help` runs with no approval prompt.
- **`pr-merge` stays deliberately excluded** — merging remains a human review gate; adding it would make it frictionless and defeat review.
- Touches PR *metadata* only (title/body/base); still no `api`/`gist`/`secret`/`auth` surface. The capability stays as narrow as the rest of the helper.

## Validation

- `python3 -m py_compile` clean.
- Byte-identical to nucstar's already-in-use deployed copy.
- `pr-edit --help` registers correctly and runs green.

For review — not urgent. Refs the review-workflow motivation (editing PR bodies like #65 going forward).
