### PR TITLE
fix: correct connections-buffer sizing in _grow_explicit (fixes segfault with few synapse metas)

### DIFF
--- a/src/spiky/spnet/tests/test_grow_explicit_buffer.py
+++ b/src/spiky/spnet/tests/test_grow_explicit_buffer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression test for _grow_explicit connections-buffer under-sizing.
+
+With a SINGLE shared SynapseMeta and many distinct (source) sublists, the old
+sizing  ceil(n_triples/gs) + (n_metas-1)*(n_sources-1)  collapses to ceil(n/gs)
+(second term = 0), which is far fewer groups than the one-per-(meta,source)-sublist
+the native grow actually writes -> buffer overflow -> segfault. This is exactly
+the per-edge-weights (#78) single-meta path. Here we grow 16 sources -> 16 targets
+(16 sublists, group_size 8 -> old formula asks for only 2 groups) with distinct
+per-edge weights, and assert: (a) no crash, (b) each edge carries its own weight.
+"""
+import torch
+
+from spiky.util.synapse_growth import SynapseGrowthEngine
+from spiky.spnet.spnet import SpikingNet, SynapseMeta, NeuronMeta
+
+
+def test_grow_explicit_buffer(device='cpu', summation_dtype=torch.float32, seed=1):
+    if device != 'cpu' and str(device) != 'cpu':
+        return None
+    NS = 16                          # 16 sources, each -> its own target = 16 sublists
+    N = 2 * NS
+    GS = 8                           # old formula: ceil(16/8)=2 groups << 16 needed
+    edges = [(i, NS + i) for i in range(NS)]
+    weights = [round(0.5 + 0.37 * i - (7.0 if i % 3 == 0 else 0.0), 3) for i in range(NS)]  # distinct, mixed sign
+    metas = [SynapseMeta(learning_rate=0.0, min_delay=1, max_delay=1, min_weight=-50.0,
+                         max_weight=50.0, initial_weight=0.0, _forward_group_size=8, _backward_group_size=8)]
+    spnet = SpikingNet(synapse_metas=metas, neuron_metas=[NeuronMeta(neuron_type=0)],
+                       neuron_counts=[N], summation_dtype=summation_dtype)
+    spnet.to_device(device)
+    ids = spnet.get_neuron_ids_by_meta(0)
+    ge = SynapseGrowthEngine(device=device, synapse_group_size=GS, max_groups_in_buffer=512)
+    ge.register_neuron_type(max_synapses=64, growth_command_list=[])
+    coords = torch.stack([torch.arange(N).float(), torch.zeros(N), torch.zeros(N)], dim=1)
+    ge.add_neurons(neuron_type_index=0, identifiers=ids, coordinates=coords)
+    triples = torch.tensor([[0, int(ids[s]), int(ids[t])] for (s, t) in edges], dtype=torch.int32, device=device)
+    wt = torch.tensor(weights, dtype=torch.float32, device=device)
+
+    # This call SEGFAULTED before the fix (undersized connections buffer).
+    chunk = ge._grow_explicit(triples, seed, weights=wt)
+    spnet.add_connections(chunk, seed)
+    spnet.compile(shuffle_synapses_random_seed=None)
+    spnet.to_device(device)
+
+    n = spnet.n_synapses()
+    ok = (n == NS)
+    if not ok:
+        print(f"❌ expected {NS} synapses, got {n}")
+    exp = {k: torch.zeros([n], dtype=(torch.float32 if k == 'weights' else torch.int32), device=device)
+           for k in ['source_ids', 'synapse_metas', 'weights', 'delays', 'target_ids']}
+    spnet.export_synapses(spnet.get_all_neuron_ids(), exp['source_ids'], exp['synapse_metas'],
+                          exp['weights'], exp['delays'], exp['target_ids'], forward_or_backward=True)
+    got = {(int(exp['source_ids'][i]), int(exp['target_ids'][i])): float(exp['weights'][i]) for i in range(n)}
+    for (s, t), w in zip(edges, weights):
+        g = got.get((int(ids[s]), int(ids[t])))
+        if g is None or abs(g - w) > 1e-5:
+            print(f"❌ edge {s}->{t}: expected {w}, got {g}")
+            ok = False
+    if ok:
+        print(f"✅ grew {NS} sublists under 1 shared meta with distinct per-edge weights — "
+              f"no crash, all weights correct")
+        print("🎉 grow_explicit buffer-sizing regression test passed!")
+    return ok
+
+
+def main():
+    return 0 if test_grow_explicit_buffer('cpu', torch.float32, 1) else 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/spiky/util/synapse_growth.py
+++ b/src/spiky/util/synapse_growth.py
@@ -343,13 +343,8 @@ class SynapseGrowthEngine(object):
 
         lowlevel_engine = self._setup_lowlevel_engine(device, random_seed)
 
-        n_synapse_metas = explicit_triples[:, 0:1].unique().shape[0]
-        n_source_ids = explicit_triples[:, 1:2].unique().shape[0]
-        n_groups = (explicit_triples.shape[0] + self._synapse_group_size - 1) // self._synapse_group_size + (n_synapse_metas - 1) * (n_source_ids - 1)
-        connections_buffer = torch.zeros(
-            [n_groups * (4 + 2 * self._synapse_group_size)], dtype=torch.int32, device=self._device
-        )
-
+        # sort triples by (source, then meta) so each distinct (meta, source) sublist is
+        # contiguous — this is the layout the native grow consumes.
         sort_idx = torch.argsort(explicit_triples[:, 1], stable=True)
         explicit_triples = explicit_triples[sort_idx]
         sort_idx = torch.argsort(explicit_triples[:, 0], stable=True)
@@ -363,9 +358,37 @@ class SynapseGrowthEngine(object):
                 )[0] + 1
             ]).flatten().to(dtype=torch.int32)
 
+        entry_points = calc_entry_points(explicit_triples)
+
+        # Connections-buffer sizing. The native grow writes ONE linked group list per
+        # distinct (synapse_meta, source) sublist, each group holding at most group_size
+        # targets, so a sublist with T targets needs ceil(T / group_size) groups. The
+        # exact number of groups is therefore the sum over sublists of ceil(T_i / gs).
+        #
+        # The previous formula  ceil(n_triples/gs) + (n_metas - 1)*(n_sources - 1)
+        # UNDERCOUNTS when there are FEW distinct synapse metas (e.g. a single shared
+        # meta — exactly the per-edge-weights path from #78): the second term collapses
+        # toward 0 while many (meta, source) sublists still each need their own group, so
+        # the buffer is allocated too small and the native kernel writes past it ->
+        # segfault. We compute the exact count from the sublist sizes instead.
+        gs = self._synapse_group_size
+        n_triples = explicit_triples.shape[0]
+        if n_triples > 0:
+            seg_sizes = torch.diff(torch.cat([
+                entry_points,
+                torch.tensor([n_triples], dtype=torch.int32, device=entry_points.device)
+            ]))
+            # exact groups needed, plus one spare group per sublist as a safety margin
+            n_groups = int(((seg_sizes + (gs - 1)) // gs).sum().item()) + int(entry_points.shape[0])
+        else:
+            n_groups = 1
+        connections_buffer = torch.zeros(
+            [n_groups * (4 + 2 * gs)], dtype=torch.int32, device=self._device
+        )
+
         lowlevel_engine._grow_explicit(
             connections_buffer,
-            calc_entry_points(explicit_triples),
+            entry_points,
             explicit_triples.flatten()
         )
         lowlevel_engine.finalize(connections_buffer, do_sort_by_target_id)


### PR DESCRIPTION
## The bug: `_grow_explicit` under-sizes its connections buffer → segfault

`SynapseGrowthEngine._grow_explicit` allocated the connections buffer as:
```python
n_groups = ceil(n_triples / group_size) + (n_synapse_metas - 1) * (n_source_ids - 1)
```
But the native grow writes **one linked group list per distinct `(synapse_meta, source)` sublist**, and each group holds at most `group_size` targets. So a sublist with `T` targets needs `ceil(T / group_size)` groups, and the real requirement is:
```
n_groups = Σ over sublists of ceil(targets_in_sublist / group_size)
```
When there are **few distinct synapse metas**, the old formula's second term `(n_metas − 1)·(n_sources − 1)` collapses toward 0, while many `(meta, source)` sublists still each need their own group. In the extreme **single-shared-meta** case the buffer is sized as just `ceil(n_triples/gs)` — far fewer groups than needed — so the native kernel writes past the buffer → **segfault**.

### Why it matters now
This single-shared-meta case is exactly the **per-edge explicit-weights path added in #78**: to place N distinct weights you use one shared `SynapseMeta` and pass a per-edge `weights` tensor. That path segfaulted for any non-trivial fan-out because of this sizing bug (hit while wiring a small explicit network with one meta and ~16 sources).

## The fix (Python only — no native change)

Sort the triples and compute the entry points **first**, then size the buffer from the actual sublist sizes:
```python
entry_points = calc_entry_points(explicit_triples)          # (meta,source) boundaries
seg_sizes = diff(cat([entry_points, [n_triples]]))          # targets per sublist
n_groups = int(((seg_sizes + gs - 1) // gs).sum()) + n_sublists   # exact + 1 spare/sublist
```
- **Exact** count of groups needed (one linked list per `(meta,source)` sublist, chained at `group_size`), plus one spare group per sublist as a safety margin.
- Correct for **any** number of distinct metas, including **1**.
- The many-metas case is preserved (the new value only differs where the old formula over-allocated). Composes with #78 — the per-edge weights buffer is built from the same, now correctly-sized, connection groups.

## Regression test

`src/spiky/spnet/tests/test_grow_explicit_buffer.py`: grows **16 sources → 16 targets under a SINGLE shared `SynapseMeta`** with distinct per-edge weights (the #78 path). With `group_size=8` the old formula asks for only `ceil(16/8)=2` groups for 16 sublists → segfault before the fix. The test asserts (a) **no crash** and (b) each edge carries its own explicit weight (via `export_synapses`).

```
✅ grew 16 sublists under 1 shared meta with distinct per-edge weights — no crash, all weights correct
🎉 grow_explicit buffer-sizing regression test passed!
```

## Validation
- New regression test **passes** on the CPU build.
- The full spnet CPU suite still passes — **8/8, no regression** (7 CPU tests incl. `test_izhikevitch_runtime`; `test_spnet_math` is CUDA-only). The change is Python-only, so no extension rebuild is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
