### PR TITLE
Add LIFMultiHeadLUT core class + tests

### DIFF
--- a/src/spiky/lutorch/lif_multi_head_lut.py
+++ b/src/spiky/lutorch/lif_multi_head_lut.py
@@ -1,0 +1,213 @@
+"""LIFMultiHeadLUT — unified LIF-detector multi-head LUT that generalizes BucketLIFDetectorsMHL and
+ProductBucketLIFMHL into one class.
+
+Structure (three nested levels):
+- n_heads output heads: the forward ALWAYS returns (B, n_heads, n_outputs); n_heads is the kept output axis.
+- tables_per_head tables per head: the `tables_per_head` tables are SUMMED within each head (same as Bucket).
+- n_det detectors per table: each detector is one LIF cell emitting one of M=n_buckets bucket digits; the
+  n_det digits combine MIXED-RADIX into an index over M**n_det cells, each holding an n_outputs vector.
+  n_det=1 => one LIF + M buckets => exactly the Bucket notion of a table.
+
+Input latency coding is FIXED (no latency_c/latency_alpha params), slope alpha=3: t = clamp(t_window*(0.5 -
+3*x/32), 0, t_window) (= 16 - 3x at t_window=32, matching the old ProductBucketLIFMHL). Expects ~unit-variance
+input — center at half-window, saturating (clamped) at x = +-16/3 ≈ +-5.33.
+
+forward() branches on self.training (standard PyTorch convention). In TRAINING mode it is straight-through:
+value == the hard winner, weight-grad to the winners, address-grad via the soft distribution against a detached
+table. In EVAL mode (module.eval()) it runs the efficient hard INFERENCE path: direct boundary-threshold
+bucketing + mixed-radix gather under no_grad, with NO softmax and NO temperatures — its value matches the
+training value. The soft temperatures (log_T_bkt / log_T_cross) survive only inside the ST address grad; pass
+freeze_temperature=True to fix them at 1.0 (non-trainable), which mimics the old ProductBucketLIFMHL fixed
+buffers and prevents them from collapsing during training.
+
+n_tables = n_heads * tables_per_head. Machinery: latency coding, bounded-excitatory w = w_max*sigmoid(w_raw)
+hot init, tau = softplus(tau_raw)+1.0 floor, the O(N) cumsum first-spike membrane, per-detector clamped delay,
+trainable strictly-increasing boundaries, trainable per-TABLE soft temperatures log_T_cross / log_T_bkt init
+at 1.0, table_init; plus the mixed-radix gather (hard) + rank-1 tensor-product contraction (soft address
+readout, sequential einsums, no dense outer product) for the n_det>1 combination. M**n_det capped at 65536.
+"""
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["LIFMultiHeadLUT"]
+
+MAX_CELLS = 65536
+
+
+class LIFMultiHeadLUT(nn.Module):
+    def __init__(self, input_dim: int, n_heads: int, n_outputs: int, tables_per_head: int = 1, n_det: int = 1,
+                 *, n_buckets: int = 16, w_max: float = 2.0, t_window: float = 32.0, delay_init_std: float = 0.0,
+                 freeze_temperature: bool = False, table_init: Optional[torch.Tensor] = None, device=None):
+        # delay_init_std: std (scale) of the half-normal delay initialization; 0.0 => all delays init to zero
+        # (neutral start). Delays are non-negative (causal).
+        # freeze_temperature: if True, log_T_cross/log_T_bkt are fixed at 0.0 (T=1.0) and non-trainable.
+        super().__init__()
+        if n_buckets < 2 or n_buckets > 256:
+            raise ValueError(f"n_buckets must be in [2,256], got {n_buckets}")
+        cells = n_buckets ** n_det
+        if cells > MAX_CELLS:
+            raise ValueError(f"n_buckets**n_det = {n_buckets}**{n_det} = {cells} exceeds MAX_CELLS={MAX_CELLS}")
+        self.input_dim = int(input_dim); self.n_heads = int(n_heads); self.n_outputs = int(n_outputs)
+        self.tables_per_head = int(tables_per_head); self.n_det = int(n_det); self.n_buckets = int(n_buckets)
+        self.n_tables = self.n_heads * self.tables_per_head
+        self.cells = int(cells); self.n_rows = self.cells
+        self.w_max = float(w_max); self.t_window = float(t_window)
+
+        T, D, M, N, O = self.n_tables, self.n_det, self.n_buckets, self.input_dim, self.n_outputs
+        dev = device or torch.device("cpu")
+        # Per-detector params ALWAYS carry the detector axis D (D==1 for the plain-bucket n_det=1 case);
+        # the forward relies on standard broadcasting — no n_det==1 special-casing.
+        dsh = (T, D, N)          # per-synapse per-detector: (tables, detectors, synapses)
+        bsh = (T, D, M - 1)      # per-detector bucket boundaries
+        tsh = (T, D)             # per-detector scalars (tau)
+        step = self.t_window / M
+        inv_softplus_step = math.log(math.expm1(step)) if step > 0 else 0.0
+        # half-normal non-negative delay init. std==0.0 => exactly zeros AND consumes NO RNG draw, so the
+        # default is byte-identical to the prior zero init and downstream params' RNG order is unaffected.
+        # std>0 draws randn here (consuming RNG at this same sequence point) — expected/intended.
+        if float(delay_init_std) > 0.0:
+            init = (float(delay_init_std) * torch.randn(*dsh, device=dev)).abs()
+        else:
+            init = torch.zeros(*dsh, device=dev)
+        self.delay = nn.Parameter(init)
+        self.w_raw = nn.Parameter(-2.2 + 0.5 * torch.randn(*dsh, device=dev))         # bounded excitatory hot init
+        self.tau_raw = nn.Parameter(torch.ones(*tsh, device=dev))
+        self.beta_base = nn.Parameter(torch.zeros(*(tsh + (1,)), device=dev))
+        self.beta_raw = nn.Parameter(torch.full(bsh, float(inv_softplus_step), device=dev))
+        # per-TABLE soft temperatures (init exp(0)=1.0 -> step-0 == Bucket). Trainable unless freeze_temperature,
+        # in which case they stay fixed at 1.0 (requires_grad=False) — mimics the old ProductBucketLIFMHL buffers.
+        trainable_T = not bool(freeze_temperature)
+        self.log_T_cross = nn.Parameter(torch.zeros(T, device=dev), requires_grad=trainable_T)
+        self.log_T_bkt = nn.Parameter(torch.zeros(T, device=dev), requires_grad=trainable_T)
+        if table_init is not None:
+            if tuple(table_init.shape) != (T, self.cells, O):
+                raise ValueError(f"table_init shape {tuple(table_init.shape)} != {(T, self.cells, O)}")
+            self.table = nn.Parameter(table_init.clone().to(dev))
+        else:
+            self.table = nn.Parameter(0.1 * torch.randn(T, self.cells, O, device=dev))
+        self.register_buffer("theta_mem", torch.tensor(1.0, device=dev))
+        self.register_buffer("radix", (M ** (D - 1 - torch.arange(D))).long())    # row-major mixed-radix
+
+    @property
+    def w(self):
+        return self.w_max * torch.sigmoid(self.w_raw)          # (T,D,N)
+
+    @property
+    def tau(self):
+        return F.softplus(self.tau_raw) + 1.0                  # (T,D)
+
+    @property
+    def T_cross(self):
+        return torch.exp(self.log_T_cross)                     # (T,)
+
+    @property
+    def T_bkt(self):
+        return torch.exp(self.log_T_bkt)                       # (T,)
+
+    @property
+    def boundaries(self):
+        return self.beta_base + torch.cumsum(F.softplus(self.beta_raw), dim=-1)   # (T,D,M-1)
+
+    def latency(self, x):
+        # Fixed latency code, slope alpha=3 (matches the old ProductBucketLIFMHL 16 - 3x at t_window=32).
+        # Center at half-window (x=0 -> t_window/2); effective slope = 3*t_window/32, saturating (clamped) at
+        # x = +-16/3 ≈ +-5.33 regardless of t_window (i.e. +-5.33 sigma for unit-variance input). t_window is
+        # the structural time-axis scale.
+        return torch.clamp(self.t_window * (0.5 - 3.0 * x / 32.0), 0.0, self.t_window)
+
+    def param_count(self):
+        return sum(p.numel() for p in self.parameters())
+
+    def _membrane(self, x):
+        """Shared hard core: sorted arrival times a_srt and the O(N) cumsum LIF membrane V, both (B,T,D,N)."""
+        B, T, D = x.shape[0], self.n_tables, self.n_det
+        lat = self.latency(x)
+        # delay clamped to [0, t_window]: non-negative floor = causality; upper bound keeps arrival in
+        # [0, 2*t_window] so exp(a/tau) stays float32-safe. delay is (T,D,N).
+        a = lat.view(B, 1, 1, -1) + torch.clamp(self.delay, 0.0, self.t_window).unsqueeze(0)   # (B,T,D,N)
+        a_srt, idx = torch.sort(a, dim=-1)
+        w_srt = self.w.unsqueeze(0).expand(B, -1, -1, -1).gather(-1, idx)
+        tv = self.tau.view(1, T, D, 1)
+        V = torch.exp(-a_srt / tv) * torch.cumsum(w_srt * torch.exp(a_srt / tv), dim=-1)   # O(N) cumsum membrane
+        return a_srt, V
+
+    def _t_hard(self, a_srt, V):
+        """Hard first-spike time: first arrival whose V crosses theta_mem (else t_window). No temperatures."""
+        crossed = V >= self.theta_mem
+        kstar = crossed.float().argmax(-1)
+        t_hard = a_srt.gather(-1, kstar.unsqueeze(-1)).squeeze(-1)
+        return torch.where(crossed.any(-1), t_hard, torch.full_like(t_hard, self.t_window))
+
+    def _first_spike(self, x):
+        """Per-detector first-spike (hard, soft): (B, n_tables, n_det) each. Soft t uses the T_cross temp."""
+        a_srt, V = self._membrane(x)
+        t_hard = self._t_hard(a_srt, V)
+        Tc = self.T_cross.view(1, self.n_tables, 1, 1)
+        c = torch.sigmoid((V - self.theta_mem) / Tc)
+        surv = torch.cumprod(1.0 - c, dim=-1)
+        surv_prev = torch.cat([torch.ones_like(surv[..., :1]), surv[..., :-1]], dim=-1)
+        p = c * surv_prev
+        t_soft = (p * a_srt).sum(-1) + surv[..., -1] * self.t_window
+        return t_hard, t_soft
+
+    def _bucket(self, t_hard, t_soft):
+        """Per-detector hard bucket (B,T,D) and soft partition (B,T,D,M)."""
+        T, D, M = self.n_tables, self.n_det, self.n_buckets
+        bnd = self.boundaries                                            # (T,D,M-1)
+        b = bnd.view(1, T, D, M - 1)
+        Tb = self.T_bkt.view(1, T, 1, 1)
+        S = torch.sigmoid((t_soft.unsqueeze(-1) - b) / Tb)               # (B,T,D,M-1)
+        p = torch.cat([1.0 - S[..., :1], S[..., :-1] - S[..., 1:], S[..., -1:]], dim=-1)   # (B,T,D,M)
+        b_hard = (t_hard.unsqueeze(-1) >= b).sum(-1)                     # (B,T,D)
+        return b_hard, p
+
+    def _hard_read(self, b_hard):
+        B, T = b_hard.shape[0], self.n_tables
+        idx = (b_hard * self.radix.view(1, 1, -1)).sum(-1)              # (B,T) joint mixed-radix index
+        tt = torch.arange(T, device=b_hard.device).view(1, T).expand(B, T)
+        return self.table[tt, idx]                                      # (B,T,O) full table grad -> selected cell
+
+    def _soft_read(self, p):
+        """Soft address readout against a DETACHED table (address grad only, no table grad) — the ST addr path."""
+        T, D, M = self.n_tables, self.n_det, self.n_buckets
+        tab = self.table.detach().reshape(T, *([M] * D), self.n_outputs)
+        cur = torch.einsum('tm...,btm->bt...', tab, p[:, :, 0, :])      # peel detector 0's axis
+        for d in range(1, D):
+            cur = torch.einsum('btm...,btm->bt...', cur, p[:, :, d, :])
+        return cur                                                     # (B,T,O)
+
+    def address(self, x):
+        t_hard, t_soft = self._first_spike(x)
+        b_hard, _ = self._bucket(t_hard, t_soft)
+        return (b_hard * self.radix.view(1, 1, -1)).sum(-1)            # (B, n_tables) joint index
+
+    @torch.compile
+    def forward(self, x):
+        """x:(B,input_dim) -> (B, n_heads, n_outputs), branching on self.training (standard PyTorch convention).
+
+        Training (self.training=True): STRAIGHT-THROUGH — value == the hard winner, weight-grad flows to the
+        hard winners, address-grad flows via the soft distribution against a DETACHED table.
+        Eval (self.training=False): efficient hard path under no_grad — NO soft math, NO temperatures (no
+        log_T_bkt / log_T_cross); direct boundary-threshold bucketing -> mixed-radix cell index -> table gather.
+        The eval value matches the training value up to float rounding (ST forward value == hard winner)."""
+        B, T, D, M = x.shape[0], self.n_tables, self.n_det, self.n_buckets
+        if self.training:
+            t_hard, t_soft = self._first_spike(x)
+            b_hard, p = self._bucket(t_hard, t_soft)
+            y_hard = self._hard_read(b_hard)                          # (B,T,O) value + weight grad to winner
+            y_addr = self._soft_read(p)                              # address grad, detached table
+            rows = y_hard + y_addr - y_addr.detach()                 # forward value == hard
+            return rows.view(B, self.n_heads, self.tables_per_head, self.n_outputs).sum(dim=2)
+        with torch.no_grad():                                        # efficient hard inference, no grad graph
+            a_srt, V = self._membrane(x)
+            t_hard = self._t_hard(a_srt, V)
+            b = self.boundaries.view(1, T, D, M - 1)
+            b_hard = (t_hard.unsqueeze(-1) >= b).sum(-1)             # (B,T,D) count of crossed boundaries
+            idx = (b_hard * self.radix.view(1, 1, -1)).sum(-1)      # (B,T) mixed-radix cell index
+            tt = torch.arange(T, device=x.device).view(1, T).expand(B, T)
+            rows = self.table[tt, idx]                              # (B,T,O)
+            return rows.view(B, self.n_heads, self.tables_per_head, self.n_outputs).sum(dim=2)

--- a/src/spiky/lutorch/tests/test_lif_multi_head_lut.py
+++ b/src/spiky/lutorch/tests/test_lif_multi_head_lut.py
@@ -1,0 +1,206 @@
+"""Tests for LIFMultiHeadLUT — the unified LIF multi-head LUT (the library's single LIF-LUT class).
+
+Folds in the behavioral coverage of the retired BucketLIFDetectorsMHL (n_det=1) and ProductBucketLIFMHL
+(n_det>1) suites, tested against LIFMultiHeadLUT directly.
+"""
+import pytest
+import torch
+import torch.nn.functional as F
+from spiky.lutorch.lif_multi_head_lut import LIFMultiHeadLUT, MAX_CELLS
+
+
+def _m(**kw):
+    torch.manual_seed(0)
+    cfg = dict(input_dim=17, n_heads=2, n_outputs=6, tables_per_head=4, n_det=1, n_buckets=16)
+    cfg.update(kw)
+    return LIFMultiHeadLUT(**cfg)
+
+
+# ---- shared ----
+def test_forward_shape_and_finite():
+    for nd, M in ((1, 16), (2, 8), (3, 4)):
+        m = _m(n_det=nd, n_buckets=M)
+        x = torch.randn(8, 17)
+        m.train(); y_train = m(x)                                 # ST path
+        m.eval();  y_eval = m(x)                                  # efficient hard path
+        for tag, out in (("train", y_train), ("eval", y_eval)):
+            assert out.shape == (8, 2, 6) and torch.isfinite(out).all(), f"nd={nd} {tag}"
+
+
+def test_train_forward_equals_eval_forward():
+    """ST (train-mode) forward value == the hard winner, so it must equal the eval-mode hard forward."""
+    for nd, M in ((1, 8), (2, 8)):
+        m = _m(n_det=nd, n_buckets=M)
+        x = torch.randn(24, 17)
+        with torch.no_grad():
+            m.train(); a = m(x)
+            m.eval();  b = m(x)
+        assert torch.allclose(a, b, atol=1e-5), f"nd={nd}: train-mode ST forward must equal eval-mode hard forward"
+
+
+def test_tph_summation():
+    """The tables_per_head tables are summed within each head -> (B, n_heads, n_outputs)."""
+    m = _m(n_heads=3, tables_per_head=5, n_det=1)
+    x = torch.randn(4, 17)
+    m.eval(); y = m(x)                                            # (4,3,6) eval-mode hard forward
+    # equals per-table hard reads reshaped (n_heads, tph) and summed over tph
+    t_hard, t_soft = m._first_spike(x)
+    rows = m._hard_read(*(m._bucket(t_hard, t_soft)[:1]))         # (B, n_tables, O)
+    assert torch.allclose(y, rows.view(4, 3, 5, 6).sum(2), atol=1e-6)
+
+
+# ---- fixed latency code ----
+def test_latency_fixed_formula():
+    """latency = clamp(t_window*(0.5 - 3x/32), 0, t_window): slope alpha=3, saturating at x=+-16/3."""
+    m = _m()
+    TW = m.t_window                                                     # 32 -> map = 16 - 3x
+    sat = 16.0 / 3.0                                                    # ~5.33: saturation point
+    assert torch.allclose(m.latency(torch.zeros(3)), torch.full((3,), TW / 2), atol=1e-6)   # x=0 -> half window
+    # +4 is NO LONGER clamped: 16 - 3*4 = 4 (positive), not 0
+    assert torch.allclose(m.latency(torch.tensor(4.0)), torch.tensor(4.0), atol=1e-6)
+    assert torch.allclose(m.latency(torch.tensor(-4.0)), torch.tensor(28.0), atol=1e-6)      # 16 + 12
+    # saturates to 0 at x=+16/3 (and stays 0 beyond), to t_window at x=-16/3
+    assert torch.allclose(m.latency(torch.tensor(sat)), torch.tensor(0.0), atol=1e-5)
+    assert torch.allclose(m.latency(torch.tensor(-sat)), torch.tensor(TW), atol=1e-5)
+    assert torch.allclose(m.latency(torch.tensor(8.0)), torch.tensor(0.0), atol=1e-6)        # beyond -> stays 0
+    assert torch.allclose(m.latency(torch.tensor(-8.0)), torch.tensor(TW), atol=1e-6)
+    xs = torch.linspace(-8, 8, 300)
+    lat = m.latency(xs)
+    assert (lat[1:] - lat[:-1] <= 1e-6).all(), "latency must be monotonically non-increasing in x"
+    assert not hasattr(m, "latency_c") and not hasattr(m, "latency_alpha")   # params removed
+
+
+# ---- bounded positive-only delay ----
+def test_delay_default_zero_init():
+    m = _m()                                              # delay_init_std unset -> default 0.0
+    assert torch.equal(m.delay, torch.zeros_like(m.delay))
+
+
+def test_delay_positive_init_and_clamp():
+    m = _m(delay_init_std=4.0)
+    d = m.delay.detach()
+    assert (d >= 0).all(), "half-normal init must be non-negative (causal)"
+    assert d.std() > 0, "delay_init_std>0 must give nonzero spread"
+    # raw init is in-range, so the clamp used in forward is a no-op here
+    assert torch.equal(torch.clamp(d, 0.0, m.t_window), d)
+    # even if a delay is pushed out of range, the effective (clamped) delay stays in [0, t_window]
+    with torch.no_grad():
+        m.delay[0, 0, 0] = -5.0; m.delay[0, 0, 1] = 10 * m.t_window
+    eff = torch.clamp(m.delay, 0.0, m.t_window)
+    assert (eff >= 0).all() and (eff <= m.t_window).all()
+    assert torch.isfinite(m(torch.randn(8, 17))).all()
+
+
+# ---- n_det=1 (plain bucket) coverage ----
+def test_bucket_n_det1_reads_and_shapes():
+    m = _m(n_det=1, n_heads=1, tables_per_head=4, n_buckets=8)
+    x = torch.randn(8, 17)
+    assert m.cells == 8 and m.table.shape == (4, 8, 6)
+    assert m.w_raw.shape == (4, 1, 17) and m.boundaries.shape == (4, 1, 7)   # detector axis always present (D=1)
+    # hard read is exactly the single-bucket row of the addressed cell
+    t_hard, t_soft = m._first_spike(x)
+    b_hard, _ = m._bucket(t_hard, t_soft)
+    y_hard = m._hard_read(b_hard)
+    manual = torch.stack([m.table[t][b_hard[:, t, 0]] for t in range(m.n_tables)], dim=1)
+    assert torch.allclose(y_hard, manual, atol=1e-6)
+    assert torch.equal(m.address(x), b_hard[:, :, 0])            # joint index == the single bucket digit
+
+
+def test_bounded_excitatory_weights():
+    m = _m(n_det=1, tables_per_head=4)
+    w = m.w
+    assert w.shape == m.w_raw.shape == (m.n_tables, 1, m.input_dim)
+    assert (w > 0).all() and (w < m.w_max).all() and m.w_max == 2.0
+    with torch.no_grad():
+        m.w_raw.fill_(30.0); assert torch.allclose(m.w, torch.full_like(m.w, m.w_max), atol=1e-3)
+        m.w_raw.fill_(-30.0); assert (m.w < 1e-6).all()
+
+
+def test_boundaries_strictly_increasing():
+    m = _m(n_heads=1, tables_per_head=5, n_det=1)
+    b = m.boundaries
+    assert b.shape == (5, 1, m.n_buckets - 1) and (b[..., 1:] - b[..., :-1] > 0).all()
+
+
+def test_no_crossing_folds_into_last_bucket():
+    m = _m(n_det=1, n_buckets=8, tables_per_head=3)
+    with torch.no_grad():
+        m.w_raw.fill_(-30.0)
+    x = torch.randn(8, 17)
+    t_hard, _ = m._first_spike(x)
+    assert torch.allclose(t_hard, torch.full_like(t_hard, m.t_window))
+    assert torch.equal(m.address(x), torch.full_like(m.address(x), m.n_buckets - 1))
+    m.train(); assert torch.isfinite(m(x)).all()
+    m.eval();  assert torch.isfinite(m(x)).all()
+
+
+# ---- n_det>1 (product / mixed-radix) coverage ----
+def test_mixed_radix_and_tensor_product_soft():
+    m = _m(n_heads=3, tables_per_head=1, n_det=2, n_buckets=8)
+    x = torch.randn(16, 17)
+    t_hard, t_soft = m._first_spike(x)
+    b_hard, p = m._bucket(t_hard, t_soft)
+    grid = m.table.reshape(m.n_tables, m.n_buckets, m.n_buckets, m.n_outputs)
+    manual = torch.stack([grid[t][b_hard[:, t, 0], b_hard[:, t, 1]] for t in range(m.n_tables)], dim=1)
+    assert torch.allclose(m._hard_read(b_hard), manual, atol=1e-5), "mixed-radix hard index"
+    P = p[:, :, 0, :].unsqueeze(-1) * p[:, :, 1, :].unsqueeze(-2)
+    dense = torch.einsum('btij,tijo->bto', P, grid)
+    assert torch.allclose(m._soft_read(p), dense, atol=1e-4), "soft addr readout == dense tensor product (value)"
+
+
+def test_st_table_grad_only_selected_cell():
+    m = _m(n_det=2, n_buckets=8, tables_per_head=1, n_heads=3)
+    x = torch.randn(4, 17); tgt = torch.randn(4, 3, 6)
+    m.zero_grad(set_to_none=True)
+    F.mse_loss(m(x), tgt).backward()
+    cells_with_grad = (m.table.grad.abs().sum(dim=-1) > 0)       # (T, cells)
+    assert cells_with_grad.any() and int(cells_with_grad.sum()) < m.table[..., 0].numel()
+
+
+def test_soft_joint_sums_to_one():
+    m = _m(n_det=2, n_buckets=8)
+    x = torch.randn(8, 17)
+    t_hard, t_soft = m._first_spike(x)
+    _, p = m._bucket(t_hard, t_soft)
+    assert torch.allclose(p.sum(-1), torch.ones_like(p.sum(-1)), atol=1e-4)   # each detector's dist sums to 1
+
+
+# ---- freeze_temperature ----
+def test_freeze_temperature():
+    # default: trainable temps at T=1.0
+    md = _m()
+    assert md.log_T_cross.requires_grad and md.log_T_bkt.requires_grad
+    # frozen: value 0.0 (T=1.0) and non-trainable
+    mf = _m(freeze_temperature=True)
+    assert not mf.log_T_cross.requires_grad and not mf.log_T_bkt.requires_grad
+    assert torch.equal(mf.log_T_cross, torch.zeros_like(mf.log_T_cross))
+    assert torch.equal(mf.log_T_bkt, torch.zeros_like(mf.log_T_bkt))
+    assert torch.allclose(mf.T_cross, torch.ones_like(mf.T_cross)) and torch.allclose(mf.T_bkt, torch.ones_like(mf.T_bkt))
+    # after a couple of ST steps: frozen temps stay put; default temps move
+    for m in (md, mf):
+        opt = torch.optim.Adam([p for p in m.parameters() if p.requires_grad], lr=1e-1)
+        for _ in range(2):
+            opt.zero_grad(); F.mse_loss(m(torch.randn(16, 17)), torch.randn(16, 2, 6)).backward(); opt.step()
+    assert torch.equal(mf.log_T_cross, torch.zeros_like(mf.log_T_cross)), "frozen T_cross must not move"
+    assert torch.equal(mf.log_T_bkt, torch.zeros_like(mf.log_T_bkt)), "frozen T_bkt must not move"
+    assert not torch.equal(md.log_T_bkt, torch.zeros_like(md.log_T_bkt)), "trainable T_bkt should move"
+
+
+# ---- params, temperatures, cap, table_init ----
+def test_all_params_incl_temperatures_get_gradient():
+    m = _m(n_det=2, n_buckets=8, tables_per_head=3)
+    x = torch.randn(16, 17); tgt = torch.randn(16, 2, 6)
+    m.zero_grad(set_to_none=True)
+    F.mse_loss(m(x), tgt).backward()
+    for name, pp in m.named_parameters():
+        assert pp.grad is not None and torch.isfinite(pp.grad).all() and pp.grad.abs().sum() > 0, f"{name} no grad"
+    assert m.log_T_cross.shape == (m.n_tables,) and m.log_T_bkt.shape == (m.n_tables,)   # trainable per-table temps
+
+
+def test_table_init_and_cell_cap():
+    tab = torch.randn(8, 16, 6)
+    m = LIFMultiHeadLUT(input_dim=17, n_heads=2, n_outputs=6, tables_per_head=4, n_det=1, n_buckets=16, table_init=tab)
+    assert torch.equal(m.table.detach(), tab)
+    with pytest.raises(ValueError):
+        LIFMultiHeadLUT(input_dim=17, n_heads=1, n_outputs=6, n_det=5, n_buckets=16)   # 16**5 > 65536
+    assert MAX_CELLS == 65536


### PR DESCRIPTION
Splits the **LIFMultiHeadLUT core class** out of `exp/lif-detectors-mhl` (PR #83) into its own reviewable PR, off `main`.

Adds `spiky.lutorch.lif_multi_head_lut.LIFMultiHeadLUT` — a straight-through-decoded LIF-detector Multi-Head LUT that unifies the bucket (`n_det=1`) and product (`n_det>1`, mixed-radix) cases in one class:

- `forward()` branches on `self.training`: the ST training path (value == hard winner, address grad via a soft distribution against a detached table) vs. an **efficient hard eval** path (no soft math, no temperatures) in eval mode.
- **Freezable** per-table temperatures (`freeze_temperature`), so they can be held at 1.0.
- **Bounded, causal** (non-negative) per-detector delays; **α=3** fixed latency map `clamp(t_window*(0.5 − 3x/32), 0, t_window)`.
- O(N) cumsum first-spike LIF membrane; bounded excitatory weights, `softplus`+1 `tau` floor, trainable strictly-increasing bucket boundaries.

Plus the full unit-test suite `tests/test_lif_multi_head_lut.py` (16 tests). On this branch: `PYTHONPATH=src pytest src/spiky/lutorch/tests/` → **88 passed, 144 skipped** (the skips are the pre-existing CUDA/native-gated tests).

The experiments, harnesses, results, and math writeup that use this class are in a separate stacked PR (`exp/lif-mhl-experiments`).
