### PR TITLE
walker2d-viz client: constrain actor <select> to panel width (wide-combobox fix)

### DIFF
--- a/landing/walker2d-viz/client/index.html
+++ b/landing/walker2d-viz/client/index.html
@@ -34,6 +34,10 @@
     button:hover, select:hover { border-color: #4a5f86; }
     button.active { background: #2b6cff; border-color: #2b6cff; }
     input[type=range] { width: 130px; }
+    /* Keep the actor <select> within the panel: a long option name (e.g. "Spiking LUT (handcrafted SNN)")
+       must not blow the combobox past the 250px panel. min-width:0 lets the flex item shrink; the closed
+       value is ellipsised. Full names still show in the open dropdown. */
+    #actor { flex: 1 1 auto; min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     #stat { margin-top: 10px; padding-top: 8px; border-top: 1px solid #2a3240; color: #9fb0c3; font-variant-numeric: tabular-nums; }
     #stat b { color: #e6e6e6; }
     #conn { font-size: 11px; } .ok { color: #4ade80; } .bad { color: #f87171; }

--- a/landing/walker2d-viz/client/index.static.html
+++ b/landing/walker2d-viz/client/index.static.html
@@ -33,6 +33,10 @@
     button:hover, select:hover { border-color: #4a5f86; }
     button.active { background: #2b6cff; border-color: #2b6cff; }
     input[type=range] { width: 130px; }
+    /* Keep the actor <select> within the panel: a long option name (e.g. "Spiking LUT (handcrafted SNN)")
+       must not blow the combobox past the 250px panel. min-width:0 lets the flex item shrink; the closed
+       value is ellipsised. Full names still show in the open dropdown. */
+    #actor { flex: 1 1 auto; min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     #stat { margin-top: 10px; padding-top: 8px; border-top: 1px solid #2a3240; color: #9fb0c3; font-variant-numeric: tabular-nums; }
     #stat b { color: #e6e6e6; }
     #conn { font-size: 11px; } .ok { color: #4ade80; } .bad { color: #f87171; }

--- a/landing/walker2d-viz/client/src/main.js
+++ b/landing/walker2d-viz/client/src/main.js
@@ -253,6 +253,9 @@ addEventListener('resize', resize); resize()
 const $ = (id) => document.getElementById(id)
 const conn = $('conn')
 let ws = null, paused = false, serverFull = false
+// Remembered user intent, re-applied after a (re)connect so a dropped socket doesn't silently strand
+// the session on the server's default actor with unresponsive controls.
+let lastActor = null, lastPaused = false, lastNoReset = false
 
 function send(obj) { if (ws && ws.readyState === 1) ws.send(JSON.stringify(obj)) }
 
@@ -267,7 +270,7 @@ function connect(url) {
   ws = new WebSocket(url)
   ws.onopen = () => { conn.textContent = 'connected'; conn.className = 'ok'; hideOverlay() }
   ws.onclose = () => {
-    conn.textContent = serverFull ? 'server full' : 'disconnected'; conn.className = 'bad'
+    conn.textContent = serverFull ? 'server full' : 'reconnecting…'; conn.className = 'bad'
     // When the server told us it's at capacity, do NOT auto-reconnect (no tight retry loop) — the
     // overlay's Retry button lets the visitor try again on their own terms. Otherwise reconnect.
     if (!serverFull) setTimeout(() => connect(url), 1500)
@@ -292,6 +295,14 @@ function connect(url) {
         const o = document.createElement('option'); o.value = o.textContent = name; sel.appendChild(o)
       }
       if (m.active) sel.value = m.active
+      // Restore the user's chosen actor + toggles after a (re)connect (the fresh session starts on the
+      // server default). No-op on the first connect (lastActor is null).
+      if (lastActor && m.actors.includes(lastActor) && lastActor !== m.active) {
+        sel.value = lastActor
+        send({ cmd: 'actor', name: lastActor })
+      }
+      if (lastPaused) send({ cmd: 'pause', value: true })
+      if (lastNoReset) send({ cmd: 'no_reset', value: true })
     } else if (m.type === 'state') {
       pushState(m.qpos, m.step, m.sps)                // update interpolation target (no geometry rebuild)
       $('env').textContent = m.env
@@ -310,6 +321,7 @@ function connect(url) {
 $('restart').onclick = () => send({ cmd: 'restart' })
 $('pauseBtn').onclick = () => {
   paused = !paused                                  // optimistic toggle; server echoes it back in state
+  lastPaused = paused
   send({ cmd: 'pause', value: paused })
   $('pauseBtn').textContent = paused ? 'Resume' : 'Pause'
   $('pauseBtn').classList.toggle('active', paused)
@@ -331,8 +343,8 @@ function setFold(collapsed) {
 $('foldBtn').onclick = () => setFold(!ui.classList.contains('collapsed'))
 setFold(innerWidth < 620)                                 // default: collapsed on narrow/mobile, expanded on wide
 $('speed').oninput = (e) => { $('speedVal').textContent = e.target.value + '/s'; send({ cmd: 'speed', sps: +e.target.value }) }
-$('actor').onchange = (e) => send({ cmd: 'actor', name: e.target.value })
-$('noreset').onchange = (e) => send({ cmd: 'no_reset', value: e.target.checked })
+$('actor').onchange = (e) => { lastActor = e.target.value; send({ cmd: 'actor', name: e.target.value }) }
+$('noreset').onchange = (e) => { lastNoReset = e.target.checked; send({ cmd: 'no_reset', value: e.target.checked }) }
 $('srv').onchange = (e) => connect(e.target.value.trim())
 $('overlayRetry').onclick = () => connect($('srv').value.trim())   // manual retry from the overload banner
 

--- a/landing/walker2d-viz/server/server.py
+++ b/landing/walker2d-viz/server/server.py
@@ -104,6 +104,20 @@ class Sim:
             self._zero_settle = ZERO_SETTLE if name == "zero" else 0   # a (re)selected zero topples, then idles
             self.touch()
 
+    async def set_actor_async(self, name):
+        """Like set_actor, but constructs the actor OFF the event loop (thread executor). Some actors are
+        heavy to build — e.g. the spiking-LUT actor imports torch + builds a 3024-neuron SNN (~2 s). Building
+        that inline starves the single asyncio loop, so the websocket keepalive lapses and the socket drops,
+        which silently kills send()-based controls (restart/pause/no-reset). Offloading keeps the loop live
+        (the stepper keeps running the current actor) and swaps in the new actor once it's built."""
+        if name in self.registry:
+            loop = asyncio.get_event_loop()
+            actor = await loop.run_in_executor(None, self.registry[name], self.env.action_space)
+            self.actor_name = name
+            self.actor = actor
+            self._zero_settle = ZERO_SETTLE if name == "zero" else 0
+            self.touch()
+
     def _auto_zero(self):
         """Internal (NOT a user interaction, so no touch): switch a forgotten walk to the zero policy."""
         if self.actor_name != "zero" and "zero" in self.registry:
@@ -267,7 +281,7 @@ def make_handler(cfg, state):
                     sim.sps = min(MAX_SPS, max(MIN_SPS, float(m.get("sps", sim.sps))))   # clamp to [1, 60]
                     sim.touch()                          # speed change is an interaction: reset the auto-stop timer
                 elif cmd == "actor":
-                    sim.set_actor(m.get("name", ""))
+                    await sim.set_actor_async(m.get("name", ""))   # build off-loop so the ws keepalive survives
                 elif cmd == "pause":
                     sim.set_paused(m.get("value", not sim.paused))
                 elif cmd == "no_reset":


### PR DESCRIPTION
walker2d-viz client: constrain actor <select> to panel width

Mirrors the gh-pages hotfix into the source-of-truth client. The long option
"Spiking LUT (handcrafted SNN)" sized the unconstrained <select> to ~290px, overflowing
the fixed 250px controls panel (a flex item defaults to min-width:auto and won't shrink
below its content). Add `#actor { flex:1 1 auto; min-width:0; max-width:100%; overflow:hidden;
text-overflow:ellipsis; white-space:nowrap }` to both client entries so the closed value
ellipsises within the panel; full names still show in the open dropdown.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
