### PR TITLE
spnet: optional per-edge explicit weights in _grow_explicit / add_connections

### DIFF
--- a/native/spiky/spnet/spnet.cu
+++ b/native/spiky/spnet/spnet.cu
@@ -439,12 +439,15 @@ public:
     void add_connections(
         const torch::Tensor &connections_buffer,
         uint32_t single_input_group_size,
-        std::optional<uint32_t> &random_seed
+        std::optional<uint32_t> &random_seed,
+        std::optional<const torch::Tensor> &external_weights_buffer
     ) {
         checkConnectionsManagerIsInitialized();
-        std::optional<const torch::Tensor> none;
+        // external_weights_buffer (optional): per-edge initial weights aligned to the
+        // connection groups (see ChunkOfConnections weights layout). When omitted, each
+        // synapse is seeded from its SynapseMeta.initial_weight as before.
         this->n_synapses += connections_manager->add_connections(
-            connections_buffer, none,
+            connections_buffer, external_weights_buffer,
             single_input_group_size,
             0, nullptr,
             random_seed ? random_seed.value() : std::random_device{}()
@@ -1118,7 +1121,8 @@ void PFX(PB_SPNetDataManager)(py::module& m) {
             "Add connections from ConnectionsBuffer",
             py::arg("connections_buffer"),
             py::arg("single_input_group_size"),
-            py::arg("random_seed") = py::none())
+            py::arg("random_seed") = py::none(),
+            py::arg("external_weights_buffer") = py::none())
         .def("compile", &SPNDM_CLASS_NAME::compile,
             "Finalize synapse groups (calculate backward synapses)",
             py::arg("only_trainable_backwards"),

--- a/src/spiky/spnet/spnet.py
+++ b/src/spiky/spnet/spnet.py
@@ -152,12 +152,20 @@ class SpikingNet(object):
 
     def add_connections(
         self, chunk_of_connections: ChunkOfConnections,
-        random_seed: int = None
+        random_seed: int = None,
+        external_weights: torch.Tensor = None
     ):
+        # external_weights (optional): a group-aligned per-edge weights buffer (as
+        # produced by _grow_explicit(..., weights=...)). When None we fall back to the
+        # chunk's own weights (if it carries any), else to each meta's initial_weight —
+        # fully backward compatible.
+        if external_weights is None:
+            external_weights = chunk_of_connections.get_weights()
         self._neuron_data_manager.add_connections(
             chunk_of_connections.get_connections(),
             chunk_of_connections.get_single_group_size(),
-            random_seed
+            random_seed,
+            external_weights
         )
 
     def compile(self, shuffle_synapses_random_seed: int = None, _only_trainable_backwards=True):

--- a/src/spiky/spnet/tests/test_explicit_weights.py
+++ b/src/spiky/spnet/tests/test_explicit_weights.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Test explicit per-edge weights in _grow_explicit.
+
+Grows a small net whose synapses ALL share a SINGLE SynapseMeta (initial_weight=0)
+but pass several DISTINCT explicit per-edge weights via the new `weights=` argument,
+then asserts each edge actually carries its distinct weight (via export_synapses).
+Also checks backward compatibility: omitting `weights` falls back to the meta's
+initial_weight. Runs on the CPU build.
+"""
+import torch
+
+from spiky.util.synapse_growth import SynapseGrowthEngine
+from spiky.spnet.spnet import SpikingNet, SynapseMeta, NeuronMeta
+
+
+def _build(device, summation_dtype, edges, weights, seed):
+    N = 6
+    # ONE shared synapse meta; wide [min,max] so the explicit weights are not clipped.
+    metas = [SynapseMeta(learning_rate=0.0, min_delay=1, max_delay=1,
+                         min_weight=-10.0, max_weight=10.0, initial_weight=0.0,
+                         _forward_group_size=8, _backward_group_size=8)]
+    nmetas = [NeuronMeta(neuron_type=0)]
+    spnet = SpikingNet(synapse_metas=metas, neuron_metas=nmetas, neuron_counts=[N],
+                       summation_dtype=summation_dtype)
+    spnet.to_device(device)
+    ids = spnet.get_neuron_ids_by_meta(0)
+    ge = SynapseGrowthEngine(device=device, synapse_group_size=8, max_groups_in_buffer=256)
+    ge.register_neuron_type(max_synapses=64, growth_command_list=[])
+    coords = torch.stack([torch.arange(N).float(), torch.zeros(N), torch.zeros(N)], dim=1)
+    ge.add_neurons(neuron_type_index=0, identifiers=ids, coordinates=coords)
+    triples = torch.tensor([[0, int(ids[s]), int(ids[t])] for (s, t) in edges],
+                           dtype=torch.int32, device=device)
+    wt = None if weights is None else torch.tensor(weights, dtype=torch.float32, device=device)
+    chunk = ge._grow_explicit(triples, seed, weights=wt)
+    spnet.add_connections(chunk, seed)
+    spnet.compile(shuffle_synapses_random_seed=None)
+    spnet.to_device(device)
+    n = spnet.n_synapses()
+    exp = {k: torch.zeros([n], dtype=(torch.float32 if k == 'weights' else torch.int32), device=device)
+           for k in ['source_ids', 'synapse_metas', 'weights', 'delays', 'target_ids']}
+    spnet.export_synapses(spnet.get_all_neuron_ids(), exp['source_ids'], exp['synapse_metas'],
+                          exp['weights'], exp['delays'], exp['target_ids'], forward_or_backward=True)
+    got = {(int(exp['source_ids'][i]), int(exp['target_ids'][i])): float(exp['weights'][i])
+           for i in range(n)}
+    return ids, got
+
+
+def test_explicit_per_edge_weights(device='cpu', summation_dtype=torch.float32, seed=1):
+    if device != 'cpu' and str(device) != 'cpu':
+        return None  # CPU test
+    edges = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)]
+    weights = [1.5, 2.5, -3.0, 4.25, 0.75]           # distinct, incl. negative, one shared meta
+    ids, got = _build(device, summation_dtype, edges, weights, seed)
+    ok = True
+    for (s, t), w in zip(edges, weights):
+        g = got.get((int(ids[s]), int(ids[t])))
+        if g is None or abs(g - w) > 1e-5:
+            print(f"❌ edge {s}->{t}: expected {w}, got {g}")
+            ok = False
+        else:
+            print(f"✅ edge {s}->{t}: weight {g:.4f} (== explicit {w})")
+    if len(set(round(v, 4) for v in got.values())) < len(weights):
+        print("❌ weights are not distinct — per-edge weights not applied")
+        ok = False
+
+    # backward compat: no weights -> every edge seeded from meta.initial_weight (0.0)
+    _, got0 = _build(device, summation_dtype, edges, None, seed)
+    if any(abs(v - 0.0) > 1e-6 for v in got0.values()):
+        print(f"❌ backward-compat: expected all initial_weight=0.0, got {sorted(got0.values())}")
+        ok = False
+    else:
+        print("✅ backward compat: omitting weights -> all edges use meta.initial_weight (0.0)")
+
+    print("🎉 explicit per-edge weights test passed!" if ok else "test FAILED")
+    return ok
+
+
+def main():
+    return 0 if test_explicit_per_edge_weights('cpu', torch.float32, 1) else 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/spiky/util/synapse_growth.py
+++ b/src/spiky/util/synapse_growth.py
@@ -309,7 +309,12 @@ class SynapseGrowthEngine(object):
                 )
         return lowlevel_engine
 
-    def _grow_explicit(self, explicit_triples, random_seed=None, do_sort_by_target_id=False):
+    def _grow_explicit(self, explicit_triples, random_seed=None, do_sort_by_target_id=False, weights=None):
+        # weights (optional): a 1-D tensor of one EXPLICIT weight per input triple, in
+        # the same order as explicit_triples. When given, the returned chunk carries a
+        # group-aligned weights buffer (see ChunkOfConnections layout) so that
+        # add_connections seeds each edge's weight from it instead of the meta's
+        # initial_weight — allowing many distinct per-edge weights under a single meta.
         # Determine device index for low-level engine (int for CUDA, -1 for CPU)
         device = self._device
         if not isinstance(device, int):
@@ -324,6 +329,17 @@ class SynapseGrowthEngine(object):
 
         assert len(explicit_triples.shape) == 2
         assert explicit_triples.shape[1] == 3
+
+        # map (source_id, target_id) -> explicit weight, from the ORIGINAL triple order
+        # (sourced before the in-place sort below, so alignment is order-independent).
+        wmap = None
+        if weights is not None:
+            assert weights.shape[0] == explicit_triples.shape[0], "weights must have one entry per triple"
+            trip_cpu = explicit_triples.cpu()
+            w_cpu = weights.detach().cpu().flatten()
+            wmap = {}
+            for k in range(trip_cpu.shape[0]):
+                wmap[(int(trip_cpu[k, 1]), int(trip_cpu[k, 2]))] = float(w_cpu[k])
 
         lowlevel_engine = self._setup_lowlevel_engine(device, random_seed)
 
@@ -355,7 +371,35 @@ class SynapseGrowthEngine(object):
         lowlevel_engine.finalize(connections_buffer, do_sort_by_target_id)
         self._profiling_stats = lowlevel_engine.get_profiling_stats()
 
-        return ChunkOfConnections(connections_buffer, self._synapse_group_size)
+        weights_buffer = None
+        if wmap is not None:
+            weights_buffer = self._build_group_aligned_weights(connections_buffer, wmap)
+
+        return ChunkOfConnections(connections_buffer, self._synapse_group_size, weights=weights_buffer)
+
+    def _build_group_aligned_weights(self, connections_buffer, wmap):
+        """Build the per-edge weights buffer aligned to the connection groups: for a
+        group at int-offset d, its weights occupy [ (d/(4+2*gs))*gs : +gs ], slot j
+        matching the j-th (meta, target) body pair. The source id lives in the root
+        group header (source>0); chained/ghost groups repeat it as 0, so we carry the
+        last positive source forward while scanning blocks in order (the explicit build
+        lays each source's groups out contiguously)."""
+        gs = self._synapse_group_size
+        block = 4 + 2 * gs
+        buf = connections_buffer.cpu().tolist()
+        n_blocks = len(buf) // block
+        wbuf = torch.zeros([n_blocks * gs], dtype=torch.float32)
+        cur_src = 0
+        for b in range(n_blocks):
+            d = b * block
+            src = buf[d]
+            if src != 0:
+                cur_src = src
+            for j in range(gs):
+                tgt = buf[d + 4 + 2 * j + 1]     # body pair j = (meta, target)
+                if tgt != 0:
+                    wbuf[b * gs + j] = wmap.get((cur_src, tgt), 0.0)
+        return wbuf.to(device=connections_buffer.device)
 
     def get_profiling_stats(self) -> str:
         return self._profiling_stats


### PR DESCRIPTION
## Problem: per-edge weights force one meta per weight, hitting the 4096-meta cap

In `spnet`, a synapse's weight is a property of its **`SynapseMeta`** (`initial_weight`), not of the individual edge. The growth API sets every connection of a meta to the same `initial_weight`. So placing **N distinct explicit weights** on an explicitly-wired network currently forces **N distinct `SynapseMeta`s** — which runs into the hard cap of **4096 distinct synapse metas** (the meta index is a 12-bit field: `MAX_N_SYNAPSE_METAS = (1 << 12)`, register throws `"too many different synapse metas"`). It's also wasteful (one meta object per weight) for nets wired explicitly via `_grow_explicit`.

## The fix: expose the per-edge weight hook that already exists in the runtime

Per-edge weight storage already exists — each synapse carries its own `SynapseInfo { target_neuron_index; weight; }` (mutated in place by STDP), and:
- the create-forward-groups kernel already reads an optional `input_weights` buffer: `weight = (input_weights == nullptr) ? synapse_meta.initial_weight : input_weights[input_cursor];`
- `ConnectionsManager::add_connections` already accepts a `std::optional<const torch::Tensor>& external_weights_buffer` and threads it to that kernel;
- `ChunkOfConnections` already has a `weights` slot + `get_weights()` with a documented group-aligned layout.

The only missing piece was Python exposure. This PR wires it up:

- **`SPNetDataManager::add_connections` (native)** — accept an optional `external_weights_buffer` and pass it through instead of a hardcoded `nullopt`; expose it in the pybind binding (`py::arg("external_weights_buffer") = py::none()`).
- **`SynapseGrowthEngine._grow_explicit`** — accept an optional `weights` tensor (one weight per input triple) and build the group-aligned weights buffer the runtime expects (`_build_group_aligned_weights`), attaching it to the returned `ChunkOfConnections`.
- **`SpikingNet.add_connections`** — accept optional `external_weights`, defaulting to the chunk's own weights, and pass through.

Result: a **single shared `SynapseMeta` can back many distinct per-edge weights**, removing the one-meta-per-weight palette and its 4096-meta ceiling. The shared meta's `[min_weight, max_weight]` must be wide enough not to clip the explicit weights.

## Backward compatibility

Fully preserved. Omitting the weights (`None`) reproduces the exact previous behavior — every edge is seeded from `meta.initial_weight`. All new parameters default to `None`.

## Test

`src/spiky/spnet/tests/test_explicit_weights.py`: grows a net whose edges all share **one** meta (`initial_weight=0`) but pass **5 distinct explicit weights** (including a negative one) via the new argument, then asserts (via `export_synapses`) that **each edge carries its own distinct weight**; and asserts the `None` path falls back to `initial_weight`. Passes on the CPU build:

```
✅ edge 0->1: weight 1.5000 (== explicit 1.5)
✅ edge 0->2: weight 2.5000 (== explicit 2.5)
✅ edge 0->3: weight -3.0000 (== explicit -3.0)
✅ edge 0->4: weight 4.2500 (== explicit 4.25)
✅ edge 0->5: weight 0.7500 (== explicit 0.75)
✅ backward compat: omitting weights -> all edges use meta.initial_weight (0.0)
🎉 explicit per-edge weights test passed!
```

The existing spnet CPU test suite (7 CPU-runnable tests + the CUDA-only `test_spnet_math`) still passes with **no regression**.

Note: per-edge weights are verified with the optional `compile(shuffle_synapses_random_seed=...)` synapse shuffle disabled; the interaction between that storage shuffle and distinct per-edge weights (only observable when weights differ per edge) is out of scope here and worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
