### PR TITLE
Fix: auto-stop-to-zero timer never firing; works in both free-fall modes

### DIFF
--- a/landing/walker2d-viz/client/src/main.js
+++ b/landing/walker2d-viz/client/src/main.js
@@ -272,6 +272,12 @@ function connect(url) {
       showOverlay(m.message || 'The demo server is at capacity, please come back later.')
       return
     }
+    if (m.type === 'actor_changed') {                  // server auto-switched the model (auto-stop -> zero)
+      const sel = $('actor')                           // reflect it in the selector so the user sees "zero".
+      if (sel && m.actor) sel.value = m.actor          // programmatic set does NOT fire onchange -> not a user interaction
+      $('actorName').textContent = m.actor
+      return
+    }
     if (m.type === 'actors') {
       const sel = $('actor'); sel.innerHTML = ''
       for (const name of m.actors) {

--- a/landing/walker2d-viz/server/server.py
+++ b/landing/walker2d-viz/server/server.py
@@ -122,14 +122,24 @@ class Sim:
         self.paused = bool(value)
         self.touch()                             # pause OR resume is an interaction: reset timer + wake
 
-    def restart(self):
+    def _reset_episode(self):
+        """Start a fresh episode WITHOUT counting as a user interaction (no touch()).
+
+        Used by the AUTOMATIC on-fall / on-truncation reset, which is part of one *uninterrupted* walk and
+        must NOT re-arm the auto-stop timer. (Bug fix: a Walker2d episode truncates at the 1000-step limit
+        ~every 33 s at 30 sps, and falls sooner — when the auto-reset called restart()->touch(), the 180 s
+        auto-idle clock was reset every episode, so it never fired on a continuously-walking demo.)"""
         self.obs, _ = self.env.reset()
         self.step_count = 0
         self.reward = 0.0
         self.ret = 0.0
         self.terminated = False
         if self.actor_name == "zero":
-            self._zero_settle = ZERO_SETTLE      # restarted while on zero -> let it topple again, then idle
+            self._zero_settle = ZERO_SETTLE      # (re)started while on zero -> let it topple again, then idle
+
+    def restart(self):
+        """USER-initiated restart (Restart button): a fresh episode AND an interaction (resets the timer)."""
+        self._reset_episode()
         self.touch()
 
     def step(self):
@@ -140,10 +150,13 @@ class Sim:
         self.ret += self.reward
         self.step_count += 1
         self.terminated = bool(terminated or truncated)
-        # Free-fall mode: keep stepping the (fallen) body instead of resetting. MuJoCo happily keeps
-        # integrating a terminated Walker2d state (verified), so the walker just lies/flails on the ground.
-        if self.terminated and not self.no_reset:
-            self.restart()
+        # Automatic episode reset on fall/truncation. Uses _reset_episode() (NOT restart()), so it does NOT
+        # touch()/re-arm the auto-stop timer — the walk is uninterrupted across episode boundaries. Guards:
+        #  - no_reset (free-fall): user asked to keep stepping the fallen body instead of resetting.
+        #  - actor "zero": never auto-reset a zeroed session — a forgotten walk switched to zero must lie
+        #    down and idle, not spring back up (a reset would re-arm _zero_settle and loop fall->reset forever).
+        if self.terminated and not self.no_reset and self.actor_name != "zero":
+            self._reset_episode()
 
     def close(self):
         with contextlib.suppress(Exception):
@@ -185,6 +198,11 @@ async def stepper(sim, ws):
             if (not sim.paused and not sim._auto_zeroed and sim.actor_name != "zero"
                     and (time.monotonic() - sim._walk_since) >= AUTO_IDLE_S):
                 sim._auto_zero()
+                try:
+                    # Tell the client the model auto-switched, so its selector visibly shows "zero".
+                    await ws.send(json.dumps({"type": "actor_changed", "actor": sim.actor_name}))
+                except websockets.exceptions.ConnectionClosed:
+                    break
 
             # Idle (~0 CPU / ~0 bandwidth): PAUSED, or on the zero policy once it has settled. Send exactly ONE
             # frozen/resting frame, then await sim._wake (no busy-spin) until an interaction. The connection is


### PR DESCRIPTION
Fixes the 3-minute auto-stop-to-zero safeguard, which never fired in practice, and makes the model selector reflect the auto-switch.

## Root cause
`Sim.step()` auto-resets the episode on fall/truncation by calling `self.restart()` — and `restart()` calls `self.touch()`, which re-arms the auto-stop timer (`_walk_since = now`).

A Walker2d episode **truncates at the 1000-step TimeLimit (~33 s at 30 sps)** and falls sooner, so on a continuously-running demo the **180 s auto-idle clock was reset every episode** and never reached `AUTO_IDLE_S`. The switch-to-zero therefore never fired. This bit the **default `no_reset=OFF`** mode (which auto-resets on fall); it happened to work in **free-fall `ON`** (no reset → no `touch()`), which is why it looked intermittent.

## Fix (`server.py`)
- Split the env reset: **`_reset_episode()`** (no `touch()`) vs **`restart()`** (the user Restart button = `_reset_episode()` + `touch()`). The **automatic** reset in `step()` now calls `_reset_episode()`, so it no longer re-arms the timer — a walk is *uninterrupted* across episode boundaries.
- Guard the automatic reset with **`actor != "zero"`**: once auto-stopped to zero, the body must lie down and idle, not spring back up. (Without this, a reset re-arms `_zero_settle` and loops fall→reset→fall forever, so the zero policy never idled in `no_reset=OFF` mode — a second latent bug.)
- Net: a genuinely uninterrupted walk auto-switches to zero **and idles** after `AUTO_IDLE_S` in **both** no-reset states; user interactions (model switch / pause / resume / restart / speed) still reset the timer via `touch()`.

## UI reflection (companion requirement)
When the server auto-switches to zero it now sends `{"type":"actor_changed","actor":"zero"}`. The client updates the model `<select>` to **zero** — a programmatic `.value` set, which does **not** fire `onchange`, so it's not treated as a user interaction (won't reset/re-trigger anything). The user visibly sees the model become "zero" at the moment of the switch.

## Verification (local, `AUTO_IDLE_S=3`, using the **random** actor that falls/auto-resets every ~1 s)
| scenario | switch fired | idled (0 fps) |
|---|---|---|
| **A** — no-reset **OFF** (the bug: frequent auto-resets) | @3.05 s | ✅ |
| **B** — no-reset **ON** (free-fall) | @3.04 s | ✅ |
| **C** — interaction (speed) @2 s | delayed to @5.0 s (= 2+3) | ✅ |

A/B prove the switch fires despite (A) constant episode resets and (B) free-fall; C proves `touch()` still resets the timer on interaction. server.py compiles; client JS brackets balance; `actor_changed` handler present. **VERDICT: PASS.**

*Left open for your review — not self-merged. No gh-pages publish / VM redeploy yet (those follow the merge, same flow as before).*
