### PR TITLE
claude/methodology: fold in the branch-prefix convention from BRANCHES.md

### DIFF
--- a/claude/experiment-methodology.md
+++ b/claude/experiment-methodology.md
@@ -21,6 +21,7 @@ care it needs.
 |---|---|
 | `main` | Stable trunk, and the curated source of truth. Everything durable lands here eventually, and **only through a reviewed pull request**. |
 | `research/` | **The idea branches** — one per idea, per the section below. All experimental work, analysis and write-up for that idea happens here. |
+| `feature/<topic>-to-<goal>` | A curated slice cut from a research branch and based off `main` — minimal and coherent, carrying only what tells the end-to-end story — opened as a PR into `main`. Optional; see the two exits below. |
 | `live/` | A branch that a **running deployment** is served from. Treat as protected: **never force-push** — a live service depends on it. How a given `live/` branch is deployed is documented on that branch itself (for `live/walker2d-viz`, see `landing/walker2d-viz/DEPLOYMENT.md`), because deployment is host-specific and so out of scope here. |
 | `gh-pages` | The published static site. Deployed by GitHub Pages straight from the branch — a push *is* a release. |
 | `exp/` | Legacy experiment branches, predating the one-idea-one-issue-one-branch rule. Kept for reference; new work uses `research/`. |
@@ -69,6 +70,13 @@ An idea-branch, and the issue behind it, ends one of two ways, decided **by resu
   (b) a short findings note under `docs/findings/<idea>.md` (what won, why, key numbers),
   and (c) the *decisive* experiment(s)' data. Losing/scratch runs stay behind on the branch;
   they do not come into `main`. This keeps `main` a curated record, not a dumping ground.
+
+  When the research branch has grown too messy to merge as it stands, curate the PR instead
+  of merging the branch: cut a **`feature/<topic>-to-<goal>`** branch off `main`, carry across
+  only the material that tells the end-to-end story, and open the PR from there. This is a
+  step *within* this exit, not an alternative to the research branch — a small, clean idea
+  still PRs directly from `research/<slug>`. The walker2d work took the long form:
+  `research/walker2d-lut` → the curated `feature/walker2d-lut-to-spiking` → PR #100 → `main`.
 - **Failure → abandon the branch.** Leave it on the remote, unmerged, never deleted (it stays
   a searchable record). **Close the issue** with a short autopsy comment, and write a one-line
   autopsy to `docs/dead-ends.md` on `main`

--- a/claude/experiment-methodology.md
+++ b/claude/experiment-methodology.md
@@ -12,6 +12,28 @@ per-machine notes — they are how you *implement* the steps below, not part of 
 method. What is shared, and belongs here, is the **branch logic** and the **multi-machine
 coordination model**.
 
+## Branch prefixes
+
+A small, scannable convention, so you can tell at a glance what a branch is for and how much
+care it needs.
+
+| Prefix | Meaning |
+|---|---|
+| `main` | Stable trunk, and the curated source of truth. Everything durable lands here eventually, and **only through a reviewed pull request**. |
+| `research/` | **The idea branches** — one per idea, per the section below. All experimental work, analysis and write-up for that idea happens here. |
+| `live/` | A branch that a **running deployment** is served from. Treat as protected: **never force-push** — a live service depends on it. How a given `live/` branch is deployed is documented on that branch itself (for `live/walker2d-viz`, see `landing/walker2d-viz/DEPLOYMENT.md`), because deployment is host-specific and so out of scope here. |
+| `gh-pages` | The published static site. Deployed by GitHub Pages straight from the branch — a push *is* a release. |
+| `exp/` | Legacy experiment branches, predating the one-idea-one-issue-one-branch rule. Kept for reference; new work uses `research/`. |
+| `archive/` | Retired branches kept for reference. More often the retirement is recorded as a **tag** — `archive/<name>` — rather than a branch, which preserves the history without leaving a branch that looks active. |
+
+Two clarifications, because these are easy to get wrong:
+
+- **`research/` is not a "writeup branch".** It is where the *work* happens — the scratch
+  experiments, the data, and the eventual narrative. `main` is the curated end state.
+- **`archive/` is not a way to delete something.** Nothing is hard-deleted (see the two exits
+  below). An `archive/<name>` tag is a durable marker on history that has been retired, so a
+  branch label can be tidied up without the commits becoming unreachable.
+
 ## The unit of work: one idea, one issue, one branch
 
 Research is structured as **one idea → one GitHub issue → one branch** — no giant


### PR DESCRIPTION
`BRANCHES.md` lives on **`live/walker2d-viz` only** — a convention document parked on a
deployment branch, where nobody starting from `main` will find it. (I found it by scanning
every ref.) Its branch-prefix table belongs with the rest of the branch logic, which is here.

**Step 1 of 2.** Removing `BRANCHES.md` from `live/walker2d-viz` is deliberately held back
until this merges, so the content is never absent from every merged branch.

## What was genuinely missing here

`live/`, `exp/` and `archive/` had no mention in this document at all.

## What was said differently — reconciled, not copied

| | `BRANCHES.md` said | resolution |
|---|---|---|
| `research/` | "Analysis / writeup branches (docs, figures, investigations)" | That is the older, looser reading. Here `research/<slug>` is **the idea branch** — where the experiments and the data live, not just the prose. The table says that, with a note underneath making the distinction explicit. |
| `archive/` | "Retired branches kept for reference. May also be tag-archived" | This conflicts with the two-exits rule ("**never deleted**") only if you read archiving as deleting. The table now says what actually happens: retirement is recorded as an `archive/<name>` **tag**, keeping commits reachable while the branch label stops looking active. **Twelve such tags exist today.** |
| `exp/` | "Active experiments" | Marked **legacy** — it predates one-idea-one-issue-one-branch. New work uses `research/`. |

`gh-pages` is added as well. Not in `BRANCHES.md`, but anyone scanning the branch list meets
it, and "a push *is* a release" is worth knowing **before** pushing.

## The deployment notes are deliberately NOT folded in

`BRANCHES.md`'s second half describes the walker2d-viz deployment. That content is **already
fully covered, in more detail**, by `landing/walker2d-viz/DEPLOYMENT.md` on
`live/walker2d-viz`:

| fact in `BRANCHES.md` | in `DEPLOYMENT.md` |
|---|---|
| `live/walker2d-viz` is the demo's source of truth | ✅ opening line |
| client → GitHub Pages from `gh-pages` | ✅ plus the exact per-file mapping |
| server → Docker websocket container on VM `89.169.96.79`, `wss://…sslip.io` | ✅ plus the Caddy TLS detail |
| syncing is MANUAL; the VM is not a git checkout | ✅ "`~/spiky` on the box has no `.git`" — with the full scp + `docker compose` + Caddy-restart procedure |
| don't force-push `live/walker2d-viz` | ✅ closing line |

So nothing is at risk of being lost. Copying it here would also break this document's own
stated scope — *"deliberately kept free of machine- and account-specific details (hostnames,
usernames, SSH keys, tokens)"* — so the `live/` row **points at** that file rather than
repeating the VM address into the shared methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
