### PR TITLE
Fix _grow_explicit(weights=) putting ~60% of explicit weights on the wrong edges

### DIFF
--- a/src/spiky/spnet/tests/run_tests_with_different_seeds.py
+++ b/src/spiky/spnet/tests/run_tests_with_different_seeds.py
@@ -8,6 +8,7 @@ from test_izhikevitch_topology import test_izhikevitch_topology
 from test_izhikevitch_runtime import test_izhikevitch_runtime
 from test_spnet_math import test_simple_math
 from test_chunk_of_connections import test_chunk_of_connections
+from test_explicit_weight_alignment import test_explicit_weight_alignment
 
 
 def main():
@@ -21,7 +22,8 @@ def main():
             test_izhikevitch_topology,
             test_izhikevitch_runtime,
             test_simple_math,
-            test_chunk_of_connections
+            test_chunk_of_connections,
+            test_explicit_weight_alignment
         ]
     }
 

--- a/src/spiky/spnet/tests/test_explicit_weight_alignment.py
+++ b/src/spiky/spnet/tests/test_explicit_weight_alignment.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""REGRESSION: _grow_explicit(weights=) must put every weight on the edge it was given for,
+and must give the same answer every time.
+
+WHAT THIS CATCHES. `SynapseGrowthEngine._build_group_aligned_weights` used to recover each
+connection group's owning source by carrying the last non-zero source header FORWARD IN MEMORY
+ORDER, on the premise it stated in its own docstring: "the explicit build lays each source's
+groups out contiguously". It does not.
+
+  * The grow kernel gives each (synapse_meta, source) sublist its own thread and every thread
+    takes its next group from one global bump allocator -- `atomicAdd(n_allocated, ...)`,
+    native/spiky/synapse_growth/aux_/synapse_growth_kernels_logic.cu:1324 -- so group placement
+    follows GPU scheduling order.
+  * `finalize() -> merge_chains` then stitches a source's per-meta chains into one by DEMOTING
+    all but one root to source_id 0 and linking the tail with a SIGNED offset to an arbitrary
+    group, forwards or backwards (same file, 1400-1418).
+
+Measured on a real 84,626-edge build at group size 128: 38,002 groups, 19,001 occupied, 1,017
+roots left of ~19,000, ZERO of 17,984 chain links landing on the physically next group, about
+half pointing backward, median jump 5,082 groups. The forward-fill named the right source for
+5.4 % of groups; every mis-attributed group missed its lookup and silently took 0.0, so only
+47.8 % of the non-zero weights and 32 % of the total weight were delivered -- a different 32 %
+on every rebuild of the same input.
+
+THE TWO DEFECTS ARE INDEPENDENT, so this test checks them separately:
+  * CORRECTNESS is host-side and deterministic. It reproduces on the CPU build path, where the
+    buffer is byte-identical between runs and the forward-fill is still 91.7 % wrong, because
+    merge_chains rewrites the links whatever the allocator did.
+  * REPRODUCIBILITY is the device-side atomic ordering. Chain-following makes the weights
+    independent of layout, so they come out identical even though the layout does not.
+
+The topology must span MANY METAS PER SOURCE or merge_chains never stitches anything and the
+bug cannot appear -- that is why this builds a multi-meta net rather than reusing
+test_explicit_weights.py's single-meta one.
+
+Not pytest -- the spnet suite is standalone scripts:
+    python test_explicit_weight_alignment.py            # cpu and cuda
+"""
+import numpy as np
+import torch
+
+from spiky.spnet.spnet import SpikingNet, SynapseMeta, NeuronMeta
+from spiky.util.synapse_growth import SynapseGrowthEngine
+
+N_SRC, N_TGT, N_METAS, FANOUT = 80, 80, 20, 40
+GROUP_SIZE = 128                     # the production value; the bug needs chained groups
+
+
+def _triples_and_weights(seed):
+    """A multi-meta explicit edge list: every source spans most of the meta bank."""
+    rng = np.random.default_rng(seed)
+    seen = {}
+    for s in range(N_SRC):
+        for t in rng.choice(N_TGT, FANOUT, replace=False):
+            seen[(s, int(t))] = int(rng.integers(0, N_METAS))     # (src,tgt) unique by dict
+    edges = sorted(seen.items())
+    tri = np.array([[m, s, t] for (s, t), m in edges], dtype=np.int32)
+    # distinct, non-zero, both signs, so a dropped weight cannot pass as a correct 0.0
+    w = rng.uniform(0.5, 5.0, len(edges)) * rng.choice([-1.0, 1.0], len(edges))
+    return tri, w.astype(np.float32)
+
+
+def _build(device, summation_dtype, tri, w, seed):
+    metas = [SynapseMeta(learning_rate=0.0, min_delay=d + 1, max_delay=d + 1,
+                         min_weight=-10.0, max_weight=10.0, initial_weight=0.0,
+                         _forward_group_size=GROUP_SIZE, _backward_group_size=GROUP_SIZE)
+             for d in range(N_METAS)]
+    spnet = SpikingNet(synapse_metas=metas, neuron_metas=[NeuronMeta(neuron_type=0)],
+                       neuron_counts=[N_SRC + N_TGT], summation_dtype=summation_dtype)
+    spnet.to_device(device)
+    ids = spnet.get_neuron_ids_by_meta(0).cpu().numpy()
+
+    ge = SynapseGrowthEngine(device=device, synapse_group_size=GROUP_SIZE,
+                             max_groups_in_buffer=max(4096, 8 * (len(tri) + ids.size)))
+    ge.register_neuron_type(max_synapses=8 * (N_SRC + N_TGT), growth_command_list=[])
+    n = ids.size
+    ge.add_neurons(neuron_type_index=0, identifiers=torch.tensor(ids, dtype=torch.int32),
+                   coordinates=torch.stack([torch.arange(n).float(), torch.zeros(n),
+                                            torch.zeros(n)], dim=1))
+
+    # sources are the first N_SRC neurons, targets the last N_TGT
+    gtri = np.stack([tri[:, 0], ids[tri[:, 1]], ids[N_SRC + tri[:, 2]]], 1).astype(np.int32)
+    chunk = ge._grow_explicit(torch.tensor(gtri, dtype=torch.int32, device=device), seed,
+                              weights=torch.tensor(w, dtype=torch.float32, device=device))
+    spnet.add_connections(chunk, seed)
+    chunk.recycle()
+    spnet.compile(shuffle_synapses_random_seed=None)
+
+    n_syn = spnet.n_synapses()
+    bufs = [torch.zeros([n_syn], dtype=t, device=device) for t in
+            (torch.int32, torch.int32, torch.float32, torch.int32, torch.int32)]
+    spnet.export_synapses(spnet.get_all_neuron_ids(), bufs[0], bufs[1], bufs[2], bufs[3],
+                          bufs[4], forward_or_backward=True)
+    es, em, ew, _ed, et = (x.cpu().numpy() for x in bufs)
+    k = np.lexsort((em, et, es))
+    kk = np.lexsort((gtri[:, 0], gtri[:, 2], gtri[:, 1]))
+    return dict(got_src=es[k], got_meta=em[k], got_w=ew[k], got_tgt=et[k],
+                want_src=gtri[kk, 1], want_meta=gtri[kk, 0], want_tgt=gtri[kk, 2],
+                want_w=w[kk])
+
+
+def _check(r, label):
+    topo = (np.array_equal(r["got_src"], r["want_src"])
+            and np.array_equal(r["got_tgt"], r["want_tgt"])
+            and np.array_equal(r["got_meta"], r["want_meta"]))
+    ok = np.isclose(r["got_w"], r["want_w"], atol=1e-5)
+    delivered = np.abs(r["got_w"]).sum() / np.abs(r["want_w"]).sum()
+    print(f"  {label}: {len(ok):,} edges, topology_ok={topo}, "
+          f"weights correct {ok.sum():,} ({100 * ok.mean():.2f} %), "
+          f"|weight| delivered {100 * delivered:.2f} %, "
+          f"dropped to 0 {int(((r['got_w'] == 0) & (r['want_w'] != 0)).sum()):,}")
+    return topo, ok, delivered
+
+
+def test_explicit_weight_alignment(device='cpu', summation_dtype=torch.float32, seed=1):
+    if str(device).startswith('cuda') and not torch.cuda.is_available():
+        return None
+    if summation_dtype != torch.float32:
+        return None      # this compares exported weights for exact equality
+
+    tri, w = _triples_and_weights(seed)
+    print(f"  multi-meta explicit build: {len(tri):,} edges, {N_METAS} metas, "
+          f"group_size {GROUP_SIZE}, "
+          f"{len(np.unique(tri[tri[:, 1] == 0, 0]))} metas on source 0")
+
+    r1 = _build(device, summation_dtype, tri, w, seed)
+    topo, ok, delivered = _check(r1, "build 1")
+    r2 = _build(device, summation_dtype, tri, w, seed)
+    _check(r2, "build 2")
+    identical = bool(np.array_equal(r1["got_w"], r2["got_w"]))
+    print(f"  two builds, same seed: weight vectors byte-identical = {identical}")
+
+    good = True
+    if not topo:
+        print("  FAIL: exported topology does not match the requested triples")
+        good = False
+    if not ok.all():
+        print(f"  FAIL: {int((~ok).sum()):,} of {len(ok):,} weights landed on the wrong edge "
+              f"(only {100 * ok.mean():.2f} % correct)")
+        good = False
+    if abs(delivered - 1.0) > 1e-6:
+        print(f"  FAIL: only {100 * delivered:.2f} % of the requested |weight| was delivered")
+        good = False
+    if not identical:
+        d = r1["got_w"] != r2["got_w"]
+        print(f"  FAIL: two builds with seed {seed} differ on {int(d.sum()):,} edges")
+        good = False
+
+    # the (source, target) uniqueness guard must fire rather than silently last-one-wins
+    try:
+        dup = np.array([[0, 1, 2], [1, 1, 2]], dtype=np.int32)     # same (src,tgt), two metas
+        ge = SynapseGrowthEngine(device=device, synapse_group_size=GROUP_SIZE,
+                                 max_groups_in_buffer=4096)
+        ge.register_neuron_type(max_synapses=64, growth_command_list=[])
+        ge.add_neurons(neuron_type_index=0, identifiers=torch.tensor([1, 2], dtype=torch.int32),
+                       coordinates=torch.zeros([2, 3]))
+        ge._grow_explicit(torch.tensor(dup, dtype=torch.int32, device=device), seed,
+                          weights=torch.tensor([1.0, 2.0], dtype=torch.float32, device=device))
+        print("  FAIL: duplicate (source, target) under two metas was accepted silently")
+        good = False
+    except ValueError as e:
+        print(f"  duplicate (source, target) rejected: {str(e)[:70]}...")
+
+    print("  passed" if good else "  FAILED")
+    return good
+
+
+def main():
+    devices = ['cpu'] + (['cuda'] if torch.cuda.is_available() else [])
+    rc = 0
+    for device in devices:
+        for seed in (1, 42):
+            print(f"\ntest_explicit_weight_alignment on {device}, seed {seed}:")
+            if test_explicit_weight_alignment(device, torch.float32, seed) is False:
+                rc = 1
+    print("\n🎉 explicit weight alignment test passed!" if rc == 0 else "\ntest FAILED")
+    return rc
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/spiky/util/synapse_growth.py
+++ b/src/spiky/util/synapse_growth.py
@@ -330,16 +330,26 @@ class SynapseGrowthEngine(object):
         assert len(explicit_triples.shape) == 2
         assert explicit_triples.shape[1] == 3
 
-        # map (source_id, target_id) -> explicit weight, from the ORIGINAL triple order
-        # (sourced before the in-place sort below, so alignment is order-independent).
-        wmap = None
+        # Keep the ORIGINAL (source, target) order alongside the weights. The sort below
+        # rebinds explicit_triples but does NOT reorder `weights`, so the aligner has to be
+        # given the pre-sort tensor. Matching is by (source, target), so the order itself is
+        # irrelevant -- only the correspondence between the two tensors matters.
+        weight_triples = None
         if weights is not None:
             assert weights.shape[0] == explicit_triples.shape[0], "weights must have one entry per triple"
-            trip_cpu = explicit_triples.cpu()
-            w_cpu = weights.detach().cpu().flatten()
-            wmap = {}
-            for k in range(trip_cpu.shape[0]):
-                wmap[(int(trip_cpu[k, 1]), int(trip_cpu[k, 2]))] = float(w_cpu[k])
+            # (source, target) is the key the weights are matched on, so it has to be unique.
+            # It was previously a dict key, where a collision under two different synapse metas
+            # silently resolved last-one-wins and one of the two edges got the other's weight.
+            pairs = explicit_triples[:, 1:3]
+            n_unique = torch.unique(pairs, dim=0).shape[0]
+            if n_unique != pairs.shape[0]:
+                raise ValueError(
+                    f"explicit weights are matched by (source, target), which must be unique "
+                    f"across the chunk: got {pairs.shape[0]} triples but only {n_unique} "
+                    f"distinct (source, target) pairs. Two edges sharing a source and a target "
+                    f"under different synapse metas cannot be told apart here."
+                )
+            weight_triples = explicit_triples
 
         lowlevel_engine = self._setup_lowlevel_engine(device, random_seed)
 
@@ -395,34 +405,100 @@ class SynapseGrowthEngine(object):
         self._profiling_stats = lowlevel_engine.get_profiling_stats()
 
         weights_buffer = None
-        if wmap is not None:
-            weights_buffer = self._build_group_aligned_weights(connections_buffer, wmap)
+        if weight_triples is not None:
+            weights_buffer = self._build_group_aligned_weights(
+                connections_buffer, weight_triples, weights)
 
         return ChunkOfConnections(connections_buffer, self._synapse_group_size, weights=weights_buffer)
 
-    def _build_group_aligned_weights(self, connections_buffer, wmap):
+    def _build_group_aligned_weights(self, connections_buffer, triples, weights):
         """Build the per-edge weights buffer aligned to the connection groups: for a
         group at int-offset d, its weights occupy [ (d/(4+2*gs))*gs : +gs ], slot j
-        matching the j-th (meta, target) body pair. The source id lives in the root
-        group header (source>0); chained/ghost groups repeat it as 0, so we carry the
-        last positive source forward while scanning blocks in order (the explicit build
-        lays each source's groups out contiguously)."""
+        matching the j-th (meta, target) body pair.
+
+        THE SOURCE OF EACH BLOCK IS RECOVERED BY FOLLOWING THE CHAIN, not by scanning
+        memory. Only a chain's root header carries its source id; every other group in the
+        chain repeats it as 0 and is reached through the root's `shift_to_next_group`.
+
+        This function used to carry the last positive source FORWARD IN MEMORY ORDER, on the
+        premise that "the explicit build lays each source's groups out contiguously". That
+        premise is false, for two compounding reasons:
+
+          * the grow kernel gives each (synapse_meta, source) sublist its own thread and every
+            thread takes its next group from one global bump allocator (`atomicAdd` on
+            n_allocated, synapse_growth_kernels_logic.cu:1324), so group placement follows GPU
+            scheduling order, not source order;
+          * `finalize() -> merge_chains` then stitches a source's per-meta chains into a single
+            chain by DEMOTING all but one root to source_id 0 and linking the tail with a
+            SIGNED offset to an arbitrary group, forwards or backwards (same file, 1400-1418).
+
+        Measured on a 84,626-edge explicit build at group size 128: 38,002 groups, 19,001
+        occupied, 1,017 surviving roots out of ~19,000 entry points, and ZERO of 17,984 chain
+        links landing on the physically next group -- about half pointed backward, with a
+        median jump of 5,082 groups. The forward-fill therefore named the right source for
+        5.4 % of groups. Every mis-attributed group missed the weight lookup and silently took
+        0.0, so only 47.8 % of the non-zero weights and 32 % of the total weight were ever
+        delivered -- and because group placement is nondeterministic, a DIFFERENT 32 % survived
+        on each rebuild of the identical input.
+
+        Note that these are two independent defects. The mis-attribution is deterministic and
+        host-side: on the CPU build path, where the bump allocator is sequential and the buffer
+        comes out byte-identical between runs, the forward-fill is still 91.7 % wrong, because
+        merge_chains rewrites the links whatever the allocator did. Following the chain fixes
+        the correctness bug outright and makes the result reproducible even though the
+        underlying layout stays nondeterministic -- the weights no longer depend on it.
+
+        `triples` and `weights` correspond element-wise; (source, target) is unique across
+        them (enforced in _grow_explicit), so the lookup is unambiguous. Empty body slots and
+        any (source, target) not present in `triples` stay 0.0.
+        """
+        dev = connections_buffer.device
         gs = self._synapse_group_size
         block = 4 + 2 * gs
-        buf = connections_buffer.cpu().tolist()
-        n_blocks = len(buf) // block
-        wbuf = torch.zeros([n_blocks * gs], dtype=torch.float32)
-        cur_src = 0
-        for b in range(n_blocks):
-            d = b * block
-            src = buf[d]
-            if src != 0:
-                cur_src = src
-            for j in range(gs):
-                tgt = buf[d + 4 + 2 * j + 1]     # body pair j = (meta, target)
-                if tgt != 0:
-                    wbuf[b * gs + j] = wmap.get((cur_src, tgt), 0.0)
-        return wbuf.to(device=connections_buffer.device)
+        n_blocks = connections_buffer.numel() // block
+        b = connections_buffer.view(n_blocks, block)
+        idx = torch.arange(n_blocks, device=dev)
+
+        # Walk every chain from its root, labelling each group with its true owning source.
+        owner = torch.zeros(n_blocks, dtype=torch.long, device=dev)
+        roots = b[:, 0].long()
+        cur = idx[roots > 0]
+        val = roots[cur]
+        for _ in range(n_blocks + 1):
+            if cur.numel() == 0:
+                break
+            owner[cur] = val
+            shift = b[cur, 3].long()
+            alive = shift != 0
+            cur = ((cur * block + shift) // block)[alive]
+            val = val[alive]
+        else:
+            # each group belongs to exactly one chain, so no chain can be longer than the
+            # buffer -- if we are still walking, the links form a cycle
+            raise RuntimeError("cycle detected in connection group chains")
+
+        if triples.shape[0] == 0:
+            return torch.zeros(n_blocks * gs, dtype=torch.float32, device=dev)
+
+        srcs = triples[:, 1].to(device=dev, dtype=torch.long)
+        tgts = triples[:, 2].to(device=dev, dtype=torch.long)
+        stride = int(torch.stack([srcs.max(), tgts.max(), owner.max()]).max().item()) + 1
+        ekey = srcs * stride + tgts
+        order = torch.argsort(ekey)
+        ekey_sorted = ekey[order]
+        w_sorted = weights.detach().flatten().to(dtype=torch.float32, device=dev)[order]
+
+        # One pass per body slot rather than one big [n_blocks, gs] tensor: the buffer can hold
+        # millions of groups and gs is up to 128, so the flattened form would not fit.
+        wbuf = torch.zeros(n_blocks * gs, dtype=torch.float32, device=dev)
+        zero = torch.zeros(n_blocks, dtype=torch.float32, device=dev)
+        for j in range(gs):
+            tgt_j = b[:, 5 + 2 * j].long()          # body pair j is (meta, target)
+            qkey = owner * stride + tgt_j
+            pos = torch.searchsorted(ekey_sorted, qkey).clamp(max=ekey_sorted.numel() - 1)
+            hit = (tgt_j > 0) & (ekey_sorted[pos] == qkey)
+            wbuf[idx * gs + j] = torch.where(hit, w_sorted[pos], zero)
+        return wbuf
 
     def get_profiling_stats(self) -> str:
         return self._profiling_stats


### PR DESCRIPTION
## The bug

`SynapseGrowthEngine._build_group_aligned_weights` recovered each connection group's owning source by carrying the last non-zero source header **forward in memory order**, on the premise it stated in its own docstring — *"the explicit build lays each source's groups out contiguously"*. That premise is false, for two compounding reasons:

- The grow kernel gives each `(synapse_meta, source)` sublist its own thread, and every thread takes its next group from one global bump allocator — `atomicAdd(n_allocated, ...)`, [`synapse_growth_kernels_logic.cu:1324`](../blob/main/native/spiky/synapse_growth/aux_/synapse_growth_kernels_logic.cu#L1324). Group placement follows GPU scheduling order, not source order.
- `finalize() -> merge_chains` then stitches a source's per-meta chains into one by **demoting all but one root to `source_id 0`** and linking the tail with a **signed** offset to an arbitrary group, forwards or backwards (same file, 1400-1418).

Only a chain's root carries its source id. Once the roots are demoted and the links scattered, scanning memory in order attributes almost every group to the wrong source, and each mis-attributed group misses its `(source, target)` lookup and silently takes `0.0`.

Measured on a real 84,626-edge explicit build at group size 128:

| | |
|---|---:|
| groups / occupied | 38,002 / 19,001 |
| surviving roots (of ~19,000 entry points) | **1,017** |
| chain links landing on the physically next group | **0 of 17,984** |
| links pointing **backward** | 8,963 |
| median jump | 5,082 groups |
| groups the forward-fill attributed correctly | **5.4 %** |
| non-zero weights delivered | **47.8 %** |
| total weight delivered | **32 %** |

…and because placement is nondeterministic, a **different** 32 % survived on every rebuild of identical input.

## Two independent defects

This matters for the fix, so it is worth stating plainly:

- **The mis-attribution is host-side and deterministic.** It reproduces on the CPU build path, where the bump allocator is sequential and the buffer comes out byte-identical between runs — and the forward-fill is *still* 91.7 % wrong, because `merge_chains` rewrites the links whatever the allocator did.
- **The irreproducibility is the device-side atomic ordering.**

**Following the chain fixes the first outright and neutralises the second**: the weights stop depending on layout, so they come out identical even though the layout does not. No kernel change is needed, and the atomic ordering becomes cosmetic — it permutes where groups sit, not what the network is.

## The fix

The rewritten aligner walks every chain from its root via `shift_to_next_group`, labels each group with its true owner, and looks weights up with a sorted-key `searchsorted` instead of a Python dict. It also raises on a cycle rather than looping.

That incidentally removes two O(n) Python loops from the build path — the per-triple dict construction and the per-group buffer scan (which did `connections_buffer.cpu().tolist()` and then iterated every group × every slot).

**Also adds the `(source, target)` uniqueness guard.** Weights are matched on that pair alone, so two edges sharing a source and a target under different synapse metas cannot be told apart. As a dict key that silently resolved last-one-wins and one edge took the other's weight. It now raises `ValueError` reporting both counts.

## Test

New `src/spiky/spnet/tests/test_explicit_weight_alignment.py`, registered in `run_tests_with_different_seeds.py`.

It builds a **multi-meta** net — 20 metas, every source spanning most of the bank — at group size 128, and asserts every weight lands on its own edge, 100 % of `|weight|` is delivered, two builds with the same seed are byte-identical, and the duplicate-pair guard fires. The multi-meta part is the point: **single-meta topologies never trigger `merge_chains`**, which is exactly why the existing `test_explicit_weights.py` passed throughout.

Before / after, 3,200 edges, same test:

| | weights correct | \|weight\| delivered | builds identical |
|---|---:|---:|---|
| cpu, before | 6.81 % | 59.42 % | yes |
| cpu, after | **100.00 %** | **100.00 %** | yes |
| cuda, before | 6.25 % | 38.54 % | **NO** — 1,411 edges differ |
| cuda, after | **100.00 %** | **100.00 %** | yes |

The cpu row is the clean demonstration that the two defects are separate: perfectly reproducible, and still almost entirely wrong.

## Verification

- New test passes on **CPU and CUDA**, seeds 1 and 42, and fails on the pre-fix aligner with the numbers above.
- Production scale: **85,000 edges** / 20 metas / group size 128 on GPU, and 9,000 on CPU — 100 % correct, 100 % delivered, byte-identical across builds.
- Full spnet suite green, **64/64**, plus `test_explicit_weights.py` and `test_grow_explicit_buffer.py` run directly.

## Impact

Every caller passing `weights=` to `_grow_explicit` has been getting a network holding roughly a third of the weights it asked for, redrawn at random on each build. `harness.py` in the neurodarwinism experiments had independently discovered this and shipped a chain-following workaround; `build_pool` in the same tree had not, which is how it surfaced. Once this merges, both workarounds can be removed in a follow-up.

Same family as #92 — that fixed a concurrent-sort race in the same file; this is the weight-placement half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
