### PR TITLE
feat(agent-cage): opt-in default-deny network egress allowlist for sandbox

### DIFF
--- a/claude/skills/agent-cage/SKILL.md
+++ b/claude/skills/agent-cage/SKILL.md
@@ -40,6 +40,7 @@ gated in the first place.
 | `sbox` | `~/.local/bin/sbox` (on `PATH`) | the bubblewrap cage wrapper |
 | `cage_policy.py` | `~/.claude/hooks/cage_policy.py` | the classifier: `classify(tool, input) -> ungated \| green \| gated` |
 | `gh_issue.py` | `~/work/gh-issue/gh_issue.py` | an optional scoped-safe helper (a green-listed GitHub-issue tool) |
+| `net_allowlist.txt` | `~/.claude/skills/agent-cage/net_allowlist.txt` (read-only in cage) | opt-in egress allowlist: `NAME → host:port` for `sbox --net-allow` (both `sbox` and `cage_policy` read it) |
 
 `cage_policy.py` is imported by the slack-facade skill's `permission_gate.py` — deploy the
 two together; the gate can't run without the classifier.
@@ -79,6 +80,42 @@ script.py` (a single clean segment); for a short snippet use `sbox python3 -c '�
 body single-quoted. Any `<`/`>`/`|`/`&&`/`$()`/heredoc you actually need must live *inside*
 `sbox bash -c '…'`, never at the outer level.
 
+### Opt-in network egress (`--net-allow`, default-deny)
+
+By default `sbox` has **no network**. When a caged job legitimately needs to reach one
+endpoint (e.g. push metrics to a self-hosted wandb server) *without* a per-call approval and
+*without* opening general network, use the opt-in allowlist mode:
+
+```sh
+sbox --net-allow WANDB -- python train.py     # egress ONLY to WANDB's endpoint(s)
+```
+
+- **`NAME` is a symbolic key** in `net_allowlist.txt` (default
+  `~/.claude/skills/agent-cage/net_allowlist.txt`, override `AGENT_CAGE_NET_ALLOWLIST`),
+  mapping `NAME → host:port [host:port …]`. The shipped file has **commented placeholders
+  only** — real endpoints are per-deployment and stay out of the repo.
+- **Enforcement = pasta + nftables (Option A).** Instead of `--unshare-net`, the cage gets a
+  fresh net namespace with userspace egress via **pasta**, and a **default-DROP** nftables
+  `output` chain that permits only: loopback, established/related, DNS to the configured
+  resolver, and the **resolved IP:port(s)** of `NAME`. Everything else is dropped *below* the
+  process, so switching language / hiding intent can't bypass it — same property as the
+  no-network default.
+- **Fail-closed & no self-grant.** `cage_policy` greenlights `sbox --net-allow NAME -- …`
+  **only** when `NAME` is a committed key in the allowlist; an unknown `NAME`, a raw
+  `host:port`, or a missing file → the call **gates** (asks a human). Adding/approving an
+  endpoint is therefore a **human-reviewed edit** to a file the cage mounts read-only — never
+  a runtime agent decision. Bare `sbox` is unchanged (green, no network).
+- **Limitations (know these):**
+  - *IP:port, not URL* — HTTPS is filtered at host:port granularity; the ruleset can't
+    distinguish paths, and can't distinguish name-based vhosts that **share an IP**.
+  - *DNS-rotation caveat* — hostnames are resolved to IP(s) **at launch** and pinned; if the
+    endpoint's DNS rotates to a new IP during the run, later connections to the new IP are
+    dropped (re-launch to re-pin). DNS egress to the resolver is allowed so resolution works.
+  - *IPv4* — the generated ruleset is IPv4; IPv6 endpoints/resolvers are skipped.
+  - Requires `pasta` and `nft` present (both ship on recent Debian/Ubuntu; `sbox` errors
+    clearly if missing). The pasta+nft egress path is best verified live against a reachable
+    allowlisted endpoint on the target host.
+
 ### Standing `sbox` up on a new host
 
 1. `sudo apt-get install -y bubblewrap socat`
@@ -111,6 +148,9 @@ tool_input)` returns:
   `NotebookRead`, `TodoRead/Write`, `BashOutput`, …). Let Claude Code's own layer handle it.
 - **`green`** — safe, auto-allow silently. Green covers:
   - a single **clean `sbox <argv>`** with **no shell operators**;
+  - `sbox --net-allow NAME -- <argv>` **only** when `NAME` is a committed key in
+    `net_allowlist.txt` (fail-closed opt-in egress — see the `--net-allow` section); an
+    unknown/absent `NAME` or a raw `host:port` gates, so the agent can't self-grant network;
   - **scoped-safe git** (`status`/`diff`/`log`/`add`/`commit`/`branch`/`checkout`/`stash`,
     and `pull`/`fetch`/`push` to a *configured named remote*) — but **NOT** explicit URLs,
     `ext::`, `-c`, `config` writes, `--upload-pack`/`--exec` (exfil / RCE / prompt-injection

--- a/claude/skills/agent-cage/cage_policy.py
+++ b/claude/skills/agent-cage/cage_policy.py
@@ -62,6 +62,33 @@ def _in_green(path):
         return False
     return any(rp == b or rp.startswith(b + os.sep) for b in _WRITABLE)
 
+# ── opt-in network-egress allowlist (for `sbox --net-allow NAME`) ────────────
+# `sbox --net-allow NAME -- <argv>` gets default-deny egress to only NAME's
+# endpoints (enforced in sbox via pasta + nftables). The CLASSIFIER greenlights
+# that invocation WITHOUT a human prompt ONLY when NAME is a committed key in
+# this file — so an endpoint becomes frictionless only by a human-reviewed edit
+# to a file the cage mounts read-only, never by an agent self-granting network.
+# Fail-CLOSED: an unknown NAME, a raw host:port, or an unreadable/missing file
+# yields no names -> the invocation gates and asks a human. Same trust model as
+# the gh_issue.py helper (a vetted capability, added out-of-band). Override the
+# path with AGENT_CAGE_NET_ALLOWLIST (must stay read-only in the cage).
+_NET_ALLOWLIST = os.path.expanduser(
+    os.environ.get("AGENT_CAGE_NET_ALLOWLIST", "~/.claude/skills/agent-cage/net_allowlist.txt"))
+
+def _net_allow_names():
+    """Set of NAME keys from the committed net allowlist (uncommented first fields)."""
+    names = set()
+    try:
+        with open(_NET_ALLOWLIST) as f:
+            for line in f:
+                s = line.strip()
+                if not s or s.startswith("#"):
+                    continue
+                names.add(s.split()[0])
+    except Exception:
+        pass
+    return names
+
 # ── read-only safe-prefix allowlist ─────────────────────────────────────────
 # Every top-level segment of the shell line must match one of these to auto-allow.
 SAFE_BASH_PATTERNS = [
@@ -241,11 +268,28 @@ def _escape_ops(s):
 # ── the sbox cage tier ──────────────────────────────────────────────────────
 def is_safe_sbox(command, segs):
     """A single, simple `sbox <argv>`. (_escape_ops is checked separately by the
-    caller, so redirects / substitution / background are already excluded.)"""
+    caller, so redirects / substitution / background are already excluded.)
+
+    Bare `sbox <argv>` (no network) stays green, unchanged. The network-granting
+    form `sbox --net-allow NAME -- <argv>` is green ONLY when NAME is a committed
+    key in the net allowlist (fail-closed) — otherwise it gates, so an agent can
+    never self-grant egress. `--net-allow` is meaningful only as sbox's OWN first
+    argument (that's all the wrapper parses); appearing later, it is just an
+    argument to the caged program and carries no network -> a bare green run."""
     if segs is None or len(segs) != 1:
         return False
     seg = segs[0]
-    return len(seg) >= 2 and seg[0] == "sbox"
+    if len(seg) < 2 or seg[0] != "sbox":
+        return False
+    if seg[1] == "--net-allow":
+        # sanctioned shape: sbox --net-allow NAME -- <cmd...>  (indices 0..4+)
+        if len(seg) < 5 or seg[3] != "--":
+            return False
+        name = seg[2]
+        if not name or name.startswith("-"):
+            return False
+        return name in _net_allow_names()
+    return True
 
 
 # ── the scoped-safe git tier ────────────────────────────────────────────────

--- a/claude/skills/agent-cage/net_allowlist.txt
+++ b/claude/skills/agent-cage/net_allowlist.txt
@@ -1,0 +1,31 @@
+# agent-cage network egress allowlist  (opt-in, default-deny)
+#
+# This file names the endpoints that `sbox --net-allow <NAME> -- <argv>` is
+# permitted to reach. It is the SINGLE source of truth for two things:
+#   1. sbox         — builds a default-DENY nftables ruleset that allows egress
+#                     ONLY to the resolved IP:port(s) of <NAME>.
+#   2. cage_policy  — greenlights `sbox --net-allow <NAME> ...` WITHOUT a human
+#                     prompt ONLY when <NAME> is an uncommented key here.
+#
+# SECURITY MODEL (fail-closed): an endpoint becomes frictionless ONLY by being
+# added to THIS file, which lives where the cage mounts read-only and is edited
+# via a human-reviewed PR (same trust model as gh_issue.py / cage_policy.py).
+# A <NAME> not present here, or a raw host:port, is NOT greenlit — it gates and
+# asks a human. Default `sbox` (no --net-allow) has NO network, unchanged.
+#
+# FORMAT (one entry per line):
+#   NAME    host:port  [host:port ...]      # optional comment
+# - NAME is a symbolic key ([A-Za-z0-9_-]); it is what you pass to --net-allow.
+# - Each host is resolved to its IP(s) at launch and pinned into the ruleset
+#   (see the DNS-rotation caveat in SKILL.md). Port is required.
+# - Lines starting with '#' (and blank lines) are ignored.
+#
+# Keep DEPLOYMENT-SPECIFIC endpoints OUT of this committed file — put your real
+# hosts in a private, per-host copy (or point AGENT_CAGE_NET_ALLOWLIST at it).
+# The entries below are COMMENTED EXAMPLES only; uncomment/edit per deployment.
+#
+# --- examples (commented; no real endpoints are shipped) ---
+#
+# WANDB   <your-wandb-host>:<port>          # self-hosted W&B server (e.g. wandb-local)
+# PYPI    pypi.org:443  files.pythonhosted.org:443   # pip installs
+# HF      huggingface.co:443  cdn-lfs.huggingface.co:443

--- a/claude/skills/agent-cage/sbox
+++ b/claude/skills/agent-cage/sbox
@@ -1,34 +1,124 @@
 #!/bin/sh
-# sbox CMD [args...] — run CMD inside the ML green-zone cage:
-#   * whole system READ-ONLY, except ~/projects and /tmp (writable)
+# sbox [--net-allow NAME --] CMD [args...] — run CMD inside the ML green-zone cage:
+#   * whole system READ-ONLY, except ~/projects, /tmp, ~/.cache (writable)
 #   * GPU passed through (/dev/nvidia*), so CUDA works
-#   * NO network (empty net namespace)
+#   * NO network by default (empty net namespace)
 #   * ~/.ssh masked so caged code can't even read keys
 # Chain caged work with:  sbox bash -c 'cd repo && python train.py && ./eval.sh'
 # (the whole pipeline runs inside the cage; the outer command has no operators).
+#
+# OPT-IN NETWORK (default-deny egress allowlist):
+#   sbox --net-allow NAME -- CMD [args...]
+# gives the cage egress ONLY to the endpoint(s) mapped to NAME in the allowlist
+# file (default ~/.claude/skills/agent-cage/net_allowlist.txt; override with
+# AGENT_CAGE_NET_ALLOWLIST). Everything else is dropped. Enforcement = pasta
+# (userspace egress in a fresh net namespace) + a default-DENY nftables ruleset
+# permitting only the resolved IP:port(s) of NAME (+ DNS to the resolver).
+# Limitations (see SKILL.md): IP:port granularity (not URL); hostnames are
+# resolved and PINNED to IPs at launch (DNS-rotation caveat); IPv4.
 set -eu
-if [ "$#" -eq 0 ]; then echo "usage: sbox CMD [args...]" >&2; exit 2; fi
+
+ALLOWLIST="${AGENT_CAGE_NET_ALLOWLIST:-$HOME/.claude/skills/agent-cage/net_allowlist.txt}"
+
+usage() { echo "usage: sbox [--net-allow NAME --] CMD [args...]" >&2; exit 2; }
+[ "$#" -eq 0 ] && usage
 command -v bwrap >/dev/null 2>&1 || { echo "sbox: bubblewrap (bwrap) not installed" >&2; exit 127; }
 
-# Assemble GPU device binds only for nodes that exist on this host.
+# ── optional '--net-allow NAME --' prefix ────────────────────────────────────
+NET_NAME=""
+if [ "$1" = "--net-allow" ]; then
+  [ "$#" -ge 4 ] || { echo "sbox: --net-allow needs: --net-allow NAME -- CMD ..." >&2; exit 2; }
+  NET_NAME="$2"
+  [ "$3" = "--" ] || { echo "sbox: expected '--' after '--net-allow NAME'" >&2; exit 2; }
+  case "$NET_NAME" in ''|*[!A-Za-z0-9_-]*) echo "sbox: invalid --net-allow name '$NET_NAME'" >&2; exit 2 ;; esac
+  shift 3   # "$@" is now the command argv
+fi
+
+# ── GPU device binds (only nodes that exist) ─────────────────────────────────
 gpu=""
 for d in /dev/nvidia0 /dev/nvidiactl /dev/nvidia-uvm /dev/nvidia-uvm-tools /dev/nvidia-modeset /dev/dri; do
   [ -e "$d" ] && gpu="$gpu --dev-bind $d $d"
 done
 
-# shellcheck disable=SC2086
 mkdir -p "$HOME/.cache" 2>/dev/null || true
 
+# ── default mode: NO network (unchanged from the original wrapper) ────────────
+if [ -z "$NET_NAME" ]; then
+  # shellcheck disable=SC2086
+  exec bwrap \
+    --ro-bind / / \
+    --bind "$HOME/projects" "$HOME/projects" \
+    --bind /tmp /tmp \
+    --bind "$HOME/.cache" "$HOME/.cache" \
+    --proc /proc \
+    --dev /dev \
+    $gpu \
+    --tmpfs "$HOME/.ssh" \
+    --unshare-net \
+    --die-with-parent \
+    -- "$@"
+fi
+
+# ── --net-allow mode: default-deny egress to only NAME's endpoints ────────────
+command -v pasta >/dev/null 2>&1 || { echo "sbox: pasta not installed (needed for --net-allow)" >&2; exit 127; }
+command -v nft   >/dev/null 2>&1 || { echo "sbox: nft not installed (needed for --net-allow)" >&2; exit 127; }
+
+# Look up NAME's endpoints (uncommented line whose first field == NAME). A
+# comment line "# NAME ..." has first field "#", so it never matches a bare NAME.
+endpoints=$(awk -v n="$NET_NAME" '$1==n {for (i=2;i<=NF;i++) printf "%s ", $i; exit}' "$ALLOWLIST" 2>/dev/null || true)
+[ -n "$endpoints" ] || { echo "sbox: --net-allow name '$NET_NAME' not found in $ALLOWLIST" >&2; exit 3; }
+
+# Resolve each host:port to IPv4(s) and pin them into the ruleset.
+accept_rules=""
+for ep in $endpoints; do
+  host=${ep%:*}; port=${ep##*:}
+  case "$port" in ''|*[!0-9]*) echo "sbox: bad endpoint '$ep' (need host:port)" >&2; exit 3 ;; esac
+  ips=$(getent ahostsv4 "$host" 2>/dev/null | awk '{print $1}' | sort -u)
+  [ -n "$ips" ] || { echo "sbox: cannot resolve '$host'" >&2; exit 3; }
+  for ip in $ips; do
+    accept_rules="${accept_rules}    ip daddr ${ip} tcp dport ${port} accept
+"
+  done
+done
+
+# Allow DNS to the configured IPv4 resolver(s) so name resolution works in-cage.
+dns_rules=""
+for r in $(awk '/^[[:space:]]*nameserver/ {print $2}' /etc/resolv.conf 2>/dev/null | sort -u); do
+  case "$r" in *:*) continue ;; esac   # skip IPv6 resolvers (ruleset is IPv4)
+  dns_rules="${dns_rules}    ip daddr ${r} udp dport 53 accept
+    ip daddr ${r} tcp dport 53 accept
+"
+done
+
+RULES=$(mktemp /tmp/agent-cage-nft.XXXXXX)
+cat > "$RULES" <<NFT
+# default-DENY egress; only loopback, established, DNS-to-resolver, and the
+# pinned allowlisted IP:port(s) for '$NET_NAME' are permitted.
+table inet cage_egress {
+  chain output {
+    type filter hook output priority 0; policy drop;
+    meta oif lo accept
+    ct state established,related accept
+${dns_rules}${accept_rules}  }
+}
+NFT
+
+# pasta sets up userspace egress in a fresh net namespace and runs the target in
+# it; bwrap --share-net reuses that namespace (instead of --unshare-net); the
+# inner shell loads the nft filter (needs CAP_NET_ADMIN in the userns) and then
+# exec's the command. $1 = rules file, $2.. = command argv.
 # shellcheck disable=SC2086
-exec bwrap \
-  --ro-bind / / \
-  --bind "$HOME/projects" "$HOME/projects" \
-  --bind /tmp /tmp \
-  --bind "$HOME/.cache" "$HOME/.cache" \
-  --proc /proc \
-  --dev /dev \
-  $gpu \
-  --tmpfs "$HOME/.ssh" \
-  --unshare-net \
-  --die-with-parent \
-  -- "$@"
+exec pasta --config-net -q -- \
+  bwrap \
+    --ro-bind / / \
+    --bind "$HOME/projects" "$HOME/projects" \
+    --bind /tmp /tmp \
+    --bind "$HOME/.cache" "$HOME/.cache" \
+    --proc /proc \
+    --dev /dev \
+    $gpu \
+    --tmpfs "$HOME/.ssh" \
+    --share-net \
+    --cap-add CAP_NET_ADMIN \
+    --die-with-parent \
+    -- sh -c 'nft -f "$1" && shift && exec "$@"' sbox-net "$RULES" "$@"

--- a/claude/skills/agent-cage/test_cage_policy.py
+++ b/claude/skills/agent-cage/test_cage_policy.py
@@ -1,0 +1,103 @@
+"""Tests for cage_policy.classify — focused on the opt-in network allowlist and
+that the default-deny cage is unchanged.
+
+The net-allow greenlight is fail-closed: `sbox --net-allow NAME -- <argv>` is
+green ONLY when NAME is a committed key in the allowlist file. We point
+AGENT_CAGE_NET_ALLOWLIST at a temp fixture BEFORE importing cage_policy (it
+reads the path from the env at import time).
+"""
+import atexit
+import os
+import sys
+import tempfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+# committed-allowlist fixture: TESTNET and WANDB are the only greenlit names.
+_fx = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+_fx.write("# a comment line\n"
+          "TESTNET  example.com:443  cdn.example.com:443\n"
+          "WANDB    host.example:8080\n")
+_fx.flush(); _fx.close()
+os.environ["AGENT_CAGE_NET_ALLOWLIST"] = _fx.name
+atexit.register(lambda: os.unlink(_fx.name))
+
+import cage_policy  # noqa: E402
+
+
+def g(cmd):
+    return cage_policy.classify("Bash", {"command": cmd})
+
+
+# ── bare sbox (no network) stays green, unchanged ────────────────────────────
+def test_bare_sbox_still_green():
+    assert g("sbox python train.py") == "green"
+    assert g("sbox bash -c 'cd ~/projects/x && python t.py | tee /tmp/log'") == "green"
+
+
+# ── --net-allow with a COMMITTED name -> green ───────────────────────────────
+def test_net_allow_committed_green():
+    assert g("sbox --net-allow TESTNET -- python train.py") == "green"
+    assert g("sbox --net-allow WANDB -- wandb sync") == "green"
+
+
+# ── --net-allow with an UNKNOWN name -> gated (no self-grant) ────────────────
+def test_net_allow_unknown_gated():
+    assert g("sbox --net-allow NOPE -- python train.py") == "gated"
+    assert g("sbox --net-allow wandb -- x") == "gated"   # case-sensitive; 'wandb' != 'WANDB'
+
+
+# ── a raw host:port passed as the name -> gated ──────────────────────────────
+def test_net_allow_raw_endpoint_gated():
+    assert g("sbox --net-allow example.com:443 -- curl https://example.com") == "gated"
+    assert g("sbox --net-allow host.example:8080 -- x") == "gated"
+
+
+# ── malformed --net-allow shapes -> gated ────────────────────────────────────
+def test_net_allow_malformed_gated():
+    assert g("sbox --net-allow TESTNET python train.py") == "gated"  # missing '--'
+    assert g("sbox --net-allow TESTNET --") == "gated"               # no command after '--'
+    assert g("sbox --net-allow -- python x") == "gated"              # name slot is '--'
+    assert g("sbox --net-allow") == "gated"                          # nothing after flag
+
+
+# ── --net-allow appearing as the caged program's own arg -> bare green (no net) ─
+def test_net_allow_as_inner_arg_is_bare_green():
+    # sbox's own $1 is 'myprog', so no network is granted; it's a normal caged run.
+    assert g("sbox myprog --net-allow foo") == "green"
+
+
+# ── default-deny: raw network / installs / containers still gate ─────────────
+def test_raw_network_still_gated():
+    assert g("curl http://example.com") == "gated"
+    assert g("pip install wandb") == "gated"
+    assert g("podman run wandb/local") == "gated"
+    assert g("wandb login --host http://x KEY") == "gated"
+
+
+# ── operators/chaining still gate even with a valid --net-allow prefix ───────
+def test_operators_gate_even_with_net_allow():
+    assert g("sbox --net-allow TESTNET -- python x && ls") == "gated"          # multi-segment
+    assert g("sbox --net-allow TESTNET -- python x > /home/u/out") == "gated"  # redirect to real path
+    assert g("sbox --net-allow TESTNET -- python $(cat x)") == "gated"         # command substitution
+
+
+# ── existing green behavior preserved ────────────────────────────────────────
+def test_existing_green_preserved():
+    assert g("git -C ~/projects/spiky status") == "green"
+    assert g("ls ~/projects") == "green"
+    assert cage_policy.classify("Read", {"file_path": "/etc/hosts"}) == "ungated"
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    ok = 0
+    for fn in fns:
+        try:
+            fn(); ok += 1; print(f"PASS {fn.__name__}")
+        except Exception:
+            print(f"FAIL {fn.__name__}"); traceback.print_exc()
+    print(f"\n{ok}/{len(fns)} passed")
+    sys.exit(0 if ok == len(fns) else 1)


### PR DESCRIPTION
## Motivation

A caged job sometimes legitimately needs to reach **one** endpoint — e.g. push metrics to a self-hosted wandb server — but today that means either a per-call approval on every network op, or opening blanket network. This adds an **opt-in, default-deny egress allowlist** so an approved endpoint is frictionless while everything else stays blocked.

> ⚠️ **This edits the security-critical cage. Please review carefully. Do not merge without review.**

## Design (additive, backward-compatible — default `sbox` is unchanged: no network)

- **`sbox --net-allow NAME -- <argv>`** (new mode): instead of `--unshare-net`, the cage gets a fresh net namespace with userspace egress via **pasta**, plus a **default-DROP `nftables` output chain** that permits only: loopback, established/related, DNS to the resolver, and the **resolved IP:port(s)** of `NAME`. Enforcement is below the process. Bare `sbox` is byte-for-byte the old wrapper.
- **`net_allowlist.txt`** (new; config-as-data): a `NAME → host:port` map read by **both** `sbox` (to build the ruleset) and `cage_policy` (to greenlight). Ships **commented placeholders only** — real endpoints are per-deployment and kept out of the repo.
- **`cage_policy.py`**: greenlights `sbox --net-allow NAME -- …` **only** when `NAME` is a committed key in the allowlist (**fail-closed**). Unknown `NAME` / raw `host:port` / missing file → **gated** (asks a human).

## Classifier security rationale (fail-closed, no self-grant)

The whole safety of this rests on the classifier: today `is_safe_sbox` greenlights any line starting with `sbox`, so a naïve `--net-allow` would auto-run with **no** approval — an agent could self-grant network. Fixed so:

- an endpoint becomes frictionless **only** by being added to `net_allowlist.txt`, a file the cage mounts **read-only** and which is edited via **this PR review flow** — never a runtime agent decision (same trust model as the `gh_issue.py` helper);
- anything but the exact `sbox --net-allow <committed-NAME> -- <cmd>` shape gates;
- operators / chaining / redirects still gate even with a valid `--net-allow` prefix.

## Enforcement & limitations (documented in SKILL.md)

- **IP:port, not URL** granularity; can't split name-based vhosts that share an IP.
- **DNS-rotation caveat**: hostnames are resolved and **pinned to IP(s) at launch**; if the endpoint's DNS rotates mid-run, new IPs are dropped (re-launch to re-pin). DNS egress to the resolver is allowed.
- **IPv4** ruleset; requires `pasta` + `nft` (sbox errors clearly if absent).

## Tests / verification

- `test_cage_policy.py` (new): bare `sbox` still green; `--net-allow` committed → green; unknown/raw/malformed → gated; operators/chaining still gate; raw network / pip / podman / `wandb login` still gated; existing green preserved — **9/9 pass**. `sh -n sbox` and `cage_policy.py` compile clean.
- ⚠️ The **pasta+nft kernel-level egress filtering** is implemented to spec but **not live-exercised** in this environment (no reachable endpoint / no network in the cage). It should be verified live on a host with a reachable allowlisted endpoint before relying on it.

## Scope

Edits only `claude/skills/agent-cage/` source of truth (`sbox`, `cage_policy.py`, `SKILL.md`, new `net_allowlist.txt`, new `test_cage_policy.py`). Live installs (`~/.claude/*`, `~/.local/bin/*`) are untouched — install per host after review. No secrets or deployment-specific endpoints committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
