### PR TITLE
spnet: fix the NeuronMeta docstring's input-current sign

### DIFF
--- a/src/spiky/spnet/spnet.py
+++ b/src/spiky/spnet/spnet.py
@@ -11,7 +11,7 @@ from spiky.util.synapse_growth import ChunkOfConnections
 @dataclass(frozen=True, order=True)
 class NeuronMeta:
     # Izhikevitch model:
-    #   v' = cf_2 * v**2 + cf_1 * v + cf_0 - u - I
+    #   v' = cf_2 * v**2 + cf_1 * v + cf_0 - u + I
     #   u' = a(b * v - u)
     #   if v >= spike_threshold:
     #     v = c


### PR DESCRIPTION
One comment character. The `NeuronMeta` docstring gave the membrane update as

```
v' = cf_2 * v**2 + cf_1 * v + cf_0 - u - I
```

but the kernel **adds** the input current — `native/spiky/spnet/spnet_runtime_kernels_logic.proto:808`:

```c
fmaf(fmaf(nm.cf_2, V.x, nm.cf_1), V.x, nm.cf_0 - U.x + I.x)
```

so it is `- u + I`. The docstring now matches.

No behaviour change, nothing else in the file touched. Found while auditing the
walker2d-spiking post against the merged code: the post quotes this equation with `+ I`,
correctly, and cites `spnet.py:14` for it — so the citation contradicted the claim it was
supporting. The post is right; this comment was the thing that was wrong.

Opened as a PR because `main` is protected (`GH013: Changes must be made through a pull
request`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
