### PR TITLE
Fix four CUDA engine bugs behind the sort_chains hang

### DIFF
--- a/native/spiky/connections_manager/connections_manager.h
+++ b/native/spiky/connections_manager/connections_manager.h
@@ -94,7 +94,15 @@ static_assert((sizeof(DoubleNeuronIndexAndSynapseId) % 8) == 0, "check sizeof(Do
 #define BACKWARD_GROUPS_HASH_KEY(neuron_id, synapse_meta_index, single_group_size, delay) ((static_cast<uint64_t>(neuron_id) << 32) | (synapse_meta_index << 18) | (single_group_size << 8) | delay)
 #define NEURON_ID_FROM_BACKWARD_GROUPS_HASH_KEY(hash_key) static_cast<NeuronIndex_t>(hash_key >> 32)
 #define SYNAPSE_META_INDEX_FROM_BACKWARD_GROUPS_HASH_KEY(hash_key) ((hash_key >> 18) & 0xFFF)
-#define SINGLE_GROUP_SIZE_FROM_BACKWARD_GROUPS_HASH_KEY(hash_key) ((hash_key >> 8) & 0x7FF)
+// Bits 8..17 (10 bits, up to 1023). The mask used to be 0x7FF, i.e. 11 bits spanning bits
+// 8..18 -- but synapse_meta_index is packed at bit 18, so the two fields OVERLAPPED. Every
+// ODD meta index set bit 18 and this accessor read the group size as size + 1024 (e.g. 8 ->
+// 1032). The capacity pass then sized that (target, meta) region as ONE group of `counter`
+// while fill_backward_groups tiled it by the meta's real _backward_group_size, so as soon as
+// counter exceeded the real group size the fill ran past the region and stamped the next
+// meta's groups -- surfacing as "wrong delay" in fill_backward_groups. Invisible at
+// backward_group_size=32 only because our per-(target,meta) counters stay under 32.
+#define SINGLE_GROUP_SIZE_FROM_BACKWARD_GROUPS_HASH_KEY(hash_key) ((hash_key >> 8) & 0x3FF)
 typedef struct {
     uint64_t key;
     uint32_t counter;

--- a/native/spiky/connections_manager/connections_manager_kernels_logic.proto
+++ b/native/spiky/connections_manager/connections_manager_kernels_logic.proto
@@ -33,7 +33,22 @@ estimate_forward_groups_capacity_logic(
                 return;
             }
 
+            // BELT-AND-SUSPENDERS (not the primary fix): a malformed chain with a cycle would
+            // otherwise spin here forever, because the only exit is shift_to_next_group == 0.
+            // The real fix is the atomicCAS chain claim in sort_chains_by_synapse_meta_logic;
+            // this bound just turns any residual corruption into a diagnosable error instead
+            // of an unkillable 100%-GPU hang. A chain cannot legitimately visit more blocks
+            // than exist.
+            uint32_t chain_steps = 0;
             while(true) {
+                if(++chain_steps > n_input_groups) {
+                    #ifdef ATOMIC
+                    atomicAdd(error_counter, 1);
+                    #else
+                    *error_counter += 1;
+                    #endif
+                    break;
+                }
                 if(header.n_target_neurons > 0) {
                     BaseSynapseMeta synapse_meta = synapse_metas[header.synapse_meta_index];
                     uint32_t n_delays = synapse_meta.max_delay - synapse_meta.min_delay + 1;
@@ -122,6 +137,10 @@ create_forward_groups_logic(
                 #endif
                 return;
             }
+            // Base of the caller-supplied weights buffer, kept so that every chain hop can
+            // recompute the slot offset from header_ptr's ABSOLUTE block index rather than
+            // accumulating a signed delta (see the hops below).
+            EXTERNAL_REAL_DT* input_weights_base = input_weights;
             if(input_weights != nullptr) {
                 input_weights += single_input_group_size * i;
             }
@@ -154,7 +173,18 @@ create_forward_groups_logic(
             #endif
             bool is_rand_initialized = false;
 
+            // BELT-AND-SUSPENDERS, same rationale as the estimator above: bound the chain
+            // walk so a cyclic chain reports an error instead of hanging the GPU forever.
+            uint32_t chain_steps = 0;
             while(true) {
+                if(++chain_steps > n_input_groups) {
+                    #ifdef ATOMIC
+                    atomicAdd(error_counter, 1);
+                    #else
+                    *error_counter += 1;
+                    #endif
+                    break;
+                }
                 synapse_meta_index = header.synapse_meta_index;
                 synapse_meta = synapse_metas[synapse_meta_index];
                 n_targets = header.n_target_neurons;
@@ -199,7 +229,19 @@ create_forward_groups_logic(
                             __DETAILED_TRACE__("[create_forward_groups] Shifting to next group by %u\n", header.shift_to_next_group);
                             header_ptr = reinterpret_cast<ConnectionsBlockHeader *>(reinterpret_cast<NeuronIndex_t *>(header_ptr) + header.shift_to_next_group);
                             if(input_weights != nullptr) {
-                                input_weights += (header.shift_to_next_group / ConnectionsBlockIntSize(single_input_group_size)) * single_input_group_size;
+                                // Recompute from header_ptr's ABSOLUTE block index. The old
+                                // form accumulated (shift / ConnectionsBlockIntSize(gs)) * gs,
+                                // but ConnectionsBlockIntSize is size_t, so a NEGATIVE
+                                // shift_to_next_group (back-links set one, see
+                                // synapse_growth_kernels_logic -main_header.shift_to_next_group)
+                                // was promoted to unsigned 64-bit before the division and the
+                                // pointer jumped ~2^64 slots. It only ever worked because the
+                                // wrap cancels when the block size divides 2^64 -- true at
+                                // gs=2 (block 8) and false at gs=128 (block 260).
+                                input_weights = input_weights_base
+                                    + (static_cast<int64_t>(reinterpret_cast<NeuronIndex_t *>(header_ptr) - input)
+                                       / static_cast<int64_t>(ConnectionsBlockIntSize(single_input_group_size)))
+                                      * static_cast<int64_t>(single_input_group_size);
                             }
                             input_targets = reinterpret_cast<SynapseMetaNeuronIdPair *>(header_ptr + 1);
                             header = *header_ptr;
@@ -296,7 +338,11 @@ create_forward_groups_logic(
                 } else {
                     header_ptr = reinterpret_cast<ConnectionsBlockHeader *>(reinterpret_cast<NeuronIndex_t *>(header_ptr) + header.shift_to_next_group);
                     if(input_weights != nullptr) {
-                        input_weights += (header.shift_to_next_group / ConnectionsBlockIntSize(single_input_group_size)) * single_input_group_size;
+                        // Same sign-promotion bug as the hop above; recompute absolutely.
+                        input_weights = input_weights_base
+                            + (static_cast<int64_t>(reinterpret_cast<NeuronIndex_t *>(header_ptr) - input)
+                               / static_cast<int64_t>(ConnectionsBlockIntSize(single_input_group_size)))
+                              * static_cast<int64_t>(single_input_group_size);
                     }
                     input_targets = reinterpret_cast<SynapseMetaNeuronIdPair *>(header_ptr + 1);
                     header = *header_ptr;

--- a/native/spiky/setup.py
+++ b/native/spiky/setup.py
@@ -153,6 +153,7 @@ def _get_ext_modules():
                         "nvcc": _cpp_std_args("nvcc") + [
                             "-O3",
                             "-v",
+                            "-lineinfo",
                             "-allow-unsupported-compiler",
                             '-Xptxas="-v"',
                         ] + BUILD_INTEGERS_COMPILE_ARGS,

--- a/native/spiky/synapse_growth/synapse_growth.cu
+++ b/native/spiky/synapse_growth/synapse_growth.cu
@@ -380,25 +380,45 @@ public:
             throw py::value_error("some error happened inside merge_chains kernel");
         }
 
+        // NOTE: error_counter is deliberately kept alive past this point --
+        // sort_chains_by_synapse_meta now reports through it too (chain-walk step caps and the
+        // root-claim invariant). Only merge_table is released here.
         if (device == -1) {
             PyMem_Free(merge_table);
-            PyMem_Free(error_counter);
         } else {
             #ifndef NO_CUDA
             c10::cuda::CUDAGuard guard(device);
             cudaFree(merge_table);
-            cudaFreeHost(error_counter);
             #endif
         }
 
+        *error_counter = 0;
         PROF_START(SYNAPSE_GROWTH_SORT_CHAINS_BY_SYNAPSE_META_PROFILER_OP);
         numBlocks = dim3((n_connection_blocks + SYNAPSE_GROWTH_TPB - 1) / SYNAPSE_GROWTH_TPB, 1);
         GRID_CALL_NO_SHARED_MEM(
             numBlocks, sort_chains_by_synapse_meta, SYNAPSE_GROWTH_TPB,
             target_buffer, n_connection_blocks,
-            this->single_block_size
+            this->single_block_size, error_counter
         );
         PROF_END(SYNAPSE_GROWTH_SORT_CHAINS_BY_SYNAPSE_META_PROFILER_OP);
+
+        if(device != -1) {
+            #ifndef NO_CUDA
+            c10::cuda::CUDAGuard guard(device);
+            cudaDeviceSynchronize();
+            #endif
+        }
+        if(*error_counter > 0) {
+            throw py::value_error("some error happened inside sort_chains_by_synapse_meta kernel");
+        }
+        if (device == -1) {
+            PyMem_Free(error_counter);
+        } else {
+            #ifndef NO_CUDA
+            c10::cuda::CUDAGuard guard(device);
+            cudaFreeHost(error_counter);
+            #endif
+        }
 
         PROF_START(SYNAPSE_GROWTH_FINAL_SORT_PROFILER_OP);
         numBlocks = dim3((n_connection_blocks + SYNAPSE_GROWTH_TPB - 1) / SYNAPSE_GROWTH_TPB, 1);

--- a/native/spiky/synapse_growth/synapse_growth_kernels_logic.proto
+++ b/native/spiky/synapse_growth/synapse_growth_kernels_logic.proto
@@ -504,7 +504,8 @@ merge_chains_logic(
 sort_chains_by_synapse_meta_logic(
     uint32_t* input,
     uint32_t n_connection_blocks,
-    uint32_t single_block_size
+    uint32_t single_block_size,
+    uint32_t* error_counter
 ) {
     uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if(i < n_connection_blocks) {
@@ -515,8 +516,22 @@ sort_chains_by_synapse_meta_logic(
 
         if((main_header.source_neuron_id > 0) && (main_header.n_target_neurons == 0)) {
             #ifdef ATOMIC
-            if(atomicAdd(&(reinterpret_cast<ConnectionsBlockHeader*>(input + current_chain_root_int_offset)->n_target_neurons), 0) > 0) {
-                // if n_target_neurons > 0 then we have root that was changed by another thread during sorting and we shouldn't touch it
+            // EXCLUSIVE CLAIM on this chain. This used to be atomicAdd(&n_target_neurons, 0),
+            // which is a READ, not a claim: two threads could both observe 0 and both sort
+            // the SAME chain. That matters because sorting MOVES the root (a swap clears
+            // source_neuron_id on the old root and sets it on the new one), so a thread whose
+            // block only becomes a root part-way through another thread's sort would start a
+            // second, concurrent sort of that chain. Two sorters rewriting shift_to_next_group
+            // in place produce either a CYCLE -- the consumer's chain walks in
+            // connections_manager then spin forever at 100% GPU -- or a TRUNCATED chain, which
+            // trips create_forward_groups' "shouldn't happen" error counter and surfaces as
+            // "some error happened inside create_forward_groups kernel". Same defect, two
+            // faces, nondeterministic; measured ~1 build in 35 at K=32.
+            // atomicCAS makes the claim atomic: exactly one thread wins a chain, losers return.
+            // n_target_neurons is only a 0/1 root marker at this stage -- final_sort assigns
+            // the real per-sublist counts afterwards -- so it is safe to use as the claim word,
+            // and the swap below already migrates the marker to the new root.
+            if(atomicCAS(&(reinterpret_cast<ConnectionsBlockHeader*>(input + current_chain_root_int_offset)->n_target_neurons), 0u, 1u) != 0u) {
                 return;
             }
             #endif
@@ -529,23 +544,68 @@ sort_chains_by_synapse_meta_logic(
             int64_t secondary_int_offset;
             int64_t prev_secondary_int_offset;
 
+            // BELT-AND-SUSPENDERS (not the primary fix): both walks below are unbounded and
+            // exit only on shift_to_next_group == 0, so a cyclic chain spins the GPU forever
+            // and cannot be killed. The primary fix is the atomic claim-then-publish above;
+            // these caps merely turn any residual corruption into a diagnosable ValueError.
+            // A walk cannot legitimately visit more blocks than exist.
+            uint32_t outer_steps = 0;
             while(main_header.shift_to_next_group != 0) {
+                if(++outer_steps > n_connection_blocks) {
+                    #ifdef ATOMIC
+                    atomicAdd(error_counter, 1);
+                    #else
+                    *error_counter += 1;
+                    #endif
+                    break;
+                }
                 secondary_int_offset = main_int_offset + main_header.shift_to_next_group;
                 secondary_header = *reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset);
                 prev_secondary_int_offset = main_int_offset;
 
+                uint32_t inner_steps = 0;
                 while(true) {
+                    if(++inner_steps > n_connection_blocks) {
+                        #ifdef ATOMIC
+                        atomicAdd(error_counter, 1);
+                        #else
+                        *error_counter += 1;
+                        #endif
+                        break;
+                    }
                     if((secondary_header.synapse_meta_index < main_header.synapse_meta_index) || ((secondary_header.synapse_meta_index == main_header.synapse_meta_index) && (main_int_offset > secondary_int_offset))) {
                         // do swap if needed
                         if(main_int_offset == current_chain_root_int_offset) {
                             #ifdef ATOMIC
-                            atomicAdd(&(reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset)->n_target_neurons), 1);
+                            // ROOT MIGRATION, CLAIM-THEN-PUBLISH, ATOMICALLY AND IN THAT ORDER.
+                            // The previous code marked the new root with atomicAdd and then
+                            // published source_neuron_id with a PLAIN STORE, with nothing
+                            // ordering the two. Another thread could observe the publication
+                            // before the marker -- seeing source_neuron_id > 0 while
+                            // n_target_neurons was still 0 -- pass the outer ownership test,
+                            // win its own entry CAS, and start a SECOND concurrent sort of this
+                            // chain. Two sorters rewriting shift_to_next_group in place close a
+                            // cycle in the list, and this kernel's own walks then spin forever
+                            // (measured: 6 hangs in 40 builds at K=128, all inside this kernel).
+                            // Marker first, threadfence, then publish the root with atomicCAS so
+                            // claiming and publishing cannot be observed out of order.
+                            atomicExch(&(reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset)->n_target_neurons), 1u);
+                            __threadfence();
+                            if(atomicCAS(&(reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset)->source_neuron_id), 0u, static_cast<uint32_t>(source_neuron_id)) != 0u) {
+                                // Someone else already owns this block as a root. With exclusive
+                                // claims this is unreachable; report rather than corrupt.
+                                atomicAdd(error_counter, 1);
+                                return;
+                            }
+                            __threadfence();
+                            atomicExch(&(reinterpret_cast<ConnectionsBlockHeader*>(input + main_int_offset)->source_neuron_id), 0u);
+                            atomicExch(&(reinterpret_cast<ConnectionsBlockHeader*>(input + main_int_offset)->n_target_neurons), 0u);
                             #else
                             reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset)->n_target_neurons++;
-                            #endif
                             reinterpret_cast<ConnectionsBlockHeader*>(input + secondary_int_offset)->source_neuron_id = source_neuron_id;
                             reinterpret_cast<ConnectionsBlockHeader*>(input + main_int_offset)->source_neuron_id = 0;
                             reinterpret_cast<ConnectionsBlockHeader*>(input + main_int_offset)->n_target_neurons = 0;
+                            #endif
                             current_chain_root_int_offset = secondary_int_offset;
                         }
 


### PR DESCRIPTION
Four bugs in the CUDA engine, found while chasing an unkillable 100%-GPU hang in
`sort_chains_by_synapse_meta`. They are independent defects, one per commit, so the
branch can be reviewed (or partly reverted) commit by commit.

## The bugs

**1. `sort_chains_by_synapse_meta` — concurrent sort over the same chain** (445c2099)

Two distinct holes let two threads sort one chain at once. Chain entry was
`atomicAdd(&root->n_target_neurons, 0) > 0`, which *observes* rather than *claims* —
both threads could see 0 and both proceed. And root migration marked the new root with
an atomic but published `source_neuron_id` with a plain store, unordered, so a thread
could see the publication before the marker and win its own entry.

Sorting rewrites `shift_to_next_group` in place, so two sorters produce either a **cycle**
(the consumer's chain walks in `connections_manager` spin forever — the hang) or a
**truncated chain** (trips `create_forward_groups`' error counter — the sporadic
`ValueError`). Same defect, two faces, nondeterministic: roughly 1 build in 35 at K=32,
6 hangs in 40 builds at K=128.

Fix: `atomicCAS(&root->n_target_neurons, 0, 1)` as the claim; marker → `__threadfence()`
→ `atomicCAS` publish. The non-atomic CPU path is unchanged — the plain stores just moved
inside the `#else`.

**2. Backward-groups hash key overlapped two fields** (de9a35b8)

`BACKWARD_GROUPS_HASH_KEY` packs `synapse_meta_index` at bit 18 and `single_group_size`
at bit 8, but the group-size accessor masked with `0x7FF` — eleven bits, spanning bit 18.
Every **odd** meta index therefore read the group size as `size + 1024`.

The consequence was a silent buffer overrun, not just a wrong number: the capacity pass
sized a `(target, meta)` region as one group of `counter`, while `fill_backward_groups`
tiled the same region by the meta's real `_backward_group_size` — so once `counter`
exceeded the real group size the fill stamped the *next* meta's groups. It surfaced as
wrong delay readings, several steps from the cause. Invisible at
`backward_group_size=32` only because our per-`(target, meta)` counters stay under 32.
Mask is now `0x3FF`.

**3. Sign promotion when advancing the weights pointer** (d4d24061)

`create_forward_groups` did
`input_weights += (header.shift_to_next_group / ConnectionsBlockIntSize(gs)) * gs;`.
`ConnectionsBlockIntSize` returns `size_t`, so a **negative** `shift_to_next_group` —
back-links do set one — was promoted to unsigned 64-bit and the pointer jumped by ~2^64
slots.

It only appeared to work because the wrap cancels exactly when the block size divides
2^64: true at group size 2 (block 8), false at group size 128 (block 260). That is why
"everything except group size 2 is broken" looked like a group-size restriction rather
than an arithmetic bug. Both hop sites now recompute the slot offset from `header_ptr`'s
**absolute** block index in signed arithmetic against a captured base pointer, so no
signed delta accumulates.

**4. Build with `-lineinfo`** (289f60db)

Source-level attribution for `cuda-gdb` / `compute-sanitizer` / Nsight, which is what made
the hang tractable. Unlike `-G` it does not disable optimisation, so generated code is
unchanged. **Drop this commit if the extra build time is not worth it.**

## Also in here (belt-and-braces, not fixes)

Bounded chain walks in both files — a chain cannot legitimately visit more blocks than
exist — and an `error_counter` threaded through `sort_chains_by_synapse_meta`. These
convert any residual corruption into a diagnosable `ValueError` instead of a spinning GPU.
The caps are sized against the total block count, so they cannot false-positive on a
well-formed chain.

## Verification

| Check | Before | After |
|---|---|---|
| Steady-state ALife, K=128 | ~15% of builds hang | 300/300 rounds clean |
| Steady-state ALife, K=32 | ~1 build in 35 fails | 200/200 rounds clean |
| Repeat-build soak, K=128 | 6 hangs / 40 builds | 8/8 clean, 0 errors, 0 hangs |
| Sort-order invariant, 1/4/20 metas × group size 2 and 128 | fails at gs=128 | green on **both** CUDA and CPU |
| spnet suite | — | green |

## Reviewer notes

- Bugs 2 and 3 were each latent behind a configuration we happened not to use (even meta
  indices only; group size 2 only). Worth a look at whether other packed accessors in
  `connections_manager.h` have the same field-width drift.
- `n_target_neurons` doubles as the claim word during sort; `final_sort` assigns the real
  per-sublist counts afterwards, so the 0/1 usage is confined to this phase.
- The pre-existing `first_group_id != 0` guard is untouched: the `per-delay (homog metas)`
  configuration still fails, because it calls `add_connections` repeatedly for the same
  sources and so violates spec rule 5 (one list per source). That is a caller-side
  violation, not a regression from this branch — `--delays 1` passes, `--delays 2` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
