### PR TITLE
walker2d-lut: make the construction scripts location-independent

### DIFF
--- a/experiments/walker2d-lut/exp19_lut-lse-expmlpcrit-t32/run_exp19.sh
+++ b/experiments/walker2d-lut/exp19_lut-lse-expmlpcrit-t32/run_exp19.sh
@@ -20,11 +20,14 @@
 #
 # Every other flag is exp10's, verbatim: 8192 envs, 768 updates, bench7 recipe, 3 seeds.
 set -uo pipefail
-SRC=/home/astarostin/projects/spiky/experiments/walker2d-lut/src
-OUT=/home/astarostin/projects/spiky/experiments/walker2d-lut/exp19_lut-lse-expmlpcrit-t32
+# Resolve everything relative to this script, so a clone or a worktree anywhere runs
+# against its own tree. Override PY if your interpreter is not the repo venv.
+OUT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SRC=$(cd "$OUT/../src" && pwd)
+REPO=$(cd "$OUT/../../.." && pwd)
 cd "$SRC"
 export WARP_CACHE_PATH=/tmp/warp_cache TRITON_CACHE_DIR=/tmp/triton_cache
-PY=/home/astarostin/projects/spiky/.venv/bin/python
+PY=${PY:-$REPO/.venv/bin/python}
 
 mkdir -p "$OUT"
 

--- a/experiments/walker2d-lut/walker2d-spiking/WALKER2D_SPIKING_WRITEUP.md
+++ b/experiments/walker2d-lut/walker2d-spiking/WALKER2D_SPIKING_WRITEUP.md
@@ -316,8 +316,9 @@ claim is "indistinguishable", and the number should not be quoted as a gain.
 **Files.** The quantised path is a fork throughout: the delay-based `tiny_lut_full_pipeline.py`
 and the deployed `spiking_lut.py` were left untouched by this work.
 
-Paths below are repo-relative; the scripts themselves hardcode them under
-`/home/astarostin/projects/spiky/`, so a clone elsewhere needs the roots adjusted.
+Paths below are repo-relative, and so are the scripts': every one of them resolves its
+inputs and outputs from its own `__file__`, so a clone or a worktree anywhere runs against
+its own tree with no roots to adjust.
 
 All ten live in `experiments/walker2d-lut/walker2d-spiking/` unless noted.
 

--- a/experiments/walker2d-lut/walker2d-spiking/bake_and_verify_actor.py
+++ b/experiments/walker2d-lut/walker2d-spiking/bake_and_verify_actor.py
@@ -14,14 +14,19 @@ import types
 
 import numpy as np
 
-BASE = "/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking"
+# Everything resolves relative to this file, the way tiny_lut_quantised_pipeline.py does,
+# so a clone or a worktree anywhere runs against its own tree.
+BASE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.join(BASE, "..", "..", "..")
 ACT = f"{BASE}/deploy_quantised/spiking_lut_quantised_actor.npz"
 WOPT = f"{BASE}/deploy_quantised/stage3_weights_bigdata.npy"
 OOPT = f"{BASE}/deploy_quantised/stage3_offset_bigdata.npy"
-POL = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/"
-       "exp19_lut-lse-expmlpcrit-t32/deploy/quantised/"
-       "walker2d_fastlut_lse_exp19_quantised.npz")
+POL = os.path.join(BASE, "..", "exp19_lut-lse-expmlpcrit-t32", "deploy", "quantised",
+                   "walker2d_fastlut_lse_exp19_quantised.npz")
 DATA = f"{BASE}/analysis/software_teacher_io_dataset_100k.npz"
+# The served actor module, staged into /tmp below and loaded the way the server loads it.
+SERVED_ACTOR = os.path.join(REPO, "landing", "walker2d-viz", "server", "actors",
+                            "spiking_lut_quantised.py")
 
 
 def main():
@@ -68,8 +73,7 @@ def main():
     STAGE = "/tmp/_bake_check"
     shutil.rmtree(STAGE, ignore_errors=True)
     os.makedirs(STAGE + "/actors"); os.makedirs(STAGE + "/models")
-    shutil.copy("/home/astarostin/projects/spiky/landing/walker2d-viz/server/actors/"
-                "spiking_lut_quantised.py", STAGE + "/actors/")
+    shutil.copy(SERVED_ACTOR, STAGE + "/actors/")
     shutil.copy(ACT, STAGE + "/models/")
     open(STAGE + "/actors/__init__.py", "w").close()
     with open(STAGE + "/actors/base.py", "w") as f:

--- a/experiments/walker2d-lut/walker2d-spiking/collect_teacher_io.py
+++ b/experiments/walker2d-lut/walker2d-spiking/collect_teacher_io.py
@@ -13,12 +13,15 @@ import time
 import numpy as np
 import torch
 
-sys.path.insert(0, "/home/astarostin/projects/spiky/experiments/walker2d-lut/src")
+# Everything resolves relative to this file, the way tiny_lut_quantised_pipeline.py does,
+# so a clone or a worktree anywhere runs against its own tree. `warp_env` lives in the
+# training tree next door.
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "src"))
 from warp_env import WarpWalker2dVecEnv                     # noqa: E402
 
-NPZ = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/"
-       "exp19_lut-lse-expmlpcrit-t32/deploy/quantised/"
-       "walker2d_fastlut_lse_exp19_quantised.npz")
+NPZ = os.path.join(HERE, "..", "exp19_lut-lse-expmlpcrit-t32", "deploy", "quantised",
+                   "walker2d_fastlut_lse_exp19_quantised.npz")
 
 
 def main():

--- a/experiments/walker2d-lut/walker2d-spiking/eval_gtskew_large.py
+++ b/experiments/walker2d-lut/walker2d-spiking/eval_gtskew_large.py
@@ -17,15 +17,18 @@ import time
 import numpy as np
 import torch
 
-sys.path.insert(0, "/home/astarostin/projects/spiky/experiments/walker2d-lut/src")
+# Everything resolves relative to this file, the way tiny_lut_quantised_pipeline.py does,
+# so a clone or a worktree anywhere runs against its own tree. `warp_env` genuinely lives
+# in the training tree next door; the pipeline module is this script's own neighbour.
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "src"))
+sys.path.insert(0, HERE)
 from warp_env import WarpWalker2dVecEnv                     # noqa: E402
 import tiny_lut_quantised_pipeline as QP                    # noqa: E402
 
-NPZ = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/"
-       "exp19_lut-lse-expmlpcrit-t32/deploy/quantised/"
-       "walker2d_fastlut_lse_exp19_quantised.npz")
-ACT = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking/"
-       "deploy_quantised/spiking_lut_quantised_actor.npz")
+NPZ = os.path.join(HERE, "..", "exp19_lut-lse-expmlpcrit-t32", "deploy", "quantised",
+                   "walker2d_fastlut_lse_exp19_quantised.npz")
+ACT = os.path.join(HERE, "deploy_quantised", "spiking_lut_quantised_actor.npz")
 
 
 def main():

--- a/experiments/walker2d-lut/walker2d-spiking/stage3_cd_bigdata.py
+++ b/experiments/walker2d-lut/walker2d-spiking/stage3_cd_bigdata.py
@@ -19,21 +19,19 @@ import time
 import numpy as np
 import torch
 
-sys.path.insert(0, "/home/astarostin/projects/spiky/experiments/walker2d-lut/src")
+# Everything resolves relative to this file, the way tiny_lut_quantised_pipeline.py does,
+# so a clone or a worktree anywhere runs against its own tree.
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
 import tiny_lut_quantised_pipeline as QP                    # noqa: E402
 
-NPZ = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/"
-       "exp19_lut-lse-expmlpcrit-t32/deploy/quantised/"
-       "walker2d_fastlut_lse_exp19_quantised.npz")
-ACT = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking/"
-       "deploy_quantised/spiking_lut_quantised_actor.npz")
-DATA = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking/"
-        "analysis/software_teacher_io_dataset_100k.npz")
+NPZ = os.path.join(HERE, "..", "exp19_lut-lse-expmlpcrit-t32", "deploy", "quantised",
+                   "walker2d_fastlut_lse_exp19_quantised.npz")
+ACT = os.path.join(HERE, "deploy_quantised", "spiking_lut_quantised_actor.npz")
+DATA = os.path.join(HERE, "analysis", "software_teacher_io_dataset_100k.npz")
 # The fit's outputs; §4 of the write-up: these two are a PAIR and must never be used apart.
-WOUT = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking/"
-        "deploy_quantised/stage3_weights_bigdata.npy")
-OOUT = ("/home/astarostin/projects/spiky/experiments/walker2d-lut/walker2d-spiking/"
-        "deploy_quantised/stage3_offset_bigdata.npy")
+WOUT = os.path.join(HERE, "deploy_quantised", "stage3_weights_bigdata.npy")
+OOUT = os.path.join(HERE, "deploy_quantised", "stage3_offset_bigdata.npy")
 PHASE, BASE = 0.750, 13.0
 
 

--- a/experiments/walker2d-lut/walker2d-spiking/tiny_lut_quantised_export.py
+++ b/experiments/walker2d-lut/walker2d-spiking/tiny_lut_quantised_export.py
@@ -24,11 +24,14 @@ import tiny_lut_quantised_pipeline as P
 
 
 def main():
+    # Resolve the default relative to this file, the way tiny_lut_quantised_pipeline.py does,
+    # so a clone or a worktree anywhere finds the exp19 teacher without flags.
+    here = os.path.dirname(os.path.abspath(__file__))
     ap = argparse.ArgumentParser()
     ap.add_argument("--npz", default=P.__dict__.get("_DEFAULT_NPZ") or
-                    "/home/astarostin/projects/spiky/experiments/walker2d-lut/"
-                    "exp19_lut-lse-expmlpcrit-t32/deploy/quantised/"
-                    "walker2d_fastlut_lse_exp19_quantised.npz")
+                    os.path.join(here, "..", "exp19_lut-lse-expmlpcrit-t32", "deploy",
+                                 "quantised",
+                                 "walker2d_fastlut_lse_exp19_quantised.npz"))
     ap.add_argument("--calib", required=True,
                     help="the JSON written by tiny_lut_quantised_pipeline.py --out "
                          "(supplies the validated beta + decode affine)")


### PR DESCRIPTION
Part 3 of `REPRODUCE.md` only worked from one directory on one machine. Five construction
scripts hardcoded **fifteen** paths under `/home/astarostin/projects/spiky/`.

The failure mode was silent. `REPRODUCE.md` tells the reader to run

```bash
python collect_teacher_io.py --out analysis/software_teacher_io_dataset_100k.npz
```

— **relative**, resolved against the cwd — and then `stage3_cd_bigdata.py` read that file from
the **absolute** path. From any other checkout the fit reads a different file than the
collector wrote. And on this machine the absolute prefix is the *deployment* checkout, which
sits on `live/walker2d-viz` — so running the documented chain from a `main` checkout reached
into the live tree, where `bake_and_verify_actor.py` "rewrites the actor npz in place".

Every path now resolves from the script's own `__file__`, reusing the pattern
`tiny_lut_quantised_pipeline.py` already had.

| file | constants |
|---|---|
| `stage3_cd_bigdata.py` | `NPZ`, `ACT`, `DATA`, `WOUT`, `OOUT` + the `sys.path` entry |
| `eval_gtskew_large.py` | `NPZ`, `ACT` + the `sys.path` entry |
| `collect_teacher_io.py` | `NPZ` + the `sys.path` entry |
| `bake_and_verify_actor.py` | `BASE`, `ACT`, `WOPT`, `OOPT`, `POL`, `DATA`, and the served actor it stages into `/tmp` (now a named `SERVED_ACTOR` instead of a literal inside the `shutil.copy`) |
| `tiny_lut_quantised_export.py` | the `--npz` argparse default |

The `sys.path.insert` calls pointed at `experiments/walker2d-lut/src`, where the construction
tree lived before `0226c173` moved it. Two of the three still need that directory — `warp_env`
genuinely lives there — so those join it relative to `HERE`; the third wanted its own
neighbour and gets `HERE`.

Two more swept by the same grep: `run_exp19.sh` (`SRC`/`OUT`/`PY`, now from `BASH_SOURCE`,
with `PY` falling back to the repo venv and honouring an existing `$PY`), and
`WALKER2D_SPIKING_WRITEUP.md` §6, which said *"the scripts themselves hardcode them under
`/home/astarostin/projects/spiky/`, so a clone elsewhere needs the roots adjusted"* — true
when written, false as of this PR.

## Verified as a no-op at the canonical checkout

Each of the **fourteen** module-level constants was resolved after the change and compared
against the absolute literal it replaced: **all fourteen identical, character for character.**
The export script's argparse default resolves to the committed exp19 teacher (exists), and
`run_exp19.sh`'s `OUT`/`SRC`/`REPO` derive to the same three directories with `$SRC/ppo.py`
present.

```
grep -rn /home/astarostin experiments/walker2d-lut/   no matches
all six scripts import and parse args                 ok
lutorch                                               242 passed
tiny_lut_quantised_pipeline.py, bare invocation       log byte-identical to the pre-change run
```

Nothing was executed that writes into `/home/astarostin/projects/spiky`.

Opened as a PR because `main` is protected (`GH013: Changes must be made through a pull
request`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
