### PR TITLE
landing: link to the walker2d-spiking write-up (mirror of the live gh-pages change)

### DIFF
--- a/landing/site/index.html
+++ b/landing/site/index.html
@@ -38,6 +38,21 @@
       <p class="small" style="margin-top:12px">Older construction demos are currently unlisted; their pages
         remain reachable by direct URL.</p>
     </div>
+
+    <div class="panel">
+      <h2>Write-up</h2>
+      <div class="cards">
+        <a class="card" href="walker2d-spiking/">
+          <h3>A lookup table that learned to walk — and then became a spiking network</h3>
+          <p>How the policy behind the demo was built. A <b>Walker2d</b> LUT policy turned into a real
+             <b>spiking network</b> by direct construction — <b>2,889 neurons, 25,953 synapses</b>, ~155
+             integer ticks per decision, no external clock and no gradient descent inside the network.
+             It walks <b>indistinguishably</b> from the software policy it came from (6312 vs 6253 return,
+             +1.31&sigma;), with 98.7% of actions identical tick for tick. Covers the whole construction:
+             order detection, lookup, and the amplitude-encoded first-spike readout.</p>
+        </a>
+      </div>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Mirrors gh-pages commit `eae19ce4`, **already live** at
https://anatoli-starostin.github.io/spiky/ — the write-up had been published at
`/walker2d-spiking/` with nothing on the landing page pointing at it.

**This PR exists to prevent drift, not to change the site.** Per `landing/README.md`,
`landing/site/index.html` is the source of truth for the gh-pages root, and the two files
were **byte-identical** before the publish. Landing the link only on `gh-pages` would have
split them; with this commit they are byte-identical again — verified by `diff`.

The entry is a new panel below the demo, reusing the `panel` / `cards` / `card` markup the
existing demo card already uses, so **no CSS change is needed**:

```html
<div class="panel">
  <h2>Write-up</h2>
  <div class="cards">
    <a class="card" href="walker2d-spiking/">
      <h3>A lookup table that learned to walk — and then became a spiking network</h3>
      <p>How the policy behind the demo was built. …</p>
    </a>
  </div>
</div>
```

The title is the post's own `<title>`/`<h1>` verbatim; the description is drawn from its
standfirst and hero figures (2,889 neurons / 25,953 synapses, ~155 ticks, 6312 vs 6253,
98.7%).

Placed **after** the demo panel rather than before it — the demo is what the page is
currently built around, and reordering that is an editorial call rather than a missing link.
Easy to swap if you'd rather the write-up led.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
