### PR TITLE
docs(agent-cage): document the git-in-cage gate trap and the git -C fix

### DIFF
--- a/claude/skills/agent-cage/SKILL.md
+++ b/claude/skills/agent-cage/SKILL.md
@@ -123,6 +123,16 @@ tool_input)` returns:
   *capability*, not syntax, so splitting a command doesn't evade the gate); broad
   Write/Edit outside the zone; `WebFetch`/`WebSearch`/MCP/unknown tools; installs.
 
+> **⚠️ Don't prefix git with `cd <dir> && …` — use `git -C <dir>`.** Scoped-safe git
+> (`fetch`/`pull`/`push` to `origin`) is green, but `cd` is **not** a green command, so
+> `cd repo && git push` has one non-green segment and the **whole line** drops to a human
+> approval — the classic *phantom* git-over-network prompt (it was never the network that
+> gated, it was the `cd`). Pass the repo with git's own `-C` flag (explicitly allowed) so it
+> stays a single green segment: `git -C ~/projects/spiky push origin research/<idea>`. `&&`
+> between two *green* segments is fine — `git -C … add x && git -C … commit -m '…'` stays
+> green; only the non-green `cd` gates. (Keep commit messages URL-free so no `://` token
+> trips the URL check.)
+
 **Security-critical parsing** (this is where a naïve classifier leaks):
 - `_segments` uses `shlex.shlex(punctuation_chars=True)` so operators are isolated **even
   when attached** — `foo|curl` becomes `foo | curl`, it can't hide in a token.


### PR DESCRIPTION
## What

Adds a short callout to `claude/skills/agent-cage/SKILL.md`, right after the classifier's
green/gated definitions, documenting a footgun that cost real approval-friction: scoped-safe
git (`fetch`/`pull`/`push` to a configured named remote like `origin`) is already **green**,
but prefixing a command with `cd <dir> && …` gates the **whole line** — because `cd` is not a
green command, that one non-green segment drops the entire line to a human approval. It reads
as a *phantom* "git-over-network needs approval" prompt when the network was never the issue.

## The DO / DON'T

- ❌ `cd ~/projects/spiky && git push origin research/idea` — the `cd` segment gates the line.
- ✅ `git -C ~/projects/spiky push origin research/idea` — single green segment, no approval.

`&&` between two *green* segments is fine (`git -C … add x && git -C … commit -m '…'` stays
green); only the non-green `cd` gates. Keep commit messages URL-free so no `://` token trips
the URL check.

## Why here

Placed next to the "scoped-safe git" green-list bullet in the agent-cage SKILL, where an agent
reading *what auto-runs* will actually see it. **No code / classifier change** — the policy
already allows `git -C`; this only documents it so agents stop hitting the phantom prompt.

For review — **do not merge**.
