### PR TITLE
Fix flaky test_hybrid_smooth_collapses_to_hard_for_confident_inputs (unseeded global torch RNG)

### DIFF
--- a/src/spiky/lutorch/tests/test_fast_multi_head_lut.py
+++ b/src/spiky/lutorch/tests/test_fast_multi_head_lut.py
@@ -285,6 +285,9 @@ def test_hybrid_smooth_collapses_to_hard_for_confident_inputs():
     blend weight u = sigmoid(-Delta/T_sel) approaches 0 (Delta -> 2,
     sigmoid(-2/T_sel) is small) and hybrid_smooth output -> hard output.
     """
+    # _make seeds the MODULE (anchors + weights); x below is drawn from the GLOBAL torch
+    # RNG, which nothing else here seeds, so without this the input differed every run.
+    torch.manual_seed(0)
     m = _make(forward_mode="hard", random_seed=7, select_temp=0.5,
               soft_score_temp=0.5, learnable_temps=False)
     # x with very large magnitudes -> all |d_j| >> T_soft -> Delta -> 2
@@ -300,9 +303,17 @@ def test_hybrid_smooth_collapses_to_hard_for_confident_inputs():
     # so y_hybrid - y_hard = u * (W[alt] - W[main]) summed over tph tables.
     # The max relative diff lives in a few-times-u envelope around the
     # typical magnitude of y_hard.
+    #
+    # The bound is 0.8, not 0.2, because the two sides are different statistics: max_diff is a
+    # MAX over 6*4*8 = 192 values from a 6-sample batch (a small-sample extreme, heavy-tailed),
+    # while `typical` is a MEAN. Measured over 300 global seeds the ratio has median 0.099 but
+    # reaches 0.71, so 0.2 sat at the 91st percentile of its own spread -- it was the tail of a
+    # legitimate distribution being read as a failure, not a real regression. 0.8 clears all
+    # 300. The seed above already makes this deterministic; the wider bound is what keeps it
+    # from re-breaking under future PyTorch/CUDA numerical drift.
     max_diff = (y_hybrid - y_hard).abs().max().item()
     typical = y_hard.abs().mean().item() + 1e-8
-    assert max_diff < 0.2 * typical, (
+    assert max_diff < 0.8 * typical, (
         f"hybrid_smooth should ~= hard for large |d| inputs "
         f"(got max_diff {max_diff:.3e}, typical |y_hard| {typical:.3e})"
     )


### PR DESCRIPTION
## The bug

`test_hybrid_smooth_collapses_to_hard_for_confident_inputs` fails on roughly **1 run in 11**, on `main`, and has since the day it was written.

It seeds the **module** — `_make(random_seed=7)` fixes the anchors and weights — but draws its input from the **global torch RNG**, at line 294:

```python
x = torch.randn(6, 64, device=_device(), dtype=torch.float32) * 1000.0
```

PyTorch seeds its default generator from entropy per process, so `x` differs on every run. A different `x` selects different sign-pack rows as `main` and `alt`, which changes `W[alt] - W[main]` and therefore the asserted statistic. The file's only `torch.manual_seed(0)` is at **line 357**, inside `test_grad_x_matches_full_soft_finite_difference` — *after* this test at line 283 — so this test never benefits from it.

## Measured

Fixing the global seed makes the outcome **fully deterministic** (a given seed reproduces its ratio exactly, e.g. seed 3 → 0.085398 twice). Pass/fail is then a pure function of that seed. Scanning **300 global seeds**:

```
max_diff / typical:   median 0.099    p95 0.318    max 0.707
bound 0.2  ->  FAILS for 26/300 seeds  (8.7%)
```

Matching empirical rates on `main` @ `91801375`:
- **3 failures in 15** full-file runs
- **2 failures in 20** runs of the test in isolation

## Not a regression

The function is **byte-identical to its first version**. It was introduced in `bccd53c1` (2026-06-04, when the file was still `test_tiny_multi_head_lut.py`); `git log -L 282,308` over its line range reports only that commit, and the June-11 rename `af82d49e` did not touch these lines. Both ingredients — the unseeded `randn` and the `0.2` bound — have been there from the start, so this has been flaky for ~2 months.

## The fix, and why it is two parts

**1. `torch.manual_seed(0)` at the top of the test.** Removes the nondeterminism, and matches the idiom `test_grad_x_matches_full_soft_finite_difference` already uses. Seed 0 lands at ratio 0.0973.

**2. The bound goes `0.2` → `0.8`.** Determinism alone would freeze the test at one seed's value while leaving it just as brittle to future PyTorch/CUDA numerical drift: `0.2` sat at the **91st percentile of the statistic's own spread**, only 2.03× its median.

The reason the spread is so wide is that the two sides of the comparison are **different statistics**. `max_diff` is a MAX over 6×4×8 = 192 values drawn from a 6-sample batch — a small-sample extreme, heavy-tailed by construction — while `typical` is a MEAN. Across 300 seeds the **numerator moves 11×** (6.18e-05 → 6.81e-04) while the **denominator moves only 1.3×** (7.66e-04 → 1.03e-03). So the failures were the tail of a legitimate distribution being read as a defect, not a real numerical problem. `0.8` clears all 300 seeds.

The property under test is unchanged: `hybrid_smooth` must still collapse onto `hard` for high-confidence inputs — it is now just measured against a bound that reflects the statistic's actual spread.

## Verification

On this branch, with the import verified to resolve to this checkout:

| | result |
|---|---|
| full file × 20 | **20/20 clean** (33 passed each) |
| this test in isolation × 20 | **20/20 clean** |

Change is confined to the one test function — no reformatting, no other test touched (12 insertions, 1 deletion, 10 of which are explanatory comments).

## Note for a follow-up (not in this PR)

**11 of the 17 test functions** in this file draw from the global RNG, and the file seeds it exactly once. The other ten have more headroom today, but they carry the same exposure. An autouse `conftest.py` fixture seeding `torch.manual_seed` per test would close all of them at once — deliberately left out of this PR to keep it minimal and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
