### PR TITLE
Cap max speed at 60 sps (client + server guard)

### DIFF
--- a/landing/walker2d-viz/client/index.html
+++ b/landing/walker2d-viz/client/index.html
@@ -72,7 +72,7 @@
     </div>
     <div class="row">
       <label for="speed">Speed</label>
-      <input id="speed" type="range" min="1" max="120" value="30" />
+      <input id="speed" type="range" min="1" max="60" value="30" />
       <span id="speedVal">30/s</span>
     </div>
     <div class="row">

--- a/landing/walker2d-viz/client/index.static.html
+++ b/landing/walker2d-viz/client/index.static.html
@@ -71,7 +71,7 @@
     </div>
     <div class="row">
       <label for="speed">Speed</label>
-      <input id="speed" type="range" min="1" max="120" value="30" />
+      <input id="speed" type="range" min="1" max="60" value="30" />
       <span id="speedVal">30/s</span>
     </div>
     <div class="row">

--- a/landing/walker2d-viz/server/server.py
+++ b/landing/walker2d-viz/server/server.py
@@ -42,6 +42,9 @@ if not REGISTRY:
 AUTO_IDLE_S = float(os.environ.get("AUTO_IDLE_S", 180.0))
 ZERO_SETTLE = 60                        # ~2 s at 30 sps
 DEFAULT_ACTOR = "fastlut_lse (exp19)"   # preferred default actor if present (else "random", else first discovered)
+MIN_SPS = 1.0
+MAX_SPS = 60.0                          # hard ceiling on steps/sec: higher sps = more step+inference+send/sec
+                                        # = more server CPU/bandwidth, so cap it (authoritative server-side guard)
 
 
 def make_env(preferred):
@@ -78,7 +81,7 @@ class Sim:
         self._wake.set()
         self.no_reset = False                    # free-fall: when True, don't auto-reset on termination
         self.terminated = False
-        self.sps = float(sps)
+        self.sps = min(MAX_SPS, max(MIN_SPS, float(sps)))   # clamp even the startup SPS to the cap
         self.obs, _ = self.env.reset(seed=0)
         self.step_count = 0
         self.reward = 0.0
@@ -243,7 +246,7 @@ def make_handler(cfg, state):
                 elif cmd == "mode":
                     sim.set_mode(m.get("mode", "test"))
                 elif cmd == "speed":
-                    sim.sps = max(1.0, float(m.get("sps", sim.sps)))
+                    sim.sps = min(MAX_SPS, max(MIN_SPS, float(m.get("sps", sim.sps))))   # clamp to [1, 60]
                     sim.touch()                          # speed change is an interaction: reset the auto-stop timer
                 elif cmd == "actor":
                     sim.set_actor(m.get("name", ""))


### PR DESCRIPTION
Caps the walker2d-viz demo speed at **60 sps**, both in the UI and as an authoritative server-side guard.

**Why:** the speed control sets `sim.sps`, which paces the stepper (`1/sps`). Higher sps = more physics steps + policy inference + websocket sends per second = more server CPU and bandwidth. A hard ceiling keeps a single viewer from driving up load.

### Client
- Speed slider `max` **120 → 60** in both entry files (`index.static.html` and `index.html`), so the UI can't request more than 60. The live `/s` label reflects the slider, so it now tops out at `60/s`.

### Server (`server.py`) — the authoritative guard
- New module constants `MIN_SPS = 1.0`, `MAX_SPS = 60.0`.
- The `speed` command clamps any incoming `sps` to `[1, 60]`, so a crafted client can't exceed the cap.
- The startup `SPS` (init / `--sps` / env) is clamped to the same range too, for defense in depth.

Everything else is untouched: auto-stop-to-zero, `server_full` overload, silent pause, `MAX_SESSIONS=48`, exp19 default actor.

### Verification (local)
- `server.py` compiles; both client entries show `max="60"`; no lingering `max="120"`.
- Server clamp test over a live WebSocket: request `200 → sps=60`, request `0.1 → sps=1`, request `45 → sps=45` (in-range passes through). **PASS.**

*Left open for your review — not self-merged. No gh-pages publish / VM redeploy yet (those follow after merge, as last time).*
