### PR TITLE
feat(agent-cage): opt-in tailnet-scoped network egress for sandbox

### DIFF
--- a/claude/skills/agent-cage/SKILL.md
+++ b/claude/skills/agent-cage/SKILL.md
@@ -79,6 +79,38 @@ script.py` (a single clean segment); for a short snippet use `sbox python3 -c '�
 body single-quoted. Any `<`/`>`/`|`/`&&`/`$()`/heredoc you actually need must live *inside*
 `sbox bash -c '…'`, never at the outer level.
 
+### Opt-in tailnet network (`--net tailnet`, default-deny)
+
+By default `sbox` has **no network**. When a caged job legitimately needs the fleet's
+trusted infra — a self-hosted wandb server, the NAS, another fleet host — use the one opt-in
+mode:
+
+```sh
+sbox --net tailnet -- python train.py     # egress to the tailnet only
+```
+
+- **Allows only the tailscale network**: egress to CIDR `100.64.0.0/10` (the tailscale CGNAT
+  range) plus DNS to the configured resolver; **everything else is dropped** (no public
+  internet — e.g. PyPI is not reachable). One coarse rule, no endpoint list to maintain, no
+  hostname resolution/pinning.
+- **Enforcement = pasta + nftables.** Instead of `--unshare-net`, the cage gets a fresh net
+  namespace with userspace egress via **pasta**, and a **default-DROP** nftables `output`
+  chain permitting only loopback, established/related, DNS-to-resolver, and
+  `ip daddr 100.64.0.0/10`. Enforcement is *below* the process. Bare `sbox` is unchanged.
+  (CIDR overridable via `AGENT_CAGE_TAILNET_CIDR`.)
+- **Why coarse is OK here:** the tailnet is trusted infrastructure; scoping to it is a much
+  smaller security surface than general network, while covering the real need. It is
+  deliberately **not** per-endpoint — any tailnet host is reachable in this mode, not just
+  wandb.
+- **Classifier rule (fail-closed):** `cage_policy` greenlights exactly
+  `sbox --net tailnet -- <cmd>`. Any other value after `--net` (unknown mode, raw
+  `host:port`, malformed) → **gated** (asks a human). Bare `sbox` stays green; operators /
+  chaining / redirects still gate even with the prefix.
+- **Limitations:** IPv4 only; reaches *any* tailnet host (not URL/host-scoped); requires
+  `pasta` + `nft` (sbox errors clearly if absent). The pasta+nft egress path is best
+  **verified live** against a reachable tailnet endpoint on the target host before relying on
+  it.
+
 ### Standing `sbox` up on a new host
 
 1. `sudo apt-get install -y bubblewrap socat`
@@ -111,6 +143,8 @@ tool_input)` returns:
   `NotebookRead`, `TodoRead/Write`, `BashOutput`, …). Let Claude Code's own layer handle it.
 - **`green`** — safe, auto-allow silently. Green covers:
   - a single **clean `sbox <argv>`** with **no shell operators**;
+  - `sbox --net tailnet -- <argv>` — the one opt-in network mode (tailnet-scoped egress; see
+    the `--net tailnet` section). Any other value after `--net` gates (fail-closed);
   - **scoped-safe git** (`status`/`diff`/`log`/`add`/`commit`/`branch`/`checkout`/`stash`,
     and `pull`/`fetch`/`push` to a *configured named remote*) — but **NOT** explicit URLs,
     `ext::`, `-c`, `config` writes, `--upload-pack`/`--exec` (exfil / RCE / prompt-injection

--- a/claude/skills/agent-cage/cage_policy.py
+++ b/claude/skills/agent-cage/cage_policy.py
@@ -241,11 +241,24 @@ def _escape_ops(s):
 # ── the sbox cage tier ──────────────────────────────────────────────────────
 def is_safe_sbox(command, segs):
     """A single, simple `sbox <argv>`. (_escape_ops is checked separately by the
-    caller, so redirects / substitution / background are already excluded.)"""
+    caller, so redirects / substitution / background are already excluded.)
+
+    Bare `sbox <argv>` (no network) is green, unchanged. The one opt-in network
+    form `sbox --net tailnet -- <argv>` is also green — a single fixed, well-
+    understood mode (egress to the tailscale CIDR + DNS only, enforced in sbox).
+    Anything else after `--net` (an unknown mode, a raw host:port, a malformed
+    shape) is NOT auto-green -> it gates (fail-closed). `--net` is meaningful only
+    as sbox's OWN first argument (that is all the wrapper parses); appearing later
+    it is just an argument to the caged program and carries no network."""
     if segs is None or len(segs) != 1:
         return False
     seg = segs[0]
-    return len(seg) >= 2 and seg[0] == "sbox"
+    if len(seg) < 2 or seg[0] != "sbox":
+        return False
+    if seg[1] == "--net":
+        # sanctioned shape: sbox --net tailnet -- <cmd...>  (indices 0..4+)
+        return len(seg) >= 5 and seg[2] == "tailnet" and seg[3] == "--"
+    return True
 
 
 # ── the scoped-safe git tier ────────────────────────────────────────────────

--- a/claude/skills/agent-cage/sbox
+++ b/claude/skills/agent-cage/sbox
@@ -1,34 +1,109 @@
 #!/bin/sh
-# sbox CMD [args...] — run CMD inside the ML green-zone cage:
-#   * whole system READ-ONLY, except ~/projects and /tmp (writable)
+# sbox [--net tailnet --] CMD [args...] — run CMD inside the ML green-zone cage:
+#   * whole system READ-ONLY, except ~/projects, /tmp, ~/.cache (writable)
 #   * GPU passed through (/dev/nvidia*), so CUDA works
-#   * NO network (empty net namespace)
+#   * NO network by default (empty net namespace)
 #   * ~/.ssh masked so caged code can't even read keys
 # Chain caged work with:  sbox bash -c 'cd repo && python train.py && ./eval.sh'
 # (the whole pipeline runs inside the cage; the outer command has no operators).
+#
+# OPT-IN TAILNET NETWORK:
+#   sbox --net tailnet -- CMD [args...]
+# gives the cage egress to the TAILSCALE network only (CIDR 100.64.0.0/10) plus
+# DNS to the configured resolver; everything else is dropped. The fleet's trusted
+# infra (self-hosted wandb, the NAS, other fleet hosts) all live on the tailnet,
+# so this one coarse rule covers the real need with no endpoint list to maintain
+# and no hostname resolution. It does NOT reach the public internet (e.g. PyPI).
+# Enforcement = pasta (userspace egress in a fresh net namespace) + a default-DROP
+# nftables ruleset. See SKILL.md for the security model and limitations.
 set -eu
-if [ "$#" -eq 0 ]; then echo "usage: sbox CMD [args...]" >&2; exit 2; fi
+
+# The tailscale CGNAT range (public, fixed). Overridable for a differently-scoped
+# tailnet, but the default is the standard 100.64.0.0/10.
+TAILNET_CIDR="${AGENT_CAGE_TAILNET_CIDR:-100.64.0.0/10}"
+
+usage() { echo "usage: sbox [--net tailnet --] CMD [args...]" >&2; exit 2; }
+[ "$#" -eq 0 ] && usage
 command -v bwrap >/dev/null 2>&1 || { echo "sbox: bubblewrap (bwrap) not installed" >&2; exit 127; }
 
-# Assemble GPU device binds only for nodes that exist on this host.
+# ── optional '--net tailnet --' prefix ───────────────────────────────────────
+NET_MODE=""
+if [ "$1" = "--net" ]; then
+  [ "$#" -ge 4 ] || { echo "sbox: --net needs: --net tailnet -- CMD ..." >&2; exit 2; }
+  [ "$2" = "tailnet" ] || { echo "sbox: unknown --net mode '$2' (only 'tailnet')" >&2; exit 2; }
+  [ "$3" = "--" ] || { echo "sbox: expected '--' after '--net tailnet'" >&2; exit 2; }
+  NET_MODE="tailnet"
+  shift 3   # "$@" is now the command argv
+fi
+
+# ── GPU device binds (only nodes that exist) ─────────────────────────────────
 gpu=""
 for d in /dev/nvidia0 /dev/nvidiactl /dev/nvidia-uvm /dev/nvidia-uvm-tools /dev/nvidia-modeset /dev/dri; do
   [ -e "$d" ] && gpu="$gpu --dev-bind $d $d"
 done
 
-# shellcheck disable=SC2086
 mkdir -p "$HOME/.cache" 2>/dev/null || true
 
+# ── default mode: NO network (unchanged from the original wrapper) ────────────
+if [ -z "$NET_MODE" ]; then
+  # shellcheck disable=SC2086
+  exec bwrap \
+    --ro-bind / / \
+    --bind "$HOME/projects" "$HOME/projects" \
+    --bind /tmp /tmp \
+    --bind "$HOME/.cache" "$HOME/.cache" \
+    --proc /proc \
+    --dev /dev \
+    $gpu \
+    --tmpfs "$HOME/.ssh" \
+    --unshare-net \
+    --die-with-parent \
+    -- "$@"
+fi
+
+# ── --net tailnet mode: egress to the tailscale CIDR + DNS only ──────────────
+command -v pasta >/dev/null 2>&1 || { echo "sbox: pasta not installed (needed for --net tailnet)" >&2; exit 127; }
+command -v nft   >/dev/null 2>&1 || { echo "sbox: nft not installed (needed for --net tailnet)" >&2; exit 127; }
+
+# Allow DNS to the configured IPv4 resolver(s) so name resolution works in-cage.
+dns_rules=""
+for r in $(awk '/^[[:space:]]*nameserver/ {print $2}' /etc/resolv.conf 2>/dev/null | sort -u); do
+  case "$r" in *:*) continue ;; esac   # skip IPv6 resolvers (ruleset is IPv4)
+  dns_rules="${dns_rules}    ip daddr ${r} udp dport 53 accept
+    ip daddr ${r} tcp dport 53 accept
+"
+done
+
+RULES=$(mktemp /tmp/agent-cage-nft.XXXXXX)
+cat > "$RULES" <<NFT
+# default-DENY egress; only loopback, established, DNS-to-resolver, and the
+# tailscale CIDR ($TAILNET_CIDR) are permitted.
+table inet cage_egress {
+  chain output {
+    type filter hook output priority 0; policy drop;
+    meta oif lo accept
+    ct state established,related accept
+${dns_rules}    ip daddr ${TAILNET_CIDR} accept
+  }
+}
+NFT
+
+# pasta sets up userspace egress in a fresh net namespace and runs the target in
+# it; bwrap --share-net reuses that namespace (instead of --unshare-net); the
+# inner shell loads the nft filter (needs CAP_NET_ADMIN in the userns) then
+# exec's the command. $1 = rules file, $2.. = command argv.
 # shellcheck disable=SC2086
-exec bwrap \
-  --ro-bind / / \
-  --bind "$HOME/projects" "$HOME/projects" \
-  --bind /tmp /tmp \
-  --bind "$HOME/.cache" "$HOME/.cache" \
-  --proc /proc \
-  --dev /dev \
-  $gpu \
-  --tmpfs "$HOME/.ssh" \
-  --unshare-net \
-  --die-with-parent \
-  -- "$@"
+exec pasta --config-net -q -- \
+  bwrap \
+    --ro-bind / / \
+    --bind "$HOME/projects" "$HOME/projects" \
+    --bind /tmp /tmp \
+    --bind "$HOME/.cache" "$HOME/.cache" \
+    --proc /proc \
+    --dev /dev \
+    $gpu \
+    --tmpfs "$HOME/.ssh" \
+    --share-net \
+    --cap-add CAP_NET_ADMIN \
+    --die-with-parent \
+    -- sh -c 'nft -f "$1" && shift && exec "$@"' sbox-net "$RULES" "$@"

--- a/claude/skills/agent-cage/test_cage_policy.py
+++ b/claude/skills/agent-cage/test_cage_policy.py
@@ -1,0 +1,89 @@
+"""Tests for cage_policy.classify — the opt-in tailnet network mode and that the
+default-deny cage is otherwise unchanged.
+
+`sbox --net tailnet -- <cmd>` is a single fixed, well-understood mode and is
+greenlit; anything else after `--net` (unknown mode, raw host:port, malformed)
+is fail-closed -> gated. Bare `sbox` (no network) stays green.
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+import cage_policy  # noqa: E402
+
+
+def g(cmd):
+    return cage_policy.classify("Bash", {"command": cmd})
+
+
+# ── bare sbox (no network) stays green, unchanged ────────────────────────────
+def test_bare_sbox_still_green():
+    assert g("sbox python train.py") == "green"
+    assert g("sbox bash -c 'cd ~/projects/x && python t.py | tee /tmp/log'") == "green"
+
+
+# ── the one opt-in mode -> green ─────────────────────────────────────────────
+def test_net_tailnet_green():
+    assert g("sbox --net tailnet -- python train.py") == "green"
+    assert g("sbox --net tailnet -- wandb sync") == "green"
+
+
+# ── any other --net value -> gated (fail-closed) ─────────────────────────────
+def test_net_unknown_value_gated():
+    assert g("sbox --net internet -- python x") == "gated"
+    assert g("sbox --net all -- curl x") == "gated"
+    assert g("sbox --net Tailnet -- x") == "gated"          # case-sensitive
+
+
+def test_net_raw_endpoint_gated():
+    assert g("sbox --net 100.64.0.1:8080 -- curl x") == "gated"
+    assert g("sbox --net host.example:8080 -- x") == "gated"
+
+
+# ── malformed --net shapes -> gated ──────────────────────────────────────────
+def test_net_malformed_gated():
+    assert g("sbox --net tailnet python train.py") == "gated"  # missing '--'
+    assert g("sbox --net tailnet --") == "gated"               # no command after '--'
+    assert g("sbox --net -- python x") == "gated"              # mode slot is '--'
+    assert g("sbox --net") == "gated"                          # nothing after flag
+
+
+# ── --net appearing as the caged program's own arg -> bare green (no net) ────
+def test_net_as_inner_arg_is_bare_green():
+    assert g("sbox myprog --net tailnet") == "green"
+
+
+# ── default-deny: raw network / installs / containers still gate ─────────────
+def test_raw_network_still_gated():
+    assert g("curl http://example.com") == "gated"
+    assert g("pip install wandb") == "gated"
+    assert g("wandb login --host http://x KEY") == "gated"
+
+
+# ── operators/chaining still gate even with a valid --net tailnet prefix ─────
+def test_operators_gate_even_with_net_tailnet():
+    assert g("sbox --net tailnet -- python x && ls") == "gated"          # multi-segment
+    assert g("sbox --net tailnet -- python x > /home/u/out") == "gated"  # redirect to real path
+    assert g("sbox --net tailnet -- python $(cat x)") == "gated"         # command substitution
+
+
+# ── existing green behavior preserved ────────────────────────────────────────
+def test_existing_green_preserved():
+    assert g("git -C ~/projects/spiky status") == "green"
+    assert g("ls ~/projects") == "green"
+    assert cage_policy.classify("Read", {"file_path": "/etc/hosts"}) == "ungated"
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    ok = 0
+    for fn in fns:
+        try:
+            fn(); ok += 1; print(f"PASS {fn.__name__}")
+        except Exception:
+            print(f"FAIL {fn.__name__}"); traceback.print_exc()
+    print(f"\n{ok}/{len(fns)} passed")
+    sys.exit(0 if ok == len(fns) else 1)


### PR DESCRIPTION
## Motivation

A caged job sometimes needs the fleet's trusted infra — push metrics to a self-hosted wandb server, reach the NAS or another fleet host — but today that means a per-call approval on every network op, or opening blanket network. This adds **one opt-in mode** that grants egress to the **tailscale network only**.

This supersedes #114 (per-endpoint named allowlist, closed): the tailnet is trusted infrastructure and everything we need lives on it, so one coarse rule covers the real need with a **much smaller surface** — no endpoint data file to maintain, no hostname resolution/pinning.

> ⚠️ **This edits the security-critical cage. Please review carefully. Do not merge without review.**

## Design (additive, backward-compatible — default `sbox` is unchanged: no network)

- **`sbox --net tailnet -- <argv>`** (new mode): instead of `--unshare-net`, the cage gets a fresh net namespace with userspace egress via **pasta**, plus a **default-DROP `nftables` output chain** permitting only: loopback, established/related, DNS to the configured resolver, and egress to the tailscale CIDR **`100.64.0.0/10`**. Everything else is dropped, below the process. Bare `sbox` is byte-for-byte the old wrapper. CIDR overridable via `AGENT_CAGE_TAILNET_CIDR`.
- **`cage_policy.py`**: greenlights exactly `sbox --net tailnet -- <cmd>` (a single fixed, well-understood mode). Any other value after `--net` (unknown mode, raw `host:port`, malformed) → **gated** (fail-closed). Bare `sbox` stays green; operators/chaining/redirects still gate even behind the prefix.

## Security model

- The tailnet is **trusted infrastructure**; scoping egress to it is far narrower than general network.
- The mode is a **fixed capability** — there is no per-run agent choice of endpoint to smuggle — and the greenlight is **fail-closed** (anything but the exact shape asks a human).
- Default behavior unchanged; no broad wildcards; the sandbox is not disabled.

## Limitations (documented in SKILL.md)

- **Coarse**: reaches **any** tailnet host, not just wandb (acceptable because the tailnet is trusted).
- Does **not** reach the public internet (e.g. PyPI installs still gate/ask).
- **IPv4** ruleset; requires `pasta` + `nft` (sbox errors clearly if absent).

## Tests / verification

- `test_cage_policy.py`: bare `sbox` green; `--net tailnet` green; unknown `--net` value / raw `host:port` / malformed → gated; operators/chaining still gate; raw curl/pip/`wandb login` still gated; existing green preserved — **9/9 pass**. `sh -n sbox` and `py_compile cage_policy.py` clean.
- ⚠️ The **pasta+nft kernel-level egress filtering** is implemented to spec but **not live-exercised** here (no reachable endpoint / network in the cage). Verify live against a reachable tailnet endpoint on the target host before relying on it.

## Scope

Edits only `claude/skills/agent-cage/` source (`sbox`, `cage_policy.py`, `SKILL.md`, new `test_cage_policy.py`). Live installs (`~/.claude/*`, `~/.local/bin/*`) untouched — install per host after review. `100.64.0.0/10` is the public tailscale CGNAT range; no secrets or deployment-specific endpoints committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
