### PR TITLE
Fix: laggy resume from zero/idle (client interp interval ballooned across the idle gap)

### DIFF
--- a/landing/walker2d-viz/client/src/main.js
+++ b/landing/walker2d-viz/client/src/main.js
@@ -202,12 +202,20 @@ let fromQ = null, toQ = null, interpStart = 0, interpDur = 1000 / 30
 let emaInterval = 1000 / 30, lastMsg = 0, prevStep = -1
 const curQ = new Array(9).fill(0)                    // reused each frame (no per-frame allocation)
 
-function pushState(qpos, step) {
+function pushState(qpos, step, sps) {
   const now = performance.now()
-  if (lastMsg) emaInterval += ((now - lastMsg) - emaInterval) * 0.2   // smoothed inter-arrival interval
+  const nominal = 1000 / Math.max(1, sps || 30)      // the stream's real inter-frame interval at this sps
+  const gap = lastMsg ? now - lastMsg : nominal
+  // A gap far larger than the stream cadence means the server was SILENT (paused, or auto-stopped to the
+  // zero idle) and has just resumed. Do NOT fold that idle gap into the smoothed interval: it would blow up
+  // interpDur and play the next move in extreme slow motion (a 3-min idle -> ~36 s lerp). Reset to the
+  // nominal cadence and snap the pose instead, so resume is immediate and smooth.
+  const resumed = gap > Math.max(1200, nominal * 4)
+  if (resumed) emaInterval = nominal
+  else if (lastMsg) emaInterval += (gap - emaInterval) * 0.2   // smoothed inter-arrival interval
   lastMsg = now
-  // On an episode reset the pose jumps discontinuously (root x snaps back) — snap instead of sliding.
-  const reset = prevStep >= 0 && (step <= prevStep || (toQ && Math.abs(qpos[0] - toQ[0]) > 0.4))
+  // On an episode reset OR a resume-from-idle the pose jumps discontinuously — snap instead of sliding.
+  const reset = resumed || (prevStep >= 0 && (step <= prevStep || (toQ && Math.abs(qpos[0] - toQ[0]) > 0.4)))
   prevStep = step
   fromQ = reset ? qpos.slice() : curQ.slice()        // start from where we're currently drawn -> no snapping
   toQ = qpos
@@ -285,7 +293,7 @@ function connect(url) {
       }
       if (m.active) sel.value = m.active
     } else if (m.type === 'state') {
-      pushState(m.qpos, m.step)                       // update interpolation target (no geometry rebuild)
+      pushState(m.qpos, m.step, m.sps)                // update interpolation target (no geometry rebuild)
       $('env').textContent = m.env
       $('step').textContent = m.step
       $('reward').textContent = (+m.reward).toFixed(2)


### PR DESCRIPTION
Fixes the "very laggy resume" after the auto-stop-to-zero (or a manual zero) idle. **Measured, not guessed.**

## Measurement (scripted ws client, full lifecycle walk → zero → idle → resume)
| phase | frames/s | bytes/s |
|---|---|---|
| walk | ~30 | 12.6 KB |
| zero-settle | ~30 | 12.3 KB |
| **idle** | **0** | ~0 |
| resume | ~30 | 12.8 KB |

- **Idle is genuinely silent** — 0 frames during the idle window, so nothing queues on the server.
- **No catch-up burst on resume** — max 7 frames per 0.2 s (= normal 30 fps); the stepper resumes in real-time from "now", it does not replay elapsed time.

➡️ The server is clean. Anatoli's hypothesis (server keeps sending frames that queue up and get chewed through on resume) is **ruled out by the data**.

## Root cause — client `pushState`
`emaInterval` is a smoothed inter-arrival interval and `interpDur = max(16, emaInterval)`. During idle the server sends nothing, so on the **first frame after resume** `now - lastMsg` equals the **entire idle duration**. `emaInterval` then jumps to ~`0.2 × idle_ms`, so `interpDur` balloons and the next pose is interpolated over that huge window — extreme slow motion. For a 3-minute idle that's **~36 000 ms (~36 s) of crawl**, unwinding only slowly via the 0.2 smoothing. That is the lag.

Simulated on the real arrival times: OLD `interpDur` at resume ≈ **820 ms** in a 4 s-idle test, scaling to ~36 000 ms for a 3-min idle.

## Fix (client only, `pushState`)
Pass the current `sps` in; compute the nominal cadence `1000/sps`. If the arrival gap is far larger than that cadence (server was silent → resume), **reset `emaInterval` to nominal** instead of folding the idle gap in, and **snap the pose** (treat as a reset) so there's no long slide. Resume is immediate and smooth. Normal streaming (including low sps) is unaffected — the reset only triggers on a gap `> max(1200 ms, 4× nominal)`.

## Verification (measured — 4 scenarios)
| scenario | idle frames | resume fps | burst/0.2s | OLD interpDur | NEW interpDur |
|---|---|---|---|---|---|
| auto-stop, free-fall OFF | 0 | 30.0 | 7 | 818 ms | **33 ms** |
| auto-stop, free-fall ON | 0 | 30.0 | 7 | 817 ms | **33 ms** |
| manual-zero, free-fall OFF | 0 | 30.0 | 7 | 823 ms | **33 ms** |
| manual-zero, free-fall ON | 0 | 30.0 | 7 | 823 ms | **33 ms** |

All PASS: idle silent, resume immediate at 30 fps, no backlog/burst, and the resume interpolation is a flat 33 ms instead of ballooning. Works after both the auto-stop path and a manual zero selection, in both free-fall modes.

*Client-only change. Left open for your review — not self-merged. No gh-pages publish / VM redeploy yet (those follow the merge; and the VM server is unaffected by this since it's purely client).*
