### PR TITLE
Consolidate walker2d-viz: newest server (overload + auto-stop) + union client into landing source-of-truth

### DIFF
--- a/landing/walker2d-viz/.env.example
+++ b/landing/walker2d-viz/.env.example
@@ -4,5 +4,6 @@
 DOMAIN=demo.example.com
 
 # Max concurrent viewers. Each is one MuJoCo env stepping at SPS; size to the VM's CPU.
-# Default 6 suits the initial 2-vCPU / 8 GB box; raise to ~16-24 on a larger machine.
-MAX_SESSIONS=6
+# Default 48 = the benchmarked clean 30 fps ceiling on the 2-vCPU / 8 GB box (LUT policy);
+# lower it for the heavier SAC-baseline MLP, raise it on a bigger machine.
+MAX_SESSIONS=48

--- a/landing/walker2d-viz/DEPLOY.md
+++ b/landing/walker2d-viz/DEPLOY.md
@@ -23,12 +23,19 @@ You provision the VM and DNS yourself. Nothing here spends money or touches a cl
 The server runs **one isolated session per WebSocket connection**: each connected browser gets its own
 Gymnasium env instance, its own selected actor, and its own pause / mode / free-fall state. Viewers never
 share or fight over a single env. A global cap **`MAX_SESSIONS`** bounds CPU — once reached, new
-connections are refused with `{"type":"error", ...}` (the client shows it as a failed connection).
+connections get a `{"type":"server_full"}` message and a clean close, and the client shows a friendly
+"server is overloaded" banner (with a Retry button) instead of a raw failure.
 
 Each session is one MuJoCo env stepping at `SPS` (default 30) steps/s — CPU-bound, no GPU. The initial
-target box is a **2 vCPU / 8 GB Nebius Ice Lake** VM, and `MAX_SESSIONS` **defaults to 6** — comfortably
-~5–8 concurrent viewers on 2 cores. Raise it (e.g. **16–24**) if you move to a larger box; watch CPU while
-a few viewers are connected and tune.
+target box is a **2 vCPU / 8 GB Nebius Ice Lake** VM, and `MAX_SESSIONS` **defaults to 48** — the
+benchmarked clean ceiling on that box with the light LUT policy: a full 30 fps held for all sessions up to
+~48, with degradation beginning around ~64 and a hard falloff past ~96. 48 keeps the box smooth for the
+common (LUT) case; lower it if you expect many viewers on the heavier SAC-baseline MLP, and raise it on a
+bigger box (watch CPU while a few viewers are connected and tune).
+
+Idle sessions are cheap: after `AUTO_IDLE_S` (default 180 s) of uninterrupted walking a forgotten session
+auto-switches to the **zero** policy, lets the body settle, then goes fully idle (≈0 CPU / 0 bandwidth)
+until the next interaction — so a tab left open doesn't keep burning a core.
 
 ---
 
@@ -65,7 +72,7 @@ Config knobs (all env vars, set in `.env` / compose):
 | var            | default        | meaning                                             |
 |----------------|----------------|-----------------------------------------------------|
 | `DOMAIN`       | *(required)*   | FQDN Caddy serves + gets a cert for                 |
-| `MAX_SESSIONS` | `6`            | concurrent viewer cap (6 fits 2 vCPU; raise on a bigger box) |
+| `MAX_SESSIONS` | `48`           | concurrent viewer cap (48 = benchmarked clean ceiling on 2 vCPU; raise on a bigger box) |
 | `SPS`          | `30`           | sim steps/sec streamed per session                  |
 | `ENV_ID`       | `Walker2d-v5`  | Gymnasium env id                                    |
 | `PORT`/`HOST`  | `8765`/`0.0.0.0` | internal server bind (rarely changed)             |

--- a/landing/walker2d-viz/client/index.html
+++ b/landing/walker2d-viz/client/index.html
@@ -20,7 +20,13 @@
     canvas { display: block; }
     #ui { position: fixed; top: 12px; left: 12px; z-index: 10; background: rgba(20,24,32,.85);
       border: 1px solid #2a3240; border-radius: 10px; padding: 12px 14px; width: 250px; backdrop-filter: blur(6px); }
-    #ui h1 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
+    #ui h1 { font-size: 14px; margin: 0; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+    #ui h1 .title { flex: 1; white-space: nowrap; }
+    #foldBtn { background: none; border: none; color: #9fb0c3; cursor: pointer; font-size: 15px; line-height: 1; padding: 2px 4px; }
+    #foldBtn:hover { color: #e6e6e6; border: none; }
+    #uiBody { margin-top: 10px; }
+    #ui.collapsed { width: auto; padding: 8px 10px; }
+    #ui.collapsed #uiBody { display: none; }
     .row { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 8px 0; }
     .row label { color: #9fb0c3; }
     button, select { background: #1b2230; color: #e6e6e6; border: 1px solid #33405a; border-radius: 6px;
@@ -32,17 +38,33 @@
     #stat b { color: #e6e6e6; }
     #conn { font-size: 11px; } .ok { color: #4ade80; } .bad { color: #f87171; }
     #srv { width: 100%; margin-top: 4px; background:#141a24; color:#cbd5e1; border:1px solid #33405a; border-radius:6px; padding:4px 6px; }
+    /* Overload banner: shown when the server replies "server_full" (at capacity). */
+    #overlay { position: fixed; inset: 0; z-index: 20; display: none; align-items: center; justify-content: center;
+      background: rgba(14,17,22,.82); backdrop-filter: blur(3px); }
+    #overlay .card { background: #141a24; border: 1px solid #33405a; border-radius: 12px; padding: 22px 26px;
+      max-width: 360px; text-align: center; box-shadow: 0 8px 40px rgba(0,0,0,.5); }
+    #overlay h2 { margin: 0 0 8px; font-size: 16px; color: #ffd479; }
+    #overlay p { margin: 0 0 14px; color: #cbd5e1; line-height: 1.5; }
+    #overlay button { background: #2b6cff; border: 1px solid #2b6cff; color: #fff; }
   </style>
 </head>
 <body>
   <div id="app"></div>
+  <div id="overlay"><div class="card">
+    <h2>Server is overloaded</h2>
+    <p id="overlayMsg">The demo server is at capacity, please come back later.</p>
+    <button id="overlayRetry">Retry</button>
+  </div></div>
   <div id="ui">
-    <h1>Walker2d Viz &middot; <span id="conn" class="bad">disconnected</span></h1>
+    <h1><span class="title">Walker2d Viz &middot; <span id="conn" class="bad">disconnected</span></span><button id="foldBtn" aria-label="Collapse controls" title="Collapse / expand controls">&#9662;</button></h1>
+    <div id="uiBody">
     <input id="srv" value="ws://localhost:8765" title="WebSocket server URL" />
     <div class="row">
       <button id="restart">Restart</button>
       <button id="pauseBtn">Pause</button>
-      <button id="modeBtn">Mode: test</button>
+    </div>
+    <div class="row">
+      <button id="renderBtn" class="active" title="Toggle between the real Walker2d MJCF geometry and the approximate one">Render: Accurate</button>
     </div>
     <div class="row">
       <label for="noreset">No-reset (free-fall)</label>
@@ -62,6 +84,7 @@
       step <b id="step">0</b> &middot; reward <b id="reward">0.00</b><br />
       return <b id="ret">0.00</b> &middot; actor <b id="actorName">&mdash;</b>
     </div>
+    </div><!-- /uiBody -->
   </div>
   <script src="config.js"></script>
   <script type="module" src="src/main.js"></script>

--- a/landing/walker2d-viz/client/index.static.html
+++ b/landing/walker2d-viz/client/index.static.html
@@ -37,10 +37,23 @@
     #stat b { color: #e6e6e6; }
     #conn { font-size: 11px; } .ok { color: #4ade80; } .bad { color: #f87171; }
     #srv { width: 100%; margin-top: 4px; background:#141a24; color:#cbd5e1; border:1px solid #33405a; border-radius:6px; padding:4px 6px; }
+    /* Overload banner: shown when the server replies "server_full" (at capacity). */
+    #overlay { position: fixed; inset: 0; z-index: 20; display: none; align-items: center; justify-content: center;
+      background: rgba(14,17,22,.82); backdrop-filter: blur(3px); }
+    #overlay .card { background: #141a24; border: 1px solid #33405a; border-radius: 12px; padding: 22px 26px;
+      max-width: 360px; text-align: center; box-shadow: 0 8px 40px rgba(0,0,0,.5); }
+    #overlay h2 { margin: 0 0 8px; font-size: 16px; color: #ffd479; }
+    #overlay p { margin: 0 0 14px; color: #cbd5e1; line-height: 1.5; }
+    #overlay button { background: #2b6cff; border: 1px solid #2b6cff; color: #fff; }
   </style>
 </head>
 <body>
   <div id="app"></div>
+  <div id="overlay"><div class="card">
+    <h2>Server is overloaded</h2>
+    <p id="overlayMsg">The demo server is at capacity, please come back later.</p>
+    <button id="overlayRetry">Retry</button>
+  </div></div>
   <div id="ui">
     <h1><span class="title">Walker2d Viz &middot; <span id="conn" class="bad">disconnected</span></span><button id="foldBtn" aria-label="Collapse controls" title="Collapse / expand controls">&#9662;</button></h1>
     <div id="uiBody">
@@ -48,7 +61,6 @@
     <div class="row">
       <button id="restart">Restart</button>
       <button id="pauseBtn">Pause</button>
-      <button id="modeBtn">Mode: test</button>
     </div>
     <div class="row">
       <button id="renderBtn" class="active" title="Toggle between the real Walker2d MJCF geometry and the approximate one">Render: Accurate</button>

--- a/landing/walker2d-viz/client/src/main.js
+++ b/landing/walker2d-viz/client/src/main.js
@@ -244,19 +244,34 @@ addEventListener('resize', resize); resize()
 // ---------------------------------------------------------------------------
 const $ = (id) => document.getElementById(id)
 const conn = $('conn')
-let ws = null, mode = 'test', paused = false
+let ws = null, paused = false, serverFull = false
 
 function send(obj) { if (ws && ws.readyState === 1) ws.send(JSON.stringify(obj)) }
 
+const overlay = $('overlay'), overlayMsg = $('overlayMsg')
+function showOverlay(msg) { if (overlayMsg) overlayMsg.textContent = msg; if (overlay) overlay.style.display = 'flex' }
+function hideOverlay() { if (overlay) overlay.style.display = 'none' }
+
 function connect(url) {
   if (ws) { try { ws.close() } catch {} }
+  serverFull = false; hideOverlay()
   conn.textContent = 'connecting…'; conn.className = ''
   ws = new WebSocket(url)
-  ws.onopen = () => { conn.textContent = 'connected'; conn.className = 'ok' }
-  ws.onclose = () => { conn.textContent = 'disconnected'; conn.className = 'bad'; setTimeout(() => connect(url), 1500) }
+  ws.onopen = () => { conn.textContent = 'connected'; conn.className = 'ok'; hideOverlay() }
+  ws.onclose = () => {
+    conn.textContent = serverFull ? 'server full' : 'disconnected'; conn.className = 'bad'
+    // When the server told us it's at capacity, do NOT auto-reconnect (no tight retry loop) — the
+    // overlay's Retry button lets the visitor try again on their own terms. Otherwise reconnect.
+    if (!serverFull) setTimeout(() => connect(url), 1500)
+  }
   ws.onerror = () => { conn.textContent = 'error'; conn.className = 'bad' }
   ws.onmessage = (ev) => {
     const m = JSON.parse(ev.data)
+    if (m.type === 'server_full') {                    // at capacity: friendly banner, stop reconnecting
+      serverFull = true
+      showOverlay(m.message || 'The demo server is at capacity, please come back later.')
+      return
+    }
     if (m.type === 'actors') {
       const sel = $('actor'); sel.innerHTML = ''
       for (const name of m.actors) {
@@ -270,8 +285,6 @@ function connect(url) {
       $('reward').textContent = (+m.reward).toFixed(2)
       $('ret').textContent = (+m.return).toFixed(1)
       $('actorName').textContent = m.actor
-      mode = m.mode; $('modeBtn').textContent = 'Mode: ' + mode
-      $('modeBtn').classList.toggle('active', mode === 'train')
       paused = !!m.paused                            // reflect server pause state
       $('pauseBtn').textContent = paused ? 'Resume' : 'Pause'
       $('pauseBtn').classList.toggle('active', paused)
@@ -287,7 +300,6 @@ $('pauseBtn').onclick = () => {
   $('pauseBtn').textContent = paused ? 'Resume' : 'Pause'
   $('pauseBtn').classList.toggle('active', paused)
 }
-$('modeBtn').onclick = () => { mode = (mode === 'test' ? 'train' : 'test'); send({ cmd: 'mode', mode }) }
 $('renderBtn').onclick = () => {                          // live switch between accurate MJCF and approximate render
   renderMode = renderMode === 'accurate' ? 'approx' : 'accurate'
   applyRenderVisibility()
@@ -308,6 +320,7 @@ $('speed').oninput = (e) => { $('speedVal').textContent = e.target.value + '/s';
 $('actor').onchange = (e) => send({ cmd: 'actor', name: e.target.value })
 $('noreset').onchange = (e) => send({ cmd: 'no_reset', value: e.target.checked })
 $('srv').onchange = (e) => connect(e.target.value.trim())
+$('overlayRetry').onclick = () => connect($('srv').value.trim())   // manual retry from the overload banner
 
 // WebSocket URL resolution order:
 //   1. window.WALKER2D_WS from config.js (set to wss://your-domain for a GitHub Pages build), else

--- a/landing/walker2d-viz/server/server.py
+++ b/landing/walker2d-viz/server/server.py
@@ -6,7 +6,7 @@ messages (restart / mode / speed / actor / pause / no_reset). Actors are auto-di
 Concurrency model: **one independent session per WebSocket connection**. Each connected browser gets its
 own Sim (its own env instance, selected actor, pause/mode/free-fall state and stepping task), so multiple
 viewers never fight over a shared env — required for a public multi-viewer demo. A global cap
-(MAX_SESSIONS) bounds CPU: extra connections are refused with an {"type":"error"} message.
+(MAX_SESSIONS) bounds CPU: extra connections get a {"type":"server_full"} message, then a clean close.
 
 Config via env vars (CLI flags override): HOST, PORT, ENV_ID, SPS, MAX_SESSIONS.
 Run:  python server.py [--host 0.0.0.0] [--port 8765] [--env Walker2d-v5] [--sps 30] [--max-sessions 8]
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import json
 import os
+import time
 
 import numpy as np
 import websockets
@@ -32,6 +33,15 @@ from actors import discover_actors
 REGISTRY = discover_actors()
 if not REGISTRY:
     raise SystemExit("no actors discovered in actors/")
+
+# Auto-stop: after this many seconds of UNINTERRUPTED walking, a session is switched to the "zero" policy so
+# a forgotten/idle viewer stops consuming compute. Any user interaction (model switch, pause/resume, restart,
+# speed change) resets the timer. The "zero" policy is itself idle (~0 CPU): the stepper lets the body settle
+# for ZERO_SETTLE frames (so it topples naturally) then goes quiet until the next interaction. AUTO_IDLE_S is
+# env-overridable (mostly for tests).
+AUTO_IDLE_S = float(os.environ.get("AUTO_IDLE_S", 180.0))
+ZERO_SETTLE = 60                        # ~2 s at 30 sps
+DEFAULT_ACTOR = "fastlut_lse (exp19)"   # preferred default actor if present (else "random", else first discovered)
 
 
 def make_env(preferred):
@@ -56,17 +66,16 @@ class Sim:
     def __init__(self, env_name, sps):
         self.env, self.env_name = make_env(env_name)
         self.registry = REGISTRY
-        # Default a fresh session to a GOOD walking policy so viewers don't see the random flail-and-fall on
-        # load; fall back to "random" then the first discovered actor if that policy isn't present.
-        _default = "fastlut_lse (exp19)"
-        self.actor_name = (_default if _default in self.registry
+        self.actor_name = (DEFAULT_ACTOR if DEFAULT_ACTOR in self.registry
                            else "random" if "random" in self.registry
                            else next(iter(self.registry)))
         self.actor = self.registry[self.actor_name](self.env.action_space)
         self.mode = "test"                       # "test" | "train"
         self.paused = False                      # when True, the stepper idles (no step, no broadcast)
-        self._resume = asyncio.Event()           # set() while running; cleared while paused -> stepper awaits it
-        self._resume.set()
+        # One wake event drives ALL idle states (pause AND the settled zero policy): cleared while idle so the
+        # stepper awaits it; any interaction sets it (see touch()). ~0 CPU / ~0 bandwidth while idle.
+        self._wake = asyncio.Event()
+        self._wake.set()
         self.no_reset = False                    # free-fall: when True, don't auto-reset on termination
         self.terminated = False
         self.sps = float(sps)
@@ -74,12 +83,31 @@ class Sim:
         self.step_count = 0
         self.reward = 0.0
         self.ret = 0.0                            # episode return
+        self._walk_since = time.monotonic()      # start of the current uninterrupted walk (auto-stop timer)
+        self._auto_zeroed = False                # set once the auto-stop has fired for this walk
+        self._zero_settle = ZERO_SETTLE if self.actor_name == "zero" else 0   # frames to step before idling on zero
 
     # ---- control ----
+    def touch(self):
+        """A user interaction: reset the auto-stop walk timer, re-arm it, and wake any idle stepper."""
+        self._walk_since = time.monotonic()
+        self._auto_zeroed = False
+        self._wake.set()
+
     def set_actor(self, name):
         if name in self.registry:
             self.actor_name = name
             self.actor = self.registry[name](self.env.action_space)
+            self._zero_settle = ZERO_SETTLE if name == "zero" else 0   # a (re)selected zero topples, then idles
+            self.touch()
+
+    def _auto_zero(self):
+        """Internal (NOT a user interaction, so no touch): switch a forgotten walk to the zero policy."""
+        if self.actor_name != "zero" and "zero" in self.registry:
+            self.actor_name = "zero"
+            self.actor = self.registry["zero"](self.env.action_space)
+        self._auto_zeroed = True
+        self._zero_settle = ZERO_SETTLE
 
     def set_mode(self, mode):
         self.mode = "train" if mode == "train" else "test"
@@ -89,10 +117,7 @@ class Sim:
 
     def set_paused(self, value):
         self.paused = bool(value)
-        if self.paused:
-            self._resume.clear()                 # stepper will send one final frame then await _resume
-        else:
-            self._resume.set()                   # wake the idling stepper -> resume stepping/broadcast
+        self.touch()                             # pause OR resume is an interaction: reset timer + wake
 
     def restart(self):
         self.obs, _ = self.env.reset()
@@ -100,6 +125,9 @@ class Sim:
         self.reward = 0.0
         self.ret = 0.0
         self.terminated = False
+        if self.actor_name == "zero":
+            self._zero_settle = ZERO_SETTLE      # restarted while on zero -> let it topple again, then idle
+        self.touch()
 
     def step(self):
         action = self.actor.act(self.obs)
@@ -149,18 +177,28 @@ async def stepper(sim, ws):
     next_t = loop.time()
     try:
         while True:
-            if sim.paused:
-                # Send exactly ONE frame reflecting the frozen pose + paused=true, then go fully quiet:
-                # no physics, no inference, no per-tick frames. Await the resume event (no busy-spin, ~0 CPU).
-                # The connection is kept alive by the websockets library's built-in ping/pong while we idle.
+            # Auto-stop: a forgotten walk (untouched for AUTO_IDLE_S) -> zero policy, which then settles + idles.
+            # (Skip if already on zero — a user-selected zero settles/idles on its own; don't re-settle it.)
+            if (not sim.paused and not sim._auto_zeroed and sim.actor_name != "zero"
+                    and (time.monotonic() - sim._walk_since) >= AUTO_IDLE_S):
+                sim._auto_zero()
+
+            # Idle (~0 CPU / ~0 bandwidth): PAUSED, or on the zero policy once it has settled. Send exactly ONE
+            # frozen/resting frame, then await sim._wake (no busy-spin) until an interaction. The connection is
+            # kept alive by the websockets library's built-in ping/pong while we idle.
+            if sim.paused or (sim.actor_name == "zero" and sim._zero_settle <= 0):
                 try:
                     await ws.send(sim.state_msg())
                 except websockets.exceptions.ConnectionClosed:
                     break
-                await sim._resume.wait()
-                next_t = loop.time()      # resync pacing on resume (don't burst-catch-up the paused gap)
+                sim._wake.clear()
+                await sim._wake.wait()
+                next_t = loop.time()      # resync pacing on wake (don't burst-catch-up the idle gap)
                 continue
-            sim.step()
+
+            sim.step()                    # normal walk, OR the brief zero-settle so the body topples naturally
+            if sim.actor_name == "zero" and sim._zero_settle > 0:
+                sim._zero_settle -= 1
             try:
                 await ws.send(sim.state_msg())
             except websockets.exceptions.ConnectionClosed:
@@ -178,9 +216,14 @@ async def stepper(sim, ws):
 def make_handler(cfg, state):
     async def handler(ws):
         # Capacity gate: one env per session is CPU-bound; refuse beyond the cap instead of thrashing.
+        # Accept the socket just long enough to send a structured "server_full" message, then close
+        # cleanly, so the client can show a friendly overload banner rather than see a raw drop.
         if state["sessions"] >= cfg.max_sessions:
             with contextlib.suppress(Exception):
-                await ws.send(json.dumps({"type": "error", "error": "Server at capacity — try again shortly."}))
+                await ws.send(json.dumps({
+                    "type": "server_full",
+                    "message": "The demo server is at capacity, please come back later.",
+                }))
                 await ws.close()
             return
         state["sessions"] += 1
@@ -201,6 +244,7 @@ def make_handler(cfg, state):
                     sim.set_mode(m.get("mode", "test"))
                 elif cmd == "speed":
                     sim.sps = max(1.0, float(m.get("sps", sim.sps)))
+                    sim.touch()                          # speed change is an interaction: reset the auto-stop timer
                 elif cmd == "actor":
                     sim.set_actor(m.get("name", ""))
                 elif cmd == "pause":
@@ -241,7 +285,7 @@ async def main():
     ap.add_argument("--port", type=int, default=_env_int("PORT", 8765))
     ap.add_argument("--env", default=os.environ.get("ENV_ID", "Walker2d-v5"))
     ap.add_argument("--sps", type=float, default=_env_float("SPS", 30.0))
-    ap.add_argument("--max-sessions", type=int, default=_env_int("MAX_SESSIONS", 6))
+    ap.add_argument("--max-sessions", type=int, default=_env_int("MAX_SESSIONS", 48))
     a = ap.parse_args()
 
     class Cfg:


### PR DESCRIPTION
Consolidates the recent **walker2d-viz** work into `landing/walker2d-viz/` — the declared source-of-truth (from PR #86) — so the three drifting copies (root `walker2d-viz` branch, `landing`, `gh-pages`) converge here. Nothing was broken live; this is source-hygiene.

### Server — `landing/walker2d-viz/server/server.py`
Replaced with the newest version from the root `walker2d-viz` branch (commit `b936a874`), a clean superset:
- **Overload**: extra connections past `MAX_SESSIONS` get `{"type":"server_full"}` + a clean close.
- **Auto-stop**: after `AUTO_IDLE_S` (default **180 s**) of uninterrupted walking, a session switches itself to the **zero** policy, settles ~2 s, then goes fully idle (≈0 CPU / 0 bandwidth) until the next interaction. One wake `Event` drives both pause and settled-zero; any interaction (actor switch, pause/resume, restart, speed) resets the timer.
- **Default actor** `fastlut_lse (exp19)` (→ random → first discovered). The exp19 model `.npz` already lives on the `landing` branch.
- **`MAX_SESSIONS` default 48**. Bumped `.env.example` (6→48) and the `DEPLOY.md` sizing notes to match, and documented the overload banner + idle behaviour.

### Client — union of both clients' features
Based on landing's client (kept its work), grafted in what it lacked:
- ✅ **Kept**: accurate MJCF render mode + Approx/Accurate toggle + foldable controls panel.
- ➕ **Added**: the `server_full` overload overlay/banner + no-tight-reconnect logic (Retry button).
- ➖ **Removed**: the display-only test/train **Mode** button.
- 🔧 **Synced** the stale Vite entry `index.html` to match `index.static.html` — it had fallen behind the shared `main.js` (referenced `renderBtn`/`foldBtn` that didn't exist in it, and still carried the Mode button), so it would have errored on load.

### Intentionally excluded
- **No `bench/` load-test tooling** — kept local only, not on GitHub (per your instruction).

### Verification
- `server.py` compiles; client JS braces/parens/brackets balance; no residual `modeBtn` anywhere.
- Local run confirms: exp19 is discovered **and** the default; a 2nd connection past the cap receives `server_full`; an untouched session auto-stops to a fully idle (0 frames/s) state.

### After merge
Publish landing's client to **gh-pages** per the documented `landing/` → gh-pages mapping (`index.static.html` → `/walker2d-viz/index.html`, `config.js`, `src/main.js`). **No server redeploy needed** — the VM already runs this exact server code (`b936a874`), and `MAX_SESSIONS=48` is already set on the box.

*Left open for your review — not merged; gh-pages untouched.*
