### PR TITLE
spiky.util: generic W&B integration (tracker, workspace, backfill)

### DIFF
--- a/src/spiky/util/wandb_integration/backfill.py
+++ b/src/spiky/util/wandb_integration/backfill.py
@@ -1,0 +1,157 @@
+"""Backfill finished runs into wandb from their recorded artefacts (metrics.csv, config.json, optional summary.json),
+and rewrite the notes of runs already on the server. Clearly marked: tag "backfilled", config backfilled=True, notes
+say so.
+
+A library: the project supplies where its runs live and everything run-specific (branch, host, tags, derived config,
+which column marks a complete row, what "complete" means, description overrides).
+
+    from spiky.util.wandb_integration import backfill as B
+    B.backfill_run(run_dir, project='P', group='family', branch='research/x', host='gpustar', tags=['line:a'],
+                   config_extra={'total_params': 123}, summary_keys=('final_val_loss',), require_col='val_loss',
+                   is_complete=lambda rows, cfg: (rows[-1][0] == cfg['n_steps'], 'last step'), mode='offline')
+    B.update_notes(api, entity, 'P', {'exp_1': '/path/to/exp_1'}, descriptions={'exp_1': '...'}, dry_run=True)
+
+backfill_run: same organisation as the live tracker (tracker.py / claude/wandb.md): name = id = cfg exp_name (else
+the folder name), tags + config with branch / commit / host. commit = the commit that recorded the run's artefacts
+(git log on its metrics.csv). One wandb row per metrics.csv row that has `require_col` (every row if None), at
+step = the row's `step_col`, with every other non-empty column as a float. `summary_keys` are copied from summary.json
+into run.summary. Refuses runs that is_complete(rows, cfg) rejects.
+
+update_notes rewrites ONLY the notes of runs that are already on the server, with the tracker's markdown notes. It
+sends one upsertBucket(id, notes) per run: no config, tags, summary or history is re-sent, nothing is re-logged and no
+artifact is attached. (Run.update() would re-send config, tags and summary.) Backfilled runs (tag "backfilled") link
+to their artefacts commit and say that wandb's Git state shows the HEAD at backfill time; live runs link to their
+launch commit. dry_run prints the notes and writes nothing.
+"""
+import csv
+import json
+import os
+import socket
+
+from spiky.util.wandb_integration.tracker import (_git, github_web_url, gql, normalise_host, run_notes, wandb_config,
+                                                  with_committed_flag, workspace_url)
+
+_SET_NOTES = 'mutation($id: String!, $notes: String){ upsertBucket(input: {id: $id, notes: $notes}){ bucket { id } } }'
+_GET_NOTES = 'query($e: String!, $p: String!, $r: String!){ project(entityName: $e, name: $p){ run(name: $r){ notes } } }'
+
+
+def read_metrics(run_dir, step_col='step', require_col=None):
+    """[(step, {column: float})] from <run_dir>/metrics.csv: rows with a non-empty `require_col` (all rows if None),
+    every other non-empty column converted to float."""
+    out = []
+    with open(os.path.join(run_dir, 'metrics.csv'), newline='') as f:
+        for r in csv.DictReader(f):
+            if require_col is not None and not r.get(require_col):
+                continue
+            out.append((int(r[step_col]), {k: float(v) for k, v in r.items() if k != step_col and v not in (None, '')}))
+    return out
+
+
+def backfill_notes(cfg, *, name, run_dir, commit, branch, host, backfilled, dirty, shown_git_commit, workspace=None,
+                   panel_title=None, description=None):
+    """Markdown notes for a run recorded in run_dir (links resolved in the checkout that holds run_dir)."""
+    root = _git(['rev-parse', '--show-toplevel'], os.path.abspath(run_dir))
+    root = None if root in ('', 'unknown') else root
+    sha = _git(['rev-parse', '--verify', '--quiet', f'{commit}^{{commit}}'], root) if commit and root else 'unknown'
+    sha = None if sha in ('', 'unknown') else sha
+    rel = os.path.relpath(os.path.abspath(run_dir), root) if root else None
+    info = with_committed_flag(dict(root=root, sha=sha, branch=branch, dirty=dirty,
+                                    rel=None if rel is None or rel.startswith('..') else rel,
+                                    web=github_web_url(_git(['remote', 'get-url', 'origin'], root)) if root else None))
+    extra = []
+    if backfilled:
+        extra.append('- **Backfilled** from the committed metrics.csv / summary.json after the run: only the series '
+                     'recorded there, at the steps recorded there (no train/\\*, time/\\* or system series logged live).')
+        if shown_git_commit and sha and shown_git_commit != sha:
+            extra.append(f"- ⚠ wandb's **Git state** on this run shows `{shown_git_commit[:8]}`, the repository HEAD "
+                         f"when the backfill ran, not this run's commit. Its artefacts commit is `{sha[:8]}` (linked "
+                         f'above).')
+    return run_notes(cfg, exp_name=name, info=info, host=host, workspace_url=workspace, panel_title=panel_title,
+                     description=description,
+                     code_label='Code + artefacts (artefacts commit)' if backfilled else 'Code at launch',
+                     extra_lines=extra)
+
+
+def _base(require_entity=False):
+    base, entity = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/'), os.environ.get('WANDB_ENTITY')
+    if not base:
+        raise RuntimeError('WANDB_BASE_URL must be set (never backfill to wandb.ai)')
+    if require_entity and not entity:
+        raise RuntimeError('WANDB_ENTITY must be set')
+    return base, entity
+
+
+def backfill_run(run_dir, *, project, entity=None, group=None, branch=None, host=None, name=None, tags=(),
+                 config_extra=None, config_renames=None, summary_keys=(), step_col='step', require_col=None,
+                 is_complete=None, mode='offline', description=None, panel_title=None, wandb=None):
+    """Upload one finished run (see the module docstring). Returns the local wandb run folder, or None if refused."""
+    if mode not in ('online', 'offline'):
+        raise ValueError(f'mode must be online or offline, got {mode!r}')
+    base, entity = _base()[0], entity or os.environ.get('WANDB_ENTITY')
+    cfg = json.load(open(os.path.join(run_dir, 'config.json')))
+    summ_path = os.path.join(run_dir, 'summary.json')
+    summ = json.load(open(summ_path)) if os.path.exists(summ_path) else {}
+    name = name or cfg.get('exp_name') or os.path.basename(os.path.abspath(run_dir))
+    rows = read_metrics(run_dir, step_col, require_col)
+    ok, why = (bool(rows), 'no rows') if is_complete is None or not rows else is_complete(rows, cfg)
+    if not ok:
+        print(f'SKIP {name}: metrics.csv incomplete ({why}; {len(rows)} rows, last step {rows[-1][0] if rows else None})')
+        return None
+    if wandb is None:
+        import wandb
+    rd = os.path.abspath(run_dir)
+    commit = _git(['log', '-1', '--format=%h', '--', 'metrics.csv'], rd) or 'unknown'
+    host = normalise_host(host or socket.gethostname())
+    config = wandb_config(cfg, dict(branch=branch, commit=commit, commit_kind='artefacts commit', host=host,
+                                    backfilled=True,
+                                    backfill_source='metrics.csv + summary.json' if summ else 'metrics.csv',
+                                    **(config_extra or {})), renames=config_renames)
+    all_tags = [t for t in ['backfilled', group, branch, commit, host] + list(tags) if t and t != 'unknown']
+    notes = backfill_notes(cfg, name=name, run_dir=rd, commit=commit, branch=branch, host=host, backfilled=True,
+                           dirty=None, shown_git_commit=_git(['rev-parse', 'HEAD'], rd),
+                           workspace=workspace_url(base, entity, project) if panel_title else None,
+                           panel_title=panel_title, description=description)
+    run = wandb.init(project=project, entity=entity, group=group, job_type='train',
+                     name=name, id=name, resume='allow', tags=all_tags, config=config, mode=mode,
+                     dir=os.environ.get('WANDB_DIR', os.path.expanduser('~/.cache/wandb')), notes=notes,
+                     settings=wandb.Settings(init_timeout=60, console='off', x_disable_stats=True))
+    for step, row in rows:
+        run.log(row, step=step)
+    for k in summary_keys:
+        if k in summ:
+            run.summary[k] = summ[k]
+    d = os.path.dirname(run.dir)
+    wandb.finish()
+    print(f'backfilled {name}: {len(rows)} rows, commit {commit}, host {host}, mode {mode} -> {d}')
+    return d
+
+
+def set_notes(api, entity, project, run, notes):
+    """upsertBucket(id, notes) on an existing run (a wandb.Api run object); True if the notes read back identical."""
+    gql(api, _SET_NOTES, {'id': run.storage_id, 'notes': notes})
+    back = gql(api, _GET_NOTES, {'e': entity, 'p': project, 'r': run.name})['project']['run']['notes']
+    return back == notes
+
+
+def update_notes(api, entity, project, runs, *, descriptions=None, panel_title=None, dry_run=False):
+    """Rewrite the notes of the runs {name: run_dir} already in entity/project (see the module docstring)."""
+    base = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/')
+    ws = workspace_url(base, entity, project) if panel_title else None
+    results = {}
+    for name, run_dir in runs.items():
+        cfg = json.load(open(os.path.join(run_dir, 'config.json')))
+        r = api.run(f'{entity}/{project}/{name}')
+        conf, backfilled = r.config, 'backfilled' in (r.tags or [])
+        notes = backfill_notes(cfg, name=name, run_dir=run_dir, commit=conf.get('commit'), branch=conf.get('branch'),
+                               host=normalise_host(conf.get('host')), backfilled=backfilled,
+                               dirty=None if backfilled else conf.get('commit_dirty'),
+                               shown_git_commit=((r.metadata or {}).get('git') or {}).get('commit'), workspace=ws,
+                               panel_title=panel_title, description=(descriptions or {}).get(name))
+        if dry_run:
+            print(f'===== {name} ({"backfilled" if backfilled else "live"})\n{notes}\n')
+            results[name] = notes
+            continue
+        same = set_notes(api, entity, project, r, notes)
+        print(f'notes set on {name}: {len(notes)} chars, read back identical: {same}')
+        results[name] = same
+    return results

--- a/src/spiky/util/wandb_integration/glossary.py
+++ b/src/spiky/util/wandb_integration/glossary.py
@@ -1,0 +1,71 @@
+"""The metric-glossary protocol: what tracker.py and workspace.py need from an injected glossary.
+
+A glossary says what every logged key measures. This package never imports one. Callers pass an object -- a plain
+module works, as long as it has these names -- to Tracker.start(glossary=...) (optional) and to the workspace
+publish / verify / audit commands (required):
+
+    PANEL_TITLE: str                      title of the workspace section and its Markdown Panel, e.g. "About these metrics"
+    SOURCE: str                           OPTIONAL: where the glossary is defined; shown in messages and artifact metadata
+    undocumented(keys) -> list[str]       the sorted keys that have no entry. Keys wandb owns (a leading underscore,
+                                          system/*) should count as documented.
+    glossary_hash() -> str                a short content hash that changes exactly when the content changes
+    table_rows() -> list[[key, description, unit]]
+                                          the rows of the per-run `metric_glossary` artifact table
+    panel_markdown() -> str               the workspace panel text. It must depend on the glossary content only (no commit
+                                          sha, no timestamp): verify compares it with the published text exactly.
+    stale(seen_keys) -> list[str]         the entries that match none of seen_keys (audit only)
+
+Who uses what: the tracker's drift check uses undocumented(); its per-run artifact uses glossary_hash() and table_rows();
+publish / verify use PANEL_TITLE, panel_markdown() and glossary_hash(); audit uses undocumented(), stale() and
+glossary_hash().
+"""
+import importlib
+import importlib.util
+import os
+from typing import Iterable, List, Protocol
+
+TRACKER_NEEDS = ('undocumented', 'glossary_hash', 'table_rows')
+PUBLISH_NEEDS = ('PANEL_TITLE', 'panel_markdown', 'glossary_hash')
+AUDIT_NEEDS = ('undocumented', 'stale', 'glossary_hash')
+
+
+class Glossary(Protocol):                                                    # documentation; nothing checks against it
+    PANEL_TITLE: str
+
+    def undocumented(self, keys: Iterable[str]) -> List[str]: ...
+
+    def glossary_hash(self) -> str: ...
+
+    def table_rows(self) -> List[List[str]]: ...
+
+    def panel_markdown(self) -> str: ...
+
+    def stale(self, seen_keys: Iterable[str]) -> List[str]: ...
+
+
+def missing(glossary, needs):
+    """The names in `needs` that `glossary` lacks."""
+    return [n for n in needs if not hasattr(glossary, n)]
+
+
+def require(glossary, needs, what):
+    """`glossary` if it has every name in `needs`, else TypeError naming what is missing."""
+    if glossary is None:
+        raise TypeError(f'{what} needs a glossary (see spiky.util.wandb_integration.glossary)')
+    lacks = missing(glossary, needs)
+    if lacks:
+        raise TypeError(f'{what}: the glossary lacks {", ".join(lacks)} (see spiky.util.wandb_integration.glossary)')
+    return glossary
+
+
+def load(spec):
+    """A glossary from a .py file path or an importable module name (for the workspace command line)."""
+    if spec.endswith('.py') or os.sep in spec:
+        path = os.path.abspath(spec)
+        mod_spec = importlib.util.spec_from_file_location(os.path.splitext(os.path.basename(path))[0], path)
+        if mod_spec is None:
+            raise ImportError(f'cannot load a glossary from {spec!r}')
+        mod = importlib.util.module_from_spec(mod_spec)
+        mod_spec.loader.exec_module(mod)
+        return mod
+    return importlib.import_module(spec)

--- a/src/spiky/util/wandb_integration/tests/conftest.py
+++ b/src/spiky/util/wandb_integration/tests/conftest.py
@@ -1,0 +1,147 @@
+"""Stubs for the wandb_integration tests: a stub glossary implementing the protocol in glossary.py, fake wandb runs and
+a fake `wandb` module. CPU only: no server, no real wandb calls, no project content."""
+import hashlib
+import json
+import os
+import re
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+
+class StubGlossary:
+    PANEL_TITLE = 'About these metrics'
+    SOURCE = 'tests/conftest.py'
+    METRICS = {                                                              # key -> (unit, description)
+        'train/loss': ('nats', 'Training loss of the step.'),
+        'time/sec_per_step': ('s', 'Wall seconds per step.'),
+        'val/loss': ('nats', 'Validation loss.'),
+        'norm_L{i}': ('L2', 'Weight norm of layer i.'),
+        'final_loss': ('nats', 'val/loss at the last eval.'),
+    }
+
+    def _entry(self, key):
+        if key in self.METRICS:
+            return key
+        for k in self.METRICS:
+            if '{i}' in k and re.fullmatch(re.escape(k).replace(re.escape('{i}'), r'\d+'), key):
+                return k
+        return None
+
+    def undocumented(self, keys):
+        return sorted({k for k in keys if not (k.startswith('_') or k.startswith('system/') or self._entry(k))})
+
+    def stale(self, seen_keys):
+        hit = {self._entry(k) for k in seen_keys}
+        return sorted(k for k in self.METRICS if k not in hit)
+
+    def glossary_hash(self):
+        return hashlib.sha256(json.dumps(self.METRICS, sort_keys=True).encode()).hexdigest()[:12]
+
+    def table_rows(self):
+        return [[k, d, u] for k, (u, d) in sorted(self.METRICS.items())]
+
+    def panel_markdown(self):
+        rows = ''.join(f'| `{k}` | {u} | {d} |\n' for k, (u, d) in sorted(self.METRICS.items()))
+        return (f'### {self.PANEL_TITLE}\n\n| key | unit | what it measures |\n|---|---|---|\n{rows}\n'
+                f'glossary `{self.glossary_hash()}`\n')
+
+
+class FakeRun:
+    def __init__(self, **init):
+        self.init = init
+        self._tags = tuple(init.get('tags') or ('a',))
+        self.summary, self.logged, self.artifacts = {}, [], []
+        self.notes = init.get('notes')
+        self.project, self.entity = init.get('project'), init.get('entity')
+        self.dir = os.path.join(init.get('dir') or '/tmp', 'run-fake', 'files')
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @tags.setter
+    def tags(self, v):
+        self._tags = tuple(v)
+
+    def log(self, row, step=None):
+        self.logged.append((step, dict(row)))
+
+    def log_artifact(self, art, aliases=()):
+        self.artifacts.append((art, list(aliases)))
+
+
+class BrokenTagsRun(FakeRun):
+    @property
+    def tags(self):
+        return ()
+
+    @tags.setter
+    def tags(self, v):
+        raise RuntimeError('server said no')
+
+
+class BlockingRun(FakeRun):
+    """run.log() blocks until release is set: a server that stopped accepting rows."""
+
+    def __init__(self, **init):
+        super().__init__(**init)
+        self.release = threading.Event()
+
+    def log(self, row, step=None):
+        self.release.wait(10)
+        super().log(row, step)
+
+
+class FakeWandb(types.ModuleType):
+    class Table:
+        def __init__(self, columns, data):
+            self.columns, self.data = columns, data
+
+    class Artifact:
+        def __init__(self, name, type, description='', metadata=None):
+            self.name, self.type, self.description, self.metadata, self.files = name, type, description, metadata, {}
+
+        def add(self, obj, name):
+            self.files[name] = obj
+
+    def __init__(self):
+        super().__init__('wandb')
+        self.runs, self.finished, self.finish_delay = [], 0, 0.0
+
+    def Settings(self, **kw):
+        return dict(kw)
+
+    def init(self, **kw):
+        run = FakeRun(**kw)
+        self.runs.append(run)
+        return run
+
+    def finish(self):
+        time.sleep(self.finish_delay)
+        self.finished += 1
+
+
+@pytest.fixture
+def glossary():
+    return StubGlossary()
+
+
+@pytest.fixture
+def fakes():
+    return types.SimpleNamespace(Run=FakeRun, BrokenTagsRun=BrokenTagsRun, BlockingRun=BlockingRun)
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch, tmp_path):
+    """`import wandb` returns a fake; the wandb environment is cleared and its directories point into tmp_path."""
+    fw = FakeWandb()
+    monkeypatch.setitem(sys.modules, 'wandb', fw)
+    for var in ('WANDB_BASE_URL', 'WANDB_MODE', 'WANDB_PROJECT', 'WANDB_ENTITY', 'WANDB_RUN_GROUP'):
+        monkeypatch.delenv(var, raising=False)
+    for var, sub in (('WANDB_DIR', 'wandb'), ('WANDB_CONFIG_DIR', 'config'), ('WANDB_DATA_DIR', 'data')):
+        monkeypatch.setenv(var, str(tmp_path / sub))
+    return fw

--- a/src/spiky/util/wandb_integration/tests/test_wandb_backfill.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_backfill.py
@@ -1,0 +1,114 @@
+"""Backfill: metrics.csv rows -> wandb rows, run-specific values injected, incomplete runs refused, and the notes-only
+path sends nothing but notes. CPU only, no server (a fake wandb module and a fake API)."""
+import json
+import os
+import types
+
+import pytest
+
+from spiky.util.wandb_integration import backfill as B
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+UTIL = os.path.abspath(os.path.join(HERE, '..', '..'))                         # src/spiky/util, committed on main
+ROWS = ((1, '', 3.0), (500, '1.5', 2.5), (1000, '1.4', 2.4))
+
+
+def _run_dir(tmp_path, name='exp_3', rows=ROWS, summary=True):
+    d = tmp_path / name
+    d.mkdir()
+    (d / 'config.json').write_text(json.dumps({'exp_name': name, 'n_steps': 1000, 'legacy': 1,
+                                               'description': 'Backfill test.'}))
+    (d / 'metrics.csv').write_text('\n'.join(['step,val/loss,train_loss'] + [f'{s},{v},{t}' for s, v, t in rows]) + '\n')
+    if summary:
+        (d / 'summary.json').write_text(json.dumps({'final_loss': 1.4, 'eval_protocol': {'x': 1}}))
+    return d
+
+
+def _last_step_is_n_steps(rows, cfg):
+    return rows[-1][0] == cfg['n_steps'], f'last step {rows[-1][0]} of {cfg["n_steps"]}'
+
+
+def test_read_metrics(tmp_path):
+    d = _run_dir(tmp_path)
+    assert B.read_metrics(d, require_col='val/loss') == [(500, {'val/loss': 1.5, 'train_loss': 2.5}),
+                                                         (1000, {'val/loss': 1.4, 'train_loss': 2.4})]
+    every = B.read_metrics(d)
+    assert [s for s, _ in every] == [1, 500, 1000] and every[0][1] == {'train_loss': 3.0}
+
+
+def test_backfill_run_logs_rows_summary_tags_and_config(monkeypatch, capsys, fake_wandb, tmp_path):
+    monkeypatch.setenv('WANDB_BASE_URL', 'http://wandb.invalid')
+    d = _run_dir(tmp_path)
+    out = B.backfill_run(str(d), project='Throwaway', entity='ent', group='family', branch='research/x', host='pasta-box',
+                         tags=['line:a'], config_extra={'total_params': 7}, config_renames={'legacy': 'legacy_ignored'},
+                         summary_keys=('final_loss', 'missing'), require_col='val/loss',
+                         is_complete=_last_step_is_n_steps, panel_title='About these metrics', wandb=fake_wandb)
+    run = fake_wandb.runs[0]
+    kw = run.init
+    assert out == os.path.dirname(run.dir) and fake_wandb.finished == 1
+    assert run.logged == [(500, {'val/loss': 1.5, 'train_loss': 2.5}), (1000, {'val/loss': 1.4, 'train_loss': 2.4})]
+    assert run.summary == {'final_loss': 1.4}
+    assert kw['tags'] == ['backfilled', 'family', 'research/x', 'box', 'line:a']   # commit unknown: not a git checkout
+    assert (kw['project'], kw['entity'], kw['group'], kw['name'], kw['id'], kw['mode']) == (
+        'Throwaway', 'ent', 'family', 'exp_3', 'exp_3', 'offline')
+    c = kw['config']
+    assert c['backfilled'] is True and c['host'] == 'box' and c['total_params'] == 7 and c['branch'] == 'research/x'
+    assert c['legacy_ignored'] == 1 and 'legacy' not in c and 'description' not in c
+    assert c['backfill_source'] == 'metrics.csv + summary.json' and c['commit_kind'] == 'artefacts commit'
+    assert '**Backfilled**' in kw['notes'] and 'Backfill test.' in kw['notes']
+    assert '[project workspace](http://wandb.invalid/ent/Throwaway/workspace)' in kw['notes']
+    assert 'backfilled exp_3: 2 rows' in capsys.readouterr().out
+
+
+def test_backfill_refuses_incomplete_runs(monkeypatch, capsys, fake_wandb, tmp_path):
+    monkeypatch.setenv('WANDB_BASE_URL', 'http://wandb.invalid')
+    short = _run_dir(tmp_path, rows=ROWS[:2])
+    assert B.backfill_run(str(short), project='P', require_col='val/loss', is_complete=_last_step_is_n_steps,
+                          wandb=fake_wandb) is None
+    assert 'SKIP exp_3: metrics.csv incomplete (last step 500 of 1000' in capsys.readouterr().out
+    empty = _run_dir(tmp_path, name='exp_4', rows=ROWS[:1], summary=False)
+    assert B.backfill_run(str(empty), project='P', require_col='val/loss', wandb=fake_wandb) is None
+    assert fake_wandb.runs == []
+    with pytest.raises(ValueError):
+        B.backfill_run(str(short), project='P', mode='sideways', wandb=fake_wandb)
+
+
+def test_backfill_notes_flag_the_git_state_of_backfilled_runs(tmp_path):
+    md = B.backfill_notes({'description': 'D.'}, name='e', run_dir=UTIL, commit='HEAD', branch='main', host='h',
+                          backfilled=True, dirty=None, shown_git_commit='f' * 40)
+    if 'Code + artefacts' not in md:
+        pytest.skip('not a git checkout')
+    assert '**Backfilled**' in md and "wandb's **Git state** on this run shows `ffffffff`" in md
+    live = B.backfill_notes({'description': 'D.'}, name='e', run_dir=str(tmp_path), commit=None, branch=None, host='h',
+                            backfilled=False, dirty=None, shown_git_commit=None)
+    assert 'Backfilled' not in live and 'Git state' not in live and live.startswith('**e**\n\nD.')
+
+
+class _Api:
+    """wandb.Api stand-in: one run on the server; GraphQL upsertBucket stores notes, the notes query reads them."""
+
+    def __init__(self):
+        self.notes, self.paths, self.mutations = {}, [], 0
+        self._service_api = types.SimpleNamespace(execute_graphql=self._gql)
+
+    def run(self, path):
+        self.paths.append(path)
+        return types.SimpleNamespace(name=path.rsplit('/', 1)[1], storage_id='S1', tags=['backfilled'], metadata={},
+                                     config={'commit': None, 'branch': 'research/x', 'host': 'pasta-box'})
+
+    def _gql(self, query, variables, timeout=None):
+        if 'upsertBucket' in query:
+            self.mutations += 1
+            self.notes[variables['id']] = variables['notes']
+            return {'upsertBucket': {'bucket': {'id': variables['id']}}}
+        return {'project': {'run': {'notes': self.notes.get('S1')}}}
+
+
+def test_update_notes_dry_run_writes_nothing_then_writes_only_notes(capsys, tmp_path):
+    d = _run_dir(tmp_path)
+    api = _Api()
+    dry = B.update_notes(api, 'ent', 'P', {'exp_3': str(d)}, descriptions={'exp_3': 'Override.'}, dry_run=True)
+    assert api.mutations == 0 and 'Override.' in dry['exp_3'] and '**Backfilled**' in dry['exp_3']
+    assert '===== exp_3 (backfilled)' in capsys.readouterr().out
+    assert B.update_notes(api, 'ent', 'P', {'exp_3': str(d)}) == {'exp_3': True}
+    assert api.mutations == 1 and api.paths == ['ent/P/exp_3', 'ent/P/exp_3'] and 'Backfill test.' in api.notes['S1']

--- a/src/spiky/util/wandb_integration/tests/test_wandb_tracker.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_tracker.py
@@ -1,0 +1,257 @@
+"""Tracker: the loop never waits on or breaks because of wandb, the drift check is never fatal, project / group / tags /
+metrics / glossary are injected, and the notes / config helpers behave. CPU only, no server (a fake wandb module).
+
+    python -m pytest src/spiky/util/wandb_integration/tests -q
+"""
+import os
+import time
+
+import pytest
+
+from spiky.util.wandb_integration import tracker as T
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+UTIL = os.path.abspath(os.path.join(HERE, '..', '..'))                         # src/spiky/util, committed on main
+
+
+def _drain(t):
+    t._q.put(None)
+    t._th.join(5)
+
+
+def _online_env(monkeypatch):
+    monkeypatch.setenv('WANDB_BASE_URL', 'http://wandb.invalid:8080')
+    monkeypatch.setenv('WANDB_MODE', 'offline')                                # no server probe
+
+
+def test_drift_check_flags_unknown_keys_once(capsys, fakes, glossary):
+    run = fakes.Run()
+    t = T.Tracker(run, wandb=None, mode='offline', glossary=glossary)
+    t.train_step(1, {'train/loss': 3.0})
+    t.eval_step(500, {'val/loss': 1.2, 'norm_L0': 1.0, 'brand_new': 2.0})
+    t.eval_step(1000, {'val/loss': 1.1, 'norm_L0': 1.0, 'brand_new': 2.0, 'other_new': 1.0})
+    _drain(t)
+    assert T.UNDOC_TAG in run.tags and run.tags.count(T.UNDOC_TAG) == 1
+    assert run.summary[T.UNDOC_SUMMARY] == 'brand_new, other_new'
+    out = capsys.readouterr().out
+    assert out.count('brand_new') == 1 and out.count('other_new') == 1
+    assert len(run.logged) == 3
+
+
+def test_drift_check_is_never_fatal(fakes, glossary):
+    run = fakes.BrokenTagsRun()
+    t = T.Tracker(run, wandb=None, mode='offline', glossary=glossary)
+    t.eval_step(500, {'val/loss': 1.2, 'brand_new': 2.0})
+    t.eval_step(1000, {'val/loss': 1.1})
+    _drain(t)
+    assert t.run is run and len(run.logged) == 2                  # still logging, not disabled
+
+
+def test_documented_rows_raise_no_flag_and_extra_eval_metrics_merge(capsys, fakes, glossary):
+    run, seen = fakes.Run(), []
+
+    def per_layer(model):
+        seen.append(model)
+        return {'norm_L0': 1.0, 'norm_L1': 2.0}
+
+    t = T.Tracker(run, wandb=None, mode='offline', glossary=glossary, extra_eval_metrics=per_layer)
+    t.train_step(10, {'train/loss': 3.0})
+    t.eval_step(500, {'val/loss': 1.2}, model='M')
+    t.eval_step(600, {'val/loss': 1.1})                           # no model: no extra metrics
+    _drain(t)
+    assert T.UNDOC_TAG not in run.tags and T.UNDOC_SUMMARY not in run.summary
+    assert 'glossary' not in capsys.readouterr().out
+    assert run.logged[1] == (500, {'val/loss': 1.2, 'norm_L0': 1.0, 'norm_L1': 2.0})
+    assert run.logged[2] == (600, {'val/loss': 1.1}) and seen == ['M']
+
+
+def test_without_a_glossary_there_is_no_drift_check(capsys, fakes):
+    run = fakes.Run()
+    t = T.Tracker(run, wandb=None, mode='offline')
+    t.eval_step(1, {'anything/at_all': 1.0})
+    _drain(t)
+    assert run.logged == [(1, {'anything/at_all': 1.0})] and T.UNDOC_TAG not in run.tags
+    assert capsys.readouterr().out == ''
+
+
+def test_train_step_throttles_converts_and_times(fakes):
+    class Tensorish:
+        def __float__(self):
+            return 0.5
+
+    run = fakes.Run()
+    t = T.Tracker(run, wandb=None, mode='offline', log_every=5)
+    for s in range(1, 12):
+        t.train_step(s, {'train/loss': 1.0, 'grad_norm': Tensorish(), 'not_a_number': object()})
+    _drain(t)
+    assert [s for s, _ in run.logged] == [1, 5, 10]
+    row = run.logged[1][1]
+    assert row['grad_norm'] == 0.5 and 'not_a_number' not in row and row[T.TIMING_KEY] >= 0
+    run2 = fakes.Run()
+    t2 = T.Tracker(run2, wandb=None, mode='offline', timing_key=None)
+    t2.train_step(1, {'train/loss': 1.0})
+    _drain(t2)
+    assert run2.logged == [(1, {'train/loss': 1.0})]
+
+
+def test_an_extra_eval_metrics_error_disables_the_tracker_without_raising(capsys, fakes):
+    def boom(model):
+        raise RuntimeError('no such layer')
+
+    run = fakes.Run()
+    t = T.Tracker(run, wandb=None, mode='offline', extra_eval_metrics=boom)
+    t.eval_step(1, {'val/loss': 1.0}, model=object())
+    assert not t.active and 'disabled after an error in eval_step' in capsys.readouterr().out
+    t.train_step(1, {'train/loss': 1.0})
+    t.eval_step(2, {'val/loss': 1.0})
+    t.finish({'final_loss': 1.0})
+    _drain(t)
+    assert run.logged == [] and run.summary == {}
+
+
+def test_a_full_queue_drops_rows_and_never_blocks(monkeypatch, fakes):
+    monkeypatch.setattr(T, 'LOG_QUEUE_MAX', 3)
+    run = fakes.BlockingRun()
+    t = T.Tracker(run, wandb=None, mode='offline')
+    t0 = time.time()
+    for s in range(50):
+        t.log({'x': float(s)}, s)
+    assert time.time() - t0 < 0.5                                 # the loop never waited
+    assert t.dropped >= 50 - 3 - 1
+    run.release.set()
+    _drain(t)
+    assert len(run.logged) == 50 - t.dropped
+
+
+def test_finish_gives_up_at_its_deadline(monkeypatch, capsys, fakes, fake_wandb):
+    monkeypatch.setattr(T, 'FINISH_TIMEOUT', 0.2)
+    monkeypatch.setattr(T, 'FINISH_GRACE', 0.3)
+    fake_wandb.finish_delay = 30                                  # a wandb.finish() that hangs
+    run = fakes.Run(dir='/tmp/x')
+    t = T.Tracker(run, wandb=fake_wandb, mode='online')
+    t.log({'val/loss': 1.0}, 1)
+    t0 = time.time()
+    t.finish({'final_loss': 1.0, 'nested': {'not': 'a scalar'}})
+    assert time.time() - t0 < 3
+    assert 'finish() gave up' in capsys.readouterr().out and not t.active
+    assert run.logged == [(1, {'val/loss': 1.0})] and run.summary == {'final_loss': 1.0}
+
+
+def test_start_is_off_without_server_project_or_when_disabled(monkeypatch, fake_wandb):
+    assert T.Tracker.start({}, '/tmp', project='P').reason == 'no WANDB_BASE_URL'
+    monkeypatch.setenv('WANDB_BASE_URL', 'http://wandb.invalid:8080')
+    assert T.Tracker.start({}, '/tmp').reason == 'no project'
+    monkeypatch.setenv('WANDB_MODE', 'disabled')
+    assert T.Tracker.start({}, '/tmp', project='P').reason == 'disabled'
+    assert fake_wandb.runs == []
+
+
+def test_start_wires_the_injected_project_group_tags_config_metrics_and_glossary(monkeypatch, capsys, fake_wandb,
+                                                                                 glossary, tmp_path):
+    _online_env(monkeypatch)
+    monkeypatch.setenv('WANDB_ENTITY', 'ent')
+    monkeypatch.setenv('WANDB_RUN_GROUP', 'family')
+    exp = tmp_path / 'exp_7'
+    exp.mkdir()
+    cfg = {'lr': 3e-4, 'legacy': 10, 'form': 'x', 'description': 'Tests a thing.', '_arch_note': 'Long note.'}
+    t = T.Tracker.start(cfg, str(exp), project='Throwaway', tags=['static'], extra_tags=lambda c: [f"form:{c['form']}"],
+                        extra_eval_metrics=lambda m: {'norm_L0': 1.0}, glossary=glossary,
+                        config_extra={'total_params': 123}, config_renames={'legacy': 'legacy_ignored'}, log_every=2)
+    assert t.active and t.mode == 'offline' and t.log_every == 2
+    run = fake_wandb.runs[0]
+    kw = run.init
+    assert (kw['project'], kw['entity'], kw['group'], kw['job_type']) == ('Throwaway', 'ent', 'family', 'train')
+    assert kw['name'] == kw['id'] == 'exp_7' and kw['resume'] == 'allow' and kw['mode'] == 'offline'
+    assert kw['tags'][0] == 'family' and 'static' in kw['tags'] and 'form:x' in kw['tags']
+    c = kw['config']
+    assert c['legacy_ignored'] == 10 and 'legacy' not in c and c['total_params'] == 123 and c['lr'] == 3e-4
+    assert 'description' not in c and '_arch_note' not in c and {'branch', 'commit', 'commit_dirty', 'host'} <= set(c)
+    assert kw['settings']['console'] == 'off' and kw['settings']['finish_timeout'] == T.FINISH_TIMEOUT
+    art, aliases = run.artifacts[0]
+    assert aliases == ['latest', f'glossary-{glossary.glossary_hash()}']
+    assert art.files['glossary'].data == glossary.table_rows() and art.metadata['source'] == glossary.SOURCE
+    assert 'Tests a thing.' in run.notes
+    assert '"About these metrics" at the top of the [project workspace](http://wandb.invalid:8080/ent/Throwaway/workspace)' in run.notes
+    t.eval_step(2, {'val/loss': 1.0}, model=object())
+    t.finish({'final_loss': 1.0})
+    assert run.logged == [(2, {'val/loss': 1.0, 'norm_L0': 1.0})] and run.summary == {'final_loss': 1.0}
+    assert fake_wandb.finished == 1 and 'undocumented' not in capsys.readouterr().out
+
+
+def test_start_survives_a_failing_extra_tags_and_an_incomplete_glossary(monkeypatch, capsys, fake_wandb, tmp_path):
+    _online_env(monkeypatch)
+
+    def bad_tags(cfg):
+        raise KeyError('form')
+
+    t = T.Tracker.start({}, str(tmp_path), project='P', extra_tags=bad_tags, glossary=object())
+    out = capsys.readouterr().out
+    assert t.active and 'extra_tags failed' in out
+    assert 'glossary ignored: it lacks undocumented, glossary_hash, table_rows' in out
+    assert t.glossary is None and fake_wandb.runs[0].artifacts == [] and 'Metric glossary' not in fake_wandb.runs[0].notes
+    t.finish()
+
+
+def test_github_web_url():
+    assert T.github_web_url('git@github-spikybot:owner/repo.git') == 'https://github.com/owner/repo'
+    assert T.github_web_url('git@github.com:owner/repo') == 'https://github.com/owner/repo'
+    assert T.github_web_url('https://github.com/owner/repo.git') == 'https://github.com/owner/repo'
+    assert T.github_web_url('ssh://git@github.com/owner/repo.git') == 'https://github.com/owner/repo'
+    assert T.github_web_url('git@gitlab.com:owner/repo.git') is None
+    assert T.github_web_url('unknown') is None and T.github_web_url(None) is None
+
+
+def test_host_and_config_normalisation():
+    assert T.normalise_host('pasta-gpustar') == 'gpustar'
+    assert T.normalise_host('gpustar') == 'gpustar' and T.normalise_host(None) is None
+    cfg = {'eval_steps': 10, 'lr': 3e-4, '_arch_note': 'long', 'description': 'short'}
+    c = T.wandb_config(cfg, {'host': 'gpustar'}, renames={'eval_steps': 'eval_steps_legacy_ignored'})
+    assert c == {'eval_steps_legacy_ignored': 10, 'lr': 3e-4, 'host': 'gpustar'}
+    assert T.wandb_config(cfg) == {'eval_steps': 10, 'lr': 3e-4}
+
+
+def test_description_text():
+    assert T.description_text({'description': 'Short.', '_arch_note': 'Long note.'}) == 'Short.'
+    note = 'First sentence. Second one here. Third (short). Fourth. Fifth should not appear.'
+    assert T.description_text({'_arch_note': note}) == 'First sentence. Second one here. Third (short). Fourth.'
+    assert T.description_text({'_arch_note': 'A' * 3000}).endswith('...')
+    assert T.description_text({}) == ''
+
+
+def test_run_notes_links_and_flags():
+    sha = 'a' * 40
+    info = dict(web='https://github.com/o/r', sha=sha, branch='research/x', dirty=True,
+                rel='experiments/f/runs/exp_1', committed=False)
+    cfg = {'_arch_note': 'What it tests. Why. How it differs. The fourth. The fifth is not in the summary. *star* x_y'}
+    ws = T.workspace_url('http://h/', 'e', 'p')
+    assert ws == 'http://h/e/p/workspace' and T.workspace_url('', 'e', 'p') is None
+    md = T.run_notes(cfg, exp_name='exp_1', info=info, host='gpustar', workspace_url=ws, panel_title='About these metrics',
+                     artifact_url='http://h/art', artifact_label='metric_glossary:glossary-abc')
+    head, _, tail = md.partition('\n---\n')
+    assert head.startswith('**exp\\_1**')
+    assert f'(https://github.com/o/r/tree/{sha}/experiments/f/runs/exp_1)' in head
+    assert '(https://github.com/o/r/tree/research/x/experiments/f/runs/exp_1)' in head
+    assert 'dirty' in head and 'not committed at launch' in head
+    assert '`experiments/f/runs/exp_1` on `gpustar`' in head
+    assert '"About these metrics" at the top of the [project workspace](http://h/e/p/workspace)' in head
+    assert '[metric\\_glossary:glossary-abc](http://h/art)' in head
+    assert 'fifth' not in head and 'The fifth' in tail
+    assert '\\*star\\* x\\_y' in tail                              # _arch_note rendered literally
+    assert 'project workspace' not in T.run_notes(cfg, exp_name='e', info=info, host='h', workspace_url=ws)
+
+
+def test_run_notes_without_git():
+    md = T.run_notes({'description': 'D.'}, exp_name='e', info=dict(), host='h')
+    assert md.startswith('**e**') and 'github' not in md and '---' not in md and 'Metric glossary' not in md
+
+
+def test_git_launch_info_on_this_checkout():
+    info = T.git_launch_info(UTIL)
+    if info['sha'] is None:
+        pytest.skip('not a git checkout')
+    assert len(info['sha']) == 40
+    assert info['rel'] == os.path.relpath(UTIL, info['root']) and not info['rel'].startswith('..')
+    assert info['committed'] is True
+    outside = T.git_launch_info('/tmp')
+    assert outside['rel'] is None and outside['committed'] is None
+    assert T.git_launch_info('/tmp', code_dir=UTIL)['root'] == info['root']

--- a/src/spiky/util/wandb_integration/tests/test_wandb_workspace.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_workspace.py
@@ -1,0 +1,114 @@
+"""Workspace panel: built and placed correctly (idempotent, other sections untouched), the glossary protocol checks,
+and the command line's no-server paths. CPU only, no server."""
+import copy
+import types
+
+import pytest
+
+from spiky.util.wandb_integration import glossary as G
+from spiky.util.wandb_integration import workspace as W
+
+TITLE = 'About these metrics'
+
+
+def _spec(extra_sections=()):
+    return {'section': {'panelBankConfig': {
+        'sections': [{'__id__': 'a1', 'name': 'Charts', 'isPanelsAuto': True, 'panels': []},
+                     {'__id__': 'b2', 'name': 'train', 'isPanelsAuto': True, 'panels': []}] + list(extra_sections)
+        + [{'__id__': 'h3', 'name': 'Hidden Panels', 'isPanelsAuto': False, 'panels': []}],
+        'panelConfigOverrides': {'val/loss': {'config': {'metrics': ['val/loss'], 'legendTemplate': 'x'}}},
+        'settings': {'searchQuery': ''}}, 'runSets': [{'id': 'r'}]}}
+
+
+def test_apply_section_is_first_idempotent_and_leaves_the_rest_alone():
+    before = _spec()
+    once = W.apply_section(before, W.glossary_section('# v1', TITLE))
+    twice = W.apply_section(once, W.glossary_section('# v2', TITLE))
+    for spec, text in ((once, '# v1'), (twice, '# v2')):
+        secs = spec['section']['panelBankConfig']['sections']
+        assert secs[0]['__id__'] == W.SECTION_ID and secs[0]['isPanelsAuto'] is False and secs[0]['pinned'] is True
+        assert [s['__id__'] for s in secs[1:]] == ['a1', 'b2', 'h3']          # others untouched, in order
+        assert sum(s['name'] == TITLE for s in secs) == 1
+        assert secs[0]['panels'][0]['viewType'] == 'Markdown Panel' and secs[0]['panels'][0]['config']['value'] == text
+        assert spec['section']['panelBankConfig']['panelConfigOverrides'] == before['section']['panelBankConfig']['panelConfigOverrides']
+        assert spec['section']['runSets'] == before['section']['runSets']
+    assert before == _spec()                                                  # input not mutated
+
+
+def test_apply_section_replaces_a_renamed_or_moved_copy():
+    moved = copy.deepcopy(W.glossary_section('# old', TITLE))
+    moved['__id__'] = 'regenerated-by-the-ui'                                 # matched by name too
+    spec = W.apply_section(_spec([moved]), W.glossary_section('# new', TITLE))
+    names = [s['name'] for s in spec['section']['panelBankConfig']['sections']]
+    assert names == [TITLE, 'Charts', 'train', 'Hidden Panels']
+
+
+def test_section_state():
+    md = '# current'
+    assert W.section_state(_spec(), md, TITLE) == (False, 'the section is absent')
+    ok, why = W.section_state(W.apply_section(_spec(), W.glossary_section(md, TITLE)), md, TITLE)
+    assert ok and why == 'present, first, current'
+    assert not W.section_state(W.apply_section(_spec(), W.glossary_section('# old', TITLE)), md, TITLE)[0]
+    late = _spec([W.glossary_section(md, TITLE)])
+    assert W.section_state(late, md, TITLE) == (False, 'the section is at position 2, not first')
+    dup = W.apply_section(_spec(), W.glossary_section(md, TITLE))
+    dup['section']['panelBankConfig']['sections'].append(W.glossary_section(md, TITLE))
+    assert W.section_state(dup, md, TITLE)[1] == '2 copies of the section'
+    assert W.section_state({}, md, TITLE)[0] is False
+
+
+def test_shared_view_names():
+    assert W.shared_nw_id('Project — described') == 'projectdescribed'
+    assert W.shared_view_name('Project — described') == 'nw-projectdescribed-v'
+    assert W.shared_view_name('Scratch 2') == 'nw-scratch2-v'
+    with pytest.raises(ValueError):
+        W.shared_nw_id('— —')
+
+
+def test_readme_is_built_from_the_injected_glossary_and_project(glossary):
+    md = W.readme('http://h/e/p?nw=x', glossary, 'Proj', 'T', intro='One project for everything.')
+    assert md.startswith('# Proj\n\nOne project for everything.\n') and md.count('http://h/e/p?nw=x') == 1
+    assert f'[{TITLE}](http://h/e/p?nw=x)' in md and glossary.glossary_hash() in md and glossary.SOURCE in md
+    assert 'saved view "T"' in md
+    assert W.readme('http://h/e/p/workspace', glossary, 'Proj').startswith('# Proj\n\n- **[')
+
+
+def test_glossary_protocol_require_and_load(glossary, tmp_path):
+    assert G.require(glossary, G.TRACKER_NEEDS + G.PUBLISH_NEEDS + G.AUDIT_NEEDS, 'all') is glossary
+    partial = types.SimpleNamespace(PANEL_TITLE='T', glossary_hash=lambda: 'h')
+    with pytest.raises(TypeError, match='publish: the glossary lacks panel_markdown'):
+        G.require(partial, G.PUBLISH_NEEDS, 'publish')
+    with pytest.raises(TypeError, match='needs a glossary'):
+        G.require(None, G.PUBLISH_NEEDS, 'publish')
+    p = tmp_path / 'my_glossary.py'
+    p.write_text("PANEL_TITLE = 'T'\n\ndef panel_markdown():\n    return '# T'\n\ndef glossary_hash():\n    return 'abc'\n")
+    mod = G.load(str(p))
+    assert mod.PANEL_TITLE == 'T' and G.missing(mod, G.PUBLISH_NEEDS) == [] and G.missing(mod, G.AUDIT_NEEDS) == [
+        'undocumented', 'stale']
+
+
+def test_publish_dry_run_needs_no_server(capsys, monkeypatch, glossary):
+    monkeypatch.delenv('WANDB_BASE_URL', raising=False)
+    assert W.main(['publish', '--dry-run', '--project', 'P'], glossary=glossary) == 0
+    out = capsys.readouterr().out
+    assert out.startswith(glossary.panel_markdown()) and W.SECTION_ID in out and repr(TITLE) in out
+
+
+def test_main_requires_a_glossary_and_a_project(monkeypatch, capsys):
+    monkeypatch.delenv('WANDB_PROJECT', raising=False)
+    with pytest.raises(SystemExit, match='--glossary'):
+        W.main(['verify'])
+    with pytest.raises(SystemExit, match='--project'):
+        W.main(['verify'], glossary=object())
+    with pytest.raises(TypeError, match='verify: the glossary lacks'):
+        W.main(['verify', '--project', 'P'], glossary=object())
+    assert W.main(['bogus']) == 2 and 'publish' in capsys.readouterr().out
+
+
+def test_csv_header_keys(tmp_path):
+    for run, header in (('r1', 'step,val/loss,norm_L0'), ('r2', 'step,val/loss,new_key')):
+        d = tmp_path / run
+        d.mkdir()
+        (d / 'metrics.csv').write_text(header + '\n1,2,3\n')
+    keys = W.csv_header_keys([str(tmp_path / 'r2' / 'metrics.csv'), str(tmp_path / 'r1' / 'metrics.csv')])
+    assert keys == {'step': 'r1', 'val/loss': 'r1', 'norm_L0': 'r1', 'new_key': 'r2'}

--- a/src/spiky/util/wandb_integration/tracker.py
+++ b/src/spiky/util/wandb_integration/tracker.py
@@ -1,0 +1,567 @@
+"""Optional, NON-FATAL wandb tracking for training loops (conventions: claude/wandb.md).
+
+    from spiky.util.wandb_integration.tracker import Tracker
+    tracker = Tracker.start(cfg, exp_dir, project=..., group=..., glossary=None,          # after the model is built
+                            extra_tags=None, extra_eval_metrics=None, config_extra=None, config_renames=None)
+    tracker.train_step(step, {'train/loss': loss, 'train/lr': lr})   # once per optimiser step (logged every log_every)
+    tracker.eval_step(step, {'val/loss': val}, model)                 # at each eval, after the local record is written
+    tracker.finish(summary)                                           # at the end, after summary/checkpoint are written
+
+WHAT IS INJECTED -- the tracker holds no project knowledge:
+  * project / entity / group: arguments, defaulting to WANDB_PROJECT / WANDB_ENTITY / WANDB_RUN_GROUP. No project
+    -> tracker OFF.
+  * which keys are logged: the caller's row dicts. The tracker adds only TIMING_KEY (time/sec_per_step) to train rows.
+  * tags: `tags` plus extra_tags(cfg) -> iterable. Per-eval metrics read off the model: extra_eval_metrics(model) -> dict.
+  * config: the run config minus NOTES_CONFIG_KEYS, with config_renames {old: new} applied, plus config_extra.
+  * glossary (optional): see glossary.py. It drives the drift check, the per-run glossary artifact and the notes pointer.
+
+MODE -- ONLINE BY DEFAULT when the server is reachable:
+  * WANDB_BASE_URL unset -> tracker OFF (a run can never silently go to wandb.ai); WANDB_MODE=disabled -> OFF.
+  * WANDB_MODE=offline   -> offline: written under $WANDB_DIR (default ~/.cache/wandb), uploaded later with
+                            `wandb sync <dir>` (from the host, or `sbox --net tailnet -- wandb sync <dir>`).
+  * otherwise            -> a 2 s TCP probe of the server: reachable -> ONLINE (live curves); unreachable ->
+                            OFFLINE with one line saying so. A dead server costs ~2 s at start, never a hang
+                            (a wandb.init against an unreachable server was measured to block for >11 min).
+                            Bare `sbox` has no network, so runs launched there go offline automatically;
+                            launch with `sbox --net tailnet -- ...` to log live.
+  * `wandb` is imported lazily in start(); if it is not installed the tracker is OFF with one line.
+
+GUARDS -- the tracker can never stall or break training:
+  * The training loop never calls wandb. train_step/eval_step put a row on a bounded in-memory queue and
+    return; a background thread does run.log(). If wandb stops accepting rows the queue fills and further
+    rows are DROPPED (counted, reported at finish) -- the loop never waits.
+  * Every wandb network path has capped retries/timeouts (BOUNDS), and finish() has a hard deadline
+    (FINISH_TIMEOUT, default 60 s, env WANDB_TRACKER_FINISH_TIMEOUT, plus FINISH_GRACE): past it the tracker gives
+    up on the upload, kills its own wandb-core helper processes and returns, so the process exits. Call finish()
+    only after the run's local record (metrics file, summary, checkpoint) is written: it stays on disk for a later
+    `wandb sync`.
+  * Any tracker error disables the tracker for the rest of the run with ONE line. Nothing is raised into
+    the training loop; the trainer's own metrics file is written exactly as without the tracker.
+  * The descriptions work below is best-effort on top of that: a failure prints one line and leaves the run
+    exactly as it was initialised.
+  * No secrets: auth from ~/.netrc (`wandb login`); server URL / entity from WANDB_BASE_URL / WANDB_ENTITY.
+  * KNOWN LIMIT: rows logged while the server is unreachable in the middle of an ONLINE run can be missing
+    server-side after it comes back; the trainer's local metrics file stays complete.
+
+ORGANISATION (claude/wandb.md section 4): name and id = cfg exp_name, else the run folder name (unique per run folder,
+so a crashed run resumes instead of duplicating); tags = group, branch, short commit, host + injected tags;
+config = the run config (minus NOTES_CONFIG_KEYS, which go into the notes) + branch, commit, commit_dirty, host
++ config_extra. host has a 'pasta-' prefix removed, so runs launched through `sbox --net tailnet` share the machine's
+name. branch / commit describe the checkout that holds the run folder (else the working directory's; code_dir overrides).
+
+DESCRIPTIONS:
+  * notes = run_notes(): bold exp_name, the config `description` (else the opening sentences of _arch_note),
+    links to the run folder on GitHub at the launch commit and at the branch head (from `git remote get-url origin`),
+    the folder and host, with a glossary: a pointer to its panel at the top of the project workspace and to this
+    run's glossary artifact, then the full _arch_note.
+  * with a glossary: a `metric_glossary` artifact (Table key | description | unit, alias glossary-<hash>) via
+    log_artifact ONLY, never into run history (a Table in history renders as a broken panel on the self-hosted
+    server). Identical glossaries dedup to one artifact version.
+  * with a glossary, the drift check: the first time a logged key has no glossary entry, one line is printed, the
+    run gets the tag glossary:undocumented and summary glossary/undocumented lists the keys. Never fatal.
+"""
+import os
+import queue
+import re
+import signal
+import socket
+import subprocess
+import threading
+import time
+from urllib.parse import urlparse
+
+from spiky.util.wandb_integration import glossary as G
+
+LOG_EVERY = 10
+LOG_QUEUE_MAX = 4096
+TIMING_KEY = 'time/sec_per_step'
+FINISH_TIMEOUT = float(os.environ.get('WANDB_TRACKER_FINISH_TIMEOUT', '60'))
+FINISH_GRACE = 45                                   # finish() waits FINISH_TIMEOUT + this before giving up
+BOUNDS = dict(init_timeout=60, x_graphql_retry_max=5, x_graphql_timeout_seconds=20,
+              x_graphql_retry_wait_min_seconds=2, x_graphql_retry_wait_max_seconds=10,
+              x_file_stream_retry_max=15, x_file_stream_timeout_seconds=30,
+              x_file_stream_retry_wait_min_seconds=2, x_file_stream_retry_wait_max_seconds=20,
+              x_file_transfer_retry_max=5, x_file_transfer_timeout_seconds=60,
+              finish_timeout=FINISH_TIMEOUT, finish_timeout_raises=False)
+
+UNDOC_TAG = 'glossary:undocumented'
+UNDOC_SUMMARY = 'glossary/undocumented'
+GLOSSARY_ARTIFACT, GLOSSARY_ARTIFACT_TYPE = 'metric_glossary', 'glossary'
+NOTES_CONFIG_KEYS = ('_arch_note', 'description')               # go into the notes, not the config
+
+
+def _git(args, cwd):
+    try:
+        return subprocess.check_output(['git'] + args, cwd=cwd, stderr=subprocess.DEVNULL, timeout=10).decode().strip()
+    except Exception:
+        return 'unknown'
+
+
+def _reachable(url, timeout=2.0):
+    try:
+        u = urlparse(url)
+        with socket.create_connection((u.hostname, u.port or (443 if u.scheme == 'https' else 80)), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+def _writable_dir(path):
+    try:
+        os.makedirs(path, exist_ok=True)
+        probe = os.path.join(path, '.write_probe')
+        with open(probe, 'w') as f:
+            f.write('x')
+        os.remove(probe)
+        return True
+    except Exception:
+        return False
+
+
+def _kill_own_wandb_helpers():
+    """SIGKILL the wandb-core / wandb-xpu processes descended from THIS process (never anyone else's)."""
+    me, killed = os.getpid(), []
+    for pid in (int(x) for x in os.listdir('/proc') if x.isdigit()):
+        try:
+            exe = os.path.basename(open(f'/proc/{pid}/cmdline', 'rb').read().split(b'\0')[0].decode(errors='ignore'))
+            if not exe.startswith(('wandb-core', 'wandb-xpu')):
+                continue
+            p = pid
+            for _ in range(8):
+                p = int(open(f'/proc/{p}/stat').read().rsplit(')', 1)[1].split()[1])
+                if p == me:
+                    os.kill(pid, signal.SIGKILL)
+                    killed.append(pid)
+                    break
+                if p <= 1:
+                    break
+        except (OSError, ValueError):
+            continue
+    return killed
+
+
+# ---- run description helpers (pure; used by Tracker.start and backfill.py) ------------------------------------
+def normalise_host(name):
+    """'pasta-gpustar' (the hostname inside `sbox --net tailnet`'s network namespace) -> 'gpustar'."""
+    return name[len('pasta-'):] if isinstance(name, str) and name.startswith('pasta-') else name
+
+
+_SSH_REMOTE = re.compile(r'^(?:ssh://)?[^@/\s]+@([^:/\s]+)[:/](.+?)(?:\.git)?/?$')
+_HTTP_REMOTE = re.compile(r'^https?://(?:[^@/\s]+@)?([^/\s]+)/(.+?)(?:\.git)?/?$')
+
+
+def github_web_url(remote):
+    """https://github.com/<owner>/<repo> for a GitHub remote -- including ssh host aliases such as
+    git@github-<alias>:<owner>/<repo>.git, where the alias only selects a key in ~/.ssh/config -- else None."""
+    for rx in (_SSH_REMOTE, _HTTP_REMOTE):
+        m = rx.match((remote or '').strip())
+        if m:
+            host, path = m.group(1).split(':')[0], m.group(2)
+            ok = (host == 'github.com' or host.startswith('github')) and path.count('/') == 1
+            return f'https://github.com/{path}' if ok else None
+    return None
+
+
+def code_root(exp_dir, code_dir=None):
+    """The top of the git checkout that describes the run's code: code_dir's if given, else the one holding exp_dir,
+    else the working directory's. None outside any checkout."""
+    for d in ([code_dir] if code_dir else [exp_dir, os.getcwd()]):
+        root = _git(['rev-parse', '--show-toplevel'], os.path.abspath(d)) if d and os.path.isdir(d) else 'unknown'
+        if root not in ('', 'unknown'):
+            return root
+    return None
+
+
+def git_launch_info(exp_dir, code_dir=None):
+    """Where the run's code lives (see code_root). Keys: root, sha (full), branch, dirty (tracked files only), rel (run
+    folder relative to the repo root, None if outside it), committed (the folder exists in the tree at sha; None if
+    unknown), web (GitHub URL or None). Any of them may be None."""
+    info = dict(root=None, sha=None, branch=None, dirty=None, rel=None, committed=None, web=None)
+    root = code_root(exp_dir, code_dir)
+    if root is None:
+        return info
+    sha = _git(['rev-parse', 'HEAD'], root)
+    branch = _git(['rev-parse', '--abbrev-ref', 'HEAD'], root)
+    dirty = _git(['status', '--porcelain', '--untracked-files=no'], root)
+    rel = os.path.relpath(os.path.abspath(exp_dir), root)
+    info.update(root=root, sha=None if sha == 'unknown' else sha,
+                branch=None if branch in ('unknown', 'HEAD') else branch,
+                dirty=None if dirty == 'unknown' else bool(dirty),
+                rel=None if rel.startswith('..') else rel,
+                web=github_web_url(_git(['remote', 'get-url', 'origin'], root)))
+    return with_committed_flag(info)
+
+
+def with_committed_flag(info):
+    """Set info['committed'] from `git ls-tree <sha> -- <rel>` (False = the folder is not in that commit)."""
+    if info.get('root') and info.get('sha') and info.get('rel'):
+        out = _git(['ls-tree', info['sha'], '--', info['rel']], info['root'])
+        info['committed'] = None if out == 'unknown' else bool(out)
+    return info
+
+
+_MD_SPECIAL = re.compile(r'([\\`*_\[\]|])')           # not < > #: wandb can show those escapes literally
+_SENTENCE_END = re.compile(r'(?<=[.!?])\s+(?=[A-Z(\["`])')
+
+
+def md_escape(text):
+    """Escape markdown syntax so free text (config notes) renders literally."""
+    return _MD_SPECIAL.sub(r'\\\1', text or '')
+
+
+def description_text(cfg, override=None, max_chars=500):
+    """The run's short description: `override`, else config `description`, else the opening sentences of the first
+    paragraph of _arch_note -- at least one, at most four, stopping before max_chars."""
+    d = (override or cfg.get('description') or '').strip()
+    if d:
+        return d
+    para = (cfg.get('_arch_note') or '').strip().split('\n\n')[0].strip()
+    out = []
+    for s in _SENTENCE_END.split(para):
+        if out and (len(out) == 4 or len(' '.join(out + [s])) > max_chars):
+            break
+        out.append(s)
+    text = ' '.join(out)
+    if len(text) > 2 * max_chars:
+        text = text[:2 * max_chars].rsplit(' ', 1)[0] + ' ...'
+    return text
+
+
+def workspace_url(base, entity, project):
+    """The project workspace, where a published glossary panel sits at the top (None without base/entity/project)."""
+    return f'{base.rstrip("/")}/{entity}/{project}/workspace' if base and entity and project else None
+
+
+def run_notes(cfg, *, exp_name, info, host, workspace_url=None, panel_title=None, artifact_url=None,
+              artifact_label=None, description=None, code_label='Code at launch', extra_lines=()):
+    """Markdown notes for a run (rendered in the run's Overview tab)."""
+    lines = [f'**{md_escape(exp_name)}**', '', md_escape(description_text(cfg, description)), '']
+    web, sha, rel, branch = info.get('web'), info.get('sha'), info.get('rel'), info.get('branch')
+    flags = []
+    if info.get('dirty'):
+        flags.append('⚠ dirty: tracked files differed from this commit at launch')
+    if info.get('committed') is False:
+        flags.append('⚠ folder not committed at launch: this link will 404')
+    flag_txt = (' — ' + '; '.join(flags)) if flags else ''
+    folder = os.path.basename(rel) if rel else None
+    if web and sha and rel:
+        lines.append(f'- **{code_label}:** [{md_escape(folder)} @ {sha[:8]}]({web}/tree/{sha}/{rel}){flag_txt}')
+    elif sha:
+        lines.append(f'- **{code_label}:** commit `{sha}`{flag_txt}')
+    if web and branch and rel:
+        lines.append(f'- **Artefacts (branch head):** [{md_escape(branch)}]({web}/tree/{branch}/{rel})')
+    if rel:
+        lines.append(f'- **Run folder:** `{rel}` on `{host}`')
+    glossary = []
+    if workspace_url and panel_title:
+        glossary.append(f'"{panel_title}" at the top of the [project workspace]({workspace_url})')
+    if artifact_label:                                   # wandb renders no link whose text is `code`: plain text
+        glossary.append(f'artifact [{md_escape(artifact_label)}]({artifact_url})' if artifact_url
+                        else f'artifact `{artifact_label}`')
+    if glossary:
+        lines.append('- **Metric glossary:** ' + ' · '.join(glossary))
+    lines += list(extra_lines)
+    note = (cfg.get('_arch_note') or '').strip()
+    if note:
+        lines += ['', '---', '', '**Architecture note** (config `_arch_note`):', '', md_escape(note)]
+    return '\n'.join(lines)
+
+
+def wandb_config(cfg, extra=None, renames=None):
+    """The config sent to wandb: the run config minus NOTES_CONFIG_KEYS, keys renamed per `renames` {old: new}
+    (e.g. a legacy key that must not be mistaken for its successor), plus `extra`."""
+    config = {k: v for k, v in cfg.items() if k not in NOTES_CONFIG_KEYS}
+    for old, new in (renames or {}).items():
+        if old in config:
+            config[new] = config.pop(old)
+    config.update(extra or {})
+    return config
+
+
+def gql(api, query, variables, timeout=None):
+    """Raw GraphQL through the public API's wandb-core connection (wandb >= 0.28; no public helper exists)."""
+    return api._service_api.execute_graphql(query, variables, timeout=timeout)
+
+
+def log_glossary_artifact(run, wandb, glossary):
+    """log_artifact ONLY (never run.log): Table key | description | unit, aliases latest + glossary-<hash>."""
+    h = glossary.glossary_hash()
+    source = getattr(glossary, 'SOURCE', None)
+    table = wandb.Table(columns=['key', 'description', 'unit'], data=glossary.table_rows())
+    art = wandb.Artifact(GLOSSARY_ARTIFACT, type=GLOSSARY_ARTIFACT_TYPE,
+                         description=f'Metric glossary {h}: what every logged key measures'
+                                     + (f' ({source}).' if source else '.'),
+                         metadata={'glossary_hash': h, 'source': source})
+    art.add(table, 'glossary')
+    run.log_artifact(art, aliases=['latest', f'glossary-{h}'])
+    return f'glossary-{h}'
+
+
+class Tracker:
+    def __init__(self, run=None, wandb=None, reason='', mode=None, glossary=None, extra_eval_metrics=None,
+                 log_every=LOG_EVERY, timing_key=TIMING_KEY):
+        self.run, self._wandb, self.reason, self.mode = run, wandb, reason, mode
+        self.glossary, self._extra_eval_metrics = glossary, extra_eval_metrics
+        self.log_every, self.timing_key = max(int(log_every), 1), timing_key
+        self._t_last, self._s_last = time.time(), 0
+        self._q, self._th, self.dropped = None, None, 0
+        self._seen, self.undocumented = set(), []
+        if run is not None:
+            self._q = queue.Queue(maxsize=LOG_QUEUE_MAX)
+            self._th = threading.Thread(target=self._worker, name='wandb-log', daemon=True)
+            self._th.start()
+
+    @property
+    def active(self):
+        return self.run is not None
+
+    def _fail(self, where, exc):
+        if self.run is not None:
+            print(f'[wandb] disabled after an error in {where}: {type(exc).__name__}: {exc} '
+                  f'-- training continues, local metrics unaffected', flush=True)
+        self.run = None
+
+    def _check_keys(self, keys):
+        """Glossary drift check, never fatal: logged keys with no entry -> one line, tag, summary list."""
+        new = [k for k in keys if k not in self._seen]
+        if not new or self.glossary is None:
+            return
+        self._seen.update(new)
+        bad = self.glossary.undocumented(new)
+        if not bad:
+            return
+        self.undocumented.extend(bad)
+        where = getattr(self.glossary, 'SOURCE', None) or 'the glossary'
+        print(f'[wandb] glossary: no entry for {", ".join(bad)} -- add to {where} (run tagged {UNDOC_TAG})', flush=True)
+        run = self.run
+        try:
+            if run is not None:
+                if UNDOC_TAG not in tuple(run.tags or ()):
+                    run.tags = tuple(run.tags or ()) + (UNDOC_TAG,)
+                run.summary[UNDOC_SUMMARY] = ', '.join(sorted(self.undocumented))
+        except Exception as e:
+            print(f'[wandb] glossary drift check could not tag the run: {type(e).__name__}: {e}', flush=True)
+
+    def _worker(self):
+        """The only place rows reach wandb. Runs off the training thread; exits on the None sentinel."""
+        while True:
+            item = self._q.get()
+            if item is None:
+                return
+            run = self.run
+            if run is None:
+                continue                                          # disabled: just drain
+            try:
+                self._check_keys(item[0].keys())
+            except Exception:
+                pass
+            try:
+                run.log(item[0], step=item[1])
+            except Exception as e:
+                self._fail('log', e)
+
+    def _enqueue(self, row, step):
+        if self.run is None or self._q is None:
+            return
+        try:
+            self._q.put_nowait((row, step))
+        except queue.Full:
+            self.dropped += 1                                      # never wait on the tracker
+
+    def _describe(self, cfg, name, info, host, project, entity):
+        """Glossary artifact + markdown notes, after init. Best-effort: a failure prints one line."""
+        run, wandb, g = self.run, self._wandb, self.glossary
+        base = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/')
+        entity = entity or getattr(run, 'entity', None)
+        project = getattr(run, 'project', None) or project
+        label = art_url = None
+        if g is not None:
+            try:
+                label = log_glossary_artifact(run, wandb, g)
+                if base and entity:
+                    art_url = f'{base}/{entity}/{project}/artifacts/{GLOSSARY_ARTIFACT_TYPE}/{GLOSSARY_ARTIFACT}/{label}'
+            except Exception as e:
+                print(f'[wandb] glossary artifact not logged: {type(e).__name__}: {e}', flush=True)
+        try:
+            run.notes = run_notes(cfg, exp_name=name, info=info, host=host,
+                                  workspace_url=workspace_url(base, entity, project) if g is not None else None,
+                                  panel_title=getattr(g, 'PANEL_TITLE', None),
+                                  artifact_url=art_url, artifact_label=label and f'{GLOSSARY_ARTIFACT}:{label}')
+        except Exception as e:
+            print(f'[wandb] markdown notes not set ({type(e).__name__}: {e}); notes stay the _arch_note', flush=True)
+
+    @classmethod
+    def start(cls, cfg, exp_dir, *, project=None, entity=None, group=None, job_type='train', name=None, tags=(),
+              extra_tags=None, extra_eval_metrics=None, glossary=None, config_extra=None, config_renames=None,
+              code_dir=None, log_every=LOG_EVERY, timing_key=TIMING_KEY):
+        """Start a run, or return an inactive tracker (with one line saying why). Never raises.
+
+        project / entity / group   default WANDB_PROJECT / WANDB_ENTITY / WANDB_RUN_GROUP; no project -> OFF
+        name                       default cfg exp_name, else the run folder name; also the run id (resume='allow')
+        tags                       static tags, after group / branch / commit / host
+        extra_tags(cfg)            optional callable -> more tags (a failure prints one line; the run starts without them)
+        extra_eval_metrics(model)  optional callable -> {key: number}, merged into eval rows that pass a model
+        glossary                   optional, see glossary.py
+        config_extra / renames     merged into / renamed in the config (see wandb_config)
+        code_dir                   the checkout that describes the code (see code_root)
+        """
+        base = os.environ.get('WANDB_BASE_URL')
+        mode = os.environ.get('WANDB_MODE')
+        if not base:
+            print('[wandb] off: WANDB_BASE_URL not set', flush=True)
+            return cls(reason='no WANDB_BASE_URL')
+        if mode == 'disabled':
+            print('[wandb] off: WANDB_MODE=disabled', flush=True)
+            return cls(reason='disabled')
+        project = project or os.environ.get('WANDB_PROJECT')
+        if not project:
+            print('[wandb] off: no project (pass project= or set WANDB_PROJECT)', flush=True)
+            return cls(reason='no project')
+        entity = entity or os.environ.get('WANDB_ENTITY')
+        group = group or os.environ.get('WANDB_RUN_GROUP')
+        if glossary is not None and G.missing(glossary, G.TRACKER_NEEDS):
+            print(f'[wandb] glossary ignored: it lacks {", ".join(G.missing(glossary, G.TRACKER_NEEDS))}', flush=True)
+            glossary = None
+        try:
+            import wandb
+        except Exception as e:                                   # pragma: no cover
+            print(f'[wandb] off: import failed ({type(e).__name__})', flush=True)
+            return cls(reason='import failed')
+        try:
+            root = os.path.expanduser('~/.cache/wandb')
+            # inside the cage the default ~/.config and ~/.local are read-only: keep wandb's own
+            # state in the writable cache when those defaults cannot be written (setdefault only)
+            for var, default, sub in (('WANDB_CONFIG_DIR', '~/.config/wandb', 'config'),
+                                      ('WANDB_DATA_DIR', '~/.local/share/wandb', 'data')):
+                if var not in os.environ and not _writable_dir(os.path.expanduser(default)):
+                    os.environ[var] = os.path.join(root, sub)
+            run_dir = os.environ.get('WANDB_DIR', root)
+            os.makedirs(run_dir, exist_ok=True)
+            if mode != 'offline':
+                if _reachable(base):
+                    mode = 'online'
+                else:
+                    print(f'[wandb] {base} unreachable (2 s probe) -> offline', flush=True)
+                    mode = 'offline'
+            repo = code_root(exp_dir, code_dir) or os.path.abspath(exp_dir)
+            branch = _git(['rev-parse', '--abbrev-ref', 'HEAD'], repo)
+            commit = _git(['rev-parse', '--short', 'HEAD'], repo)
+            dirty = _git(['status', '--porcelain', '--untracked-files=no'], repo)
+            host = normalise_host(socket.gethostname())
+            name = name or cfg.get('exp_name') or os.path.basename(os.path.abspath(exp_dir))
+            config = wandb_config(cfg, dict(branch=branch, commit=commit,
+                                            commit_dirty=bool(dirty and dirty != 'unknown'), host=host,
+                                            **(config_extra or {})), renames=config_renames)
+            all_tags = [group, branch, commit, host] + list(tags or ())
+            if extra_tags is not None:
+                try:
+                    all_tags += list(extra_tags(cfg) or ())
+                except Exception as e:
+                    print(f'[wandb] extra_tags failed ({type(e).__name__}: {e}); starting without them', flush=True)
+            run = wandb.init(project=project, entity=entity, group=group, job_type=job_type,
+                             name=name, id=name, resume='allow', tags=[t for t in all_tags if t and t != 'unknown'],
+                             notes=(cfg.get('_arch_note') or None), config=config, dir=run_dir,
+                             mode=mode, settings=wandb.Settings(console='off', **BOUNDS))
+            print(f'[wandb] {mode}: run {name} -> {run.dir}'
+                  + ('  (sync later: wandb sync ' + os.path.dirname(run.dir) + ')' if mode == 'offline' else ''),
+                  flush=True)
+            tracker = cls(run, wandb, mode=mode, glossary=glossary, extra_eval_metrics=extra_eval_metrics,
+                          log_every=log_every, timing_key=timing_key)
+        except Exception as e:
+            print(f'[wandb] off: init failed: {type(e).__name__}: {e} -- training continues', flush=True)
+            return cls(reason='init failed')
+        try:
+            tracker._describe(cfg, name, git_launch_info(exp_dir, code_dir), host, project, entity)
+        except Exception as e:
+            print(f'[wandb] run description skipped: {type(e).__name__}: {e}', flush=True)
+        return tracker
+
+    def train_step(self, step, row):
+        """Call once per optimiser step; rows are logged at step 1 and every log_every-th step, other calls return at
+        once. Values that are not plain numbers (e.g. a 0-d tensor) are converted with float() on logged steps only --
+        one device sync per logged step; a value that cannot be converted is left out. Adds timing_key: wall seconds
+        per step since the previous logged row."""
+        if self.run is None or not (step % self.log_every == 0 or step == 1):
+            return
+        now = time.time()
+        dt = (now - self._t_last) / max(step - self._s_last, 1)
+        self._t_last, self._s_last = now, step
+        out = {}
+        for k, v in (row or {}).items():
+            if isinstance(v, (int, float)):
+                out[k] = v
+                continue
+            try:
+                out[k] = float(v)
+            except Exception:
+                pass
+        if self.timing_key:
+            out[self.timing_key] = dt
+        self._enqueue(out, step)
+
+    def eval_step(self, step, row=None, model=None):
+        """Log `row` at `step`, plus extra_eval_metrics(model) when a model is passed."""
+        if self.run is None:
+            return
+        try:
+            out = dict(row or {})
+            if model is not None and self._extra_eval_metrics is not None:
+                out.update(self._extra_eval_metrics(model))
+        except Exception as e:
+            self._fail('eval_step', e)
+            return
+        self._enqueue(out, step)
+
+    def log(self, row, step):
+        """Log any row at `step`, unthrottled (never blocks)."""
+        if self.run is None:
+            return
+        self._enqueue(dict(row), step)
+
+    def finish(self, summary=None):
+        run = self.run
+        if run is None:
+            return
+        try:
+            d = os.path.dirname(run.dir)
+        except Exception:
+            d = '?'
+        done, errs, t0 = threading.Event(), [], time.time()
+
+        def _finish():
+            try:
+                try:
+                    self._q.put(None, timeout=5)                   # let queued rows go out (bounded)
+                except queue.Full:
+                    pass
+                self._th.join(timeout=20)
+                scalars = {k: v for k, v in (summary or {}).items()
+                           if isinstance(v, (int, float, str, bool)) or v is None}
+                try:
+                    self._check_keys(scalars.keys())
+                except Exception:
+                    pass
+                for k, v in scalars.items():
+                    run.summary[k] = v
+                self._wandb.finish()                              # bounded by BOUNDS['finish_timeout']
+            except Exception as e:
+                errs.append(e)
+            finally:
+                done.set()
+
+        threading.Thread(target=_finish, name='wandb-finish', daemon=True).start()
+        deadline = FINISH_TIMEOUT + FINISH_GRACE
+        extra = f'; {self.dropped} log rows dropped' if self.dropped else ''
+        if not done.wait(deadline):
+            killed = _kill_own_wandb_helpers()
+            print(f'[wandb] finish() gave up after {deadline:.0f}s (killed wandb helpers {killed}){extra}; '
+                  f'local record intact: wandb sync {d}', flush=True)
+        elif errs:
+            print(f'[wandb] finish() error: {type(errs[0]).__name__}: {errs[0]}{extra}; local record: {d}', flush=True)
+        elif self.mode == 'online' and time.time() - t0 >= FINISH_TIMEOUT - 1:
+            print(f'[wandb] finish() hit its {FINISH_TIMEOUT:.0f}s timeout -- upload likely incomplete{extra}; '
+                  f'local record intact: wandb sync {d}', flush=True)
+        else:
+            print(f'[wandb] finished in {time.time() - t0:.1f}s{extra}'
+                  + (f' (offline; sync with: wandb sync {d})' if self.mode == 'offline' else ''), flush=True)
+        self.run = None

--- a/src/spiky/util/wandb_integration/workspace.py
+++ b/src/spiky/util/wandb_integration/workspace.py
@@ -1,0 +1,325 @@
+"""Publish, verify and audit a metric glossary (protocol: glossary.py) as a pinned panel on a self-hosted wandb.
+
+    WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace publish --glossary G [--project P] [--shared TITLE | --user NAME] [--dry-run] [--if-idle MIN]
+    WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace verify  --glossary G [--project P] [--shared TITLE | --user NAME]
+    WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace audit   --glossary G [--project P] [--csv-glob PATTERN]
+
+G is a .py file or an importable module name; --project defaults to WANDB_PROJECT. A project wrapper calls
+main(argv, glossary=..., project=..., readme_intro=..., audit_csvs=..., audit_extra_keys=...) instead, so its users
+need neither flag.
+
+publish  Writes a Markdown Panel with glossary.panel_markdown() into its own pinned section, titled
+         glossary.PANEL_TITLE, at the TOP of a workspace view. Idempotent: the section and panel carry fixed ids and
+         are replaced in place, never duplicated. Nothing else in the spec is touched -- in particular no
+         panelConfigOverrides (an override REPLACES an auto panel's whole config). Afterwards the spec is re-read:
+         a loud warning and exit 2 if the section is not first or not identical.
+         Target view:
+         --shared TITLE  (recommended) a SHARED saved view named TITLE (view name nw-<id>-v, id = TITLE lower-cased,
+                         letters and digits only), opened at <server>/<entity>/<project>?nw=<id>. Created from the
+                         user's current personal workspace layout; later runs only replace our section, keeping any
+                         edits saved into the view. The web client does NOT auto-save saved views ("Changes are not
+                         auto-saved ... Save view"), so an open browser tab cannot silently remove the panel; only an
+                         explicit "Save view" from a tab loaded before the write can.
+         default         the user's personal workspace (nw-nwuser<username>-w), what they see on opening the project.
+                         CLOBBER RISK: the client auto-saves the whole personal spec, so a tab opened BEFORE the
+                         write removes the section on its next change. publish prints when the workspace was last
+                         saved and by whom; --if-idle MIN refuses to write if that was less than MIN minutes ago.
+         It also points the project description at the panel.
+verify   READ-ONLY. Exit 2 unless the section is present, first, and matches the current glossary.
+audit    READ-ONLY. Undocumented keys -- logged keys with no glossary entry -- from the project's runs (their summary
+         holds every logged key's last value), from the headers of local metrics CSVs and from any extra key lists
+         the caller passes (e.g. the keys its trainer emits); and stale entries, which match none of those.
+         Exit status 1 when anything is undocumented.
+
+No secrets: auth from ~/.netrc; server and entity from the environment.
+"""
+import copy
+import csv
+import datetime
+import glob
+import json
+import os
+import re
+import sys
+
+from spiky.util.wandb_integration import glossary as G
+from spiky.util.wandb_integration.tracker import gql
+
+SECTION_ID, PANEL_ID = 'metric-glossary-section', 'metric-glossary-panel'
+# One full-width column; tall enough to show a few tables without scrolling the page (the panel scrolls inside).
+FLOW_CONFIG = {'columnsPerPage': 1, 'rowsPerPage': 1, 'boxHeight': 560}
+
+_VIEWS = ('query($e: String!, $p: String!){ project(entityName: $e, name: $p){ allViews(viewType: "project-view", first: 100){ '
+          'edges { node { id name displayName updatedAt user { username } updatedBy { username } } } } } }')
+_VIEW = 'query($id: ID!){ view(id: $id){ id name displayName type updatedAt updatedBy { username } specObject } }'
+_UPSERT_VIEW = 'mutation($i: UpsertViewInput!){ upsertView(input: $i){ inserted view { id name updatedAt } } }'
+_UPSERT_MODEL = 'mutation($i: UpsertModelInput!){ upsertModel(input: $i){ project { id name description } } }'
+
+
+# ---- pure helpers (unit-tested, no server) ------------------------------------------------------------------------
+def glossary_section(markdown, title):
+    """The explicit, non-auto section holding the one Markdown Panel. pinned=True: the web client keeps pinned
+    sections ahead of unpinned ones when sections are (un)pinned, and shows it as pinned."""
+    return {'__id__': SECTION_ID, 'name': title, 'isOpen': True, 'isPanelsAuto': False, 'sorted': 0,
+            'pinned': True, 'flowConfig': dict(FLOW_CONFIG),
+            'panels': [{'__id__': PANEL_ID, 'viewType': 'Markdown Panel', 'config': {'value': markdown}}]}
+
+
+def _is_ours(section, title):
+    return section.get('__id__') == SECTION_ID or section.get('name') == title
+
+
+def apply_section(spec, section):
+    """A copy of the workspace spec with our section first and every other section untouched and in order.
+    Any previous copy of our section (matched by id or by name) is removed, so re-running never duplicates."""
+    out = copy.deepcopy(spec)
+    pbc = out['section']['panelBankConfig']
+    pbc['sections'] = [section] + [s for s in pbc.get('sections', []) if not _is_ours(s, section['name'])]
+    return out
+
+
+def section_state(spec, markdown, title):
+    """(ok, reason) for our section in a workspace spec."""
+    secs = ((spec or {}).get('section') or {}).get('panelBankConfig', {}).get('sections', [])
+    ours = [i for i, s in enumerate(secs) if _is_ours(s, title)]
+    if not ours:
+        return False, 'the section is absent'
+    if len(ours) > 1:
+        return False, f'{len(ours)} copies of the section'
+    s = secs[ours[0]]
+    if ours[0] != 0:
+        return False, f'the section is at position {ours[0]}, not first'
+    values = [(p.get('config') or {}).get('value') for p in s.get('panels', []) if p.get('viewType') == 'Markdown Panel']
+    if not values:
+        return False, 'the section has no Markdown Panel'
+    if values[0] != markdown:
+        return False, 'the panel text differs from the current glossary (stale or edited)'
+    return True, 'present, first, current'
+
+
+def shared_nw_id(title):
+    """The named-workspace id of a shared saved view: the title lower-cased, letters and digits only."""
+    nwid = re.sub(r'[^a-z0-9]', '', (title or '').lower())
+    if not nwid:
+        raise ValueError(f'cannot derive a view id from {title!r}')
+    return nwid[:40]
+
+
+def shared_view_name(title):
+    return f'nw-{shared_nw_id(title)}-v'
+
+
+def readme(url, glossary, project, shared_title=None, intro=None):
+    """The project description: a heading, the caller's intro (optional), then pointers to the panel and the notes."""
+    where = (f'the saved view "{shared_title}" -- the project workspace with the panel pinned on top'
+             if shared_title else 'the panel at the top of the workspace')
+    source = getattr(glossary, 'SOURCE', None)
+    lines = [f'# {project}', '']
+    if intro:
+        lines += [intro.strip(), '']
+    lines.append(f'- **[{glossary.PANEL_TITLE}]({url})** -- {where}: what every logged key measures (glossary '
+                 f'`{glossary.glossary_hash()}`' + (f', generated from `{source}`' if source else '') + ').')
+    lines.append("- Each run's **notes** (Overview tab) say what the run tests and link to its code on GitHub at the launch "
+                 'commit and its run folder.')
+    return '\n'.join(lines) + '\n'
+
+
+def csv_header_keys(paths):
+    """{column: the parent folder of the first CSV that has it} over the header rows of `paths`."""
+    out = {}
+    for p in sorted(paths):
+        with open(p, newline='') as f:
+            for h in next(csv.reader(f), []):
+                out.setdefault(h, os.path.basename(os.path.dirname(os.path.abspath(p))))
+    return out
+
+
+# ---- server helpers ------------------------------------------------------------------------------------------------
+def _env():
+    base, entity = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/'), os.environ.get('WANDB_ENTITY')
+    if not base or not entity:
+        sys.exit('WANDB_BASE_URL and WANDB_ENTITY must be set (never publish to wandb.ai)')
+    return base, entity
+
+
+def _arg(argv, flag, default):
+    return argv[argv.index(flag) + 1] if flag in argv else default
+
+
+def _views(api, entity, project):
+    edges = ((gql(api, _VIEWS, {'e': entity, 'p': project}) or {}).get('project') or {}).get('allViews', {}).get('edges', [])
+    return [e['node'] for e in edges]
+
+
+def personal_workspace(api, entity, project, username):
+    """The user's personal workspace view (created by the web UI on their first visit), or None."""
+    nodes = _views(api, entity, project)
+    exact = [n for n in nodes if n['name'] == f'nw-nwuser{username}-w']
+    loose = [n for n in nodes if (n.get('user') or {}).get('username') == username
+             and n['name'].startswith('nw-nwuser') and n['name'].endswith('-w')]
+    return (exact or loose or [None])[0]
+
+
+def _age_minutes(ts):
+    t = datetime.datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    return (datetime.datetime.now(datetime.timezone.utc) - t).total_seconds() / 60
+
+
+def _connect(user=None):
+    base, entity = _env()
+    import wandb
+    api = wandb.Api(timeout=60)
+    user = user or ((gql(api, '{ viewer { username } }', {}) or {}).get('viewer') or {}).get('username')
+    return api, base, entity, user
+
+
+def _personal_or_exit(api, base, entity, project, user):
+    ws = personal_workspace(api, entity, project, user)
+    if ws is None:
+        print(f'no personal workspace for {user!r} in {entity}/{project}: open {base}/{entity}/{project}/workspace '
+              f'once in the browser as that user (wandb creates it on the first visit), then re-run')
+        sys.exit(3)
+    return gql(api, _VIEW, {'id': ws['id']})['view']
+
+
+def _target(shared_title, api, base, entity, project, user):
+    """(view or None, url, description) of the view publish/verify works on."""
+    if shared_title is None:
+        view = _personal_or_exit(api, base, entity, project, user)
+        return view, f'{base}/{entity}/{project}/workspace', f"{user}'s personal workspace"
+    name = shared_view_name(shared_title)
+    hit = [n for n in _views(api, entity, project) if n['name'] == name]
+    view = gql(api, _VIEW, {'id': hit[0]['id']})['view'] if hit else None
+    return view, f'{base}/{entity}/{project}?nw={shared_nw_id(shared_title)}', f'shared saved view {shared_title!r} ({name})'
+
+
+def publish(glossary, project, *, shared_title=None, user=None, if_idle=None, dry_run=False, readme_intro=None):
+    G.require(glossary, G.PUBLISH_NEEDS, 'publish')
+    title, md = glossary.PANEL_TITLE, glossary.panel_markdown()
+    if dry_run:
+        print(md)
+        print(f'({len(md)} chars; section {title!r}, id {SECTION_ID}, flowConfig {FLOW_CONFIG})')
+        return 0
+    api, base, entity, user = _connect(user)
+    view, url, what = _target(shared_title, api, base, entity, project, user)
+    if shared_title is not None:
+        if view is None:                                  # create from the user's current layout
+            base_spec = _personal_or_exit(api, base, entity, project, user)['specObject']
+            inp = {'entityName': entity, 'projectName': project, 'name': shared_view_name(shared_title),
+                   'displayName': shared_title, 'type': 'project-view',
+                   'description': f'{project} workspace with the {title} panel pinned on top'}
+            print(f'{what}: creating it from {user}\'s personal workspace layout')
+        else:
+            base_spec = view['specObject']
+            inp = {'id': view['id']}
+            print(f'{what} ({view["id"]}) last saved {_age_minutes(view["updatedAt"]):.1f} min ago by '
+                  f'{(view.get("updatedBy") or {}).get("username")}; saved views are not auto-saved by the web client')
+    else:
+        age = _age_minutes(view['updatedAt'])
+        by = (view.get('updatedBy') or {}).get('username')
+        print(f'{what} {view["name"]} ({view["id"]}) last saved {age:.1f} min ago by {by} ({view["updatedAt"]})')
+        if if_idle is not None and age < float(if_idle):
+            print(f'NOT WRITTEN: saved less than {if_idle} min ago -- a browser tab may be open and would overwrite the '
+                  f'change on its next save. Close the tabs (or wait) and re-run.')
+            return 4
+        if age < 15:
+            print('!' * 100 + f'\nWARNING: the workspace was saved {age:.1f} min ago -- a browser tab may be open. If one is,'
+                  f' its next save will silently remove this section; run `verify` later, or use --shared.\n' + '!' * 100)
+        base_spec = view['specObject']
+        inp = {'id': view['id']}
+    new = apply_section(base_spec, glossary_section(md, title))
+    others_before = [s.get('__id__') for s in base_spec['section']['panelBankConfig']['sections'] if not _is_ours(s, title)]
+    had = any(_is_ours(s, title) for s in base_spec['section']['panelBankConfig']['sections']) and view is not None
+    inp['spec'] = json.dumps(new)
+    res = gql(api, _UPSERT_VIEW, {'i': inp})['upsertView']
+    after = gql(api, _VIEW, {'id': res['view']['id']})['view']
+    ok, why = section_state(after['specObject'], md, title)
+    others_after = [s.get('__id__') for s in after['specObject']['section']['panelBankConfig']['sections']
+                    if not _is_ours(s, title)]
+    same_overrides = (base_spec['section']['panelBankConfig'].get('panelConfigOverrides')
+                      == after['specObject']['section']['panelBankConfig'].get('panelConfigOverrides'))
+    print(f'section {"replaced" if had else "created"} in {what}: {len(md)} chars, glossary {glossary.glossary_hash()}; '
+          f'other sections unchanged and in order: {others_before == others_after}; '
+          f'panelConfigOverrides unchanged: {same_overrides}')
+    description = readme(url, glossary, project, shared_title, readme_intro)
+    p = gql(api, _UPSERT_MODEL, {'i': {'entityName': entity, 'name': project, 'description': description}})['upsertModel']
+    print(f'project {p["project"]["name"]} description set ({len(p["project"]["description"])} chars)')
+    if not ok or others_before != others_after:
+        bar = '!' * 100
+        print(f'{bar}\nWARNING: after the write the glossary section is NOT right in {what}: {why}'
+              + ('' if others_before == others_after else '; the other sections changed') + f'.\n{bar}')
+        return 2
+    print(f'verified: {why} in {what} -> {url}')
+    return 0
+
+
+def verify(glossary, project, *, shared_title=None, user=None):
+    G.require(glossary, G.PUBLISH_NEEDS, 'verify')
+    api, base, entity, user = _connect(user)
+    view, url, what = _target(shared_title, api, base, entity, project, user)
+    if view is None:
+        print(f'{what} does not exist -> run publish')
+        return 2
+    ok, why = section_state(view['specObject'], glossary.panel_markdown(), glossary.PANEL_TITLE)
+    print(f'{what} last saved {_age_minutes(view["updatedAt"]):.1f} min ago by '
+          f'{(view.get("updatedBy") or {}).get("username")}: {why}  ({url})')
+    if not ok:
+        print('!' * 100 + f'\nWARNING: the glossary panel is not in place in {what} -- re-run publish'
+              + ('' if shared_title else ' (with the browser tabs closed, or use --shared)') + '.\n' + '!' * 100)
+    return 0 if ok else 2
+
+
+def audit(glossary, project, *, csv_paths=(), extra_keys=None):
+    """extra_keys: {label: iterable of keys} that must be documented even before any run has logged them."""
+    G.require(glossary, G.AUDIT_NEEDS, 'audit')
+    base, entity = _env()
+    import wandb
+    api = wandb.Api(timeout=60)
+    server = {}
+    for r in api.runs(f'{entity}/{project}', per_page=100):
+        for k in r.summary_metrics.keys():
+            server.setdefault(k, r.name)
+    csv_keys = csv_header_keys(csv_paths)
+    extra = {label: {k: label for k in keys} for label, keys in (extra_keys or {}).items()}
+    bad = 0
+    for label, keys in [('server runs', server), ('metrics CSV headers', csv_keys)] + list(extra.items()):
+        und = glossary.undocumented(keys)
+        bad += len(und)
+        print(f'{label}: {len(keys)} keys, {len(und)} undocumented'
+              + ''.join(f'\n   {k}  (e.g. {keys[k]})' for k in und))
+    emitted = set().union(*[set(v) for v in extra.values()]) if extra else set()
+    stale_all = glossary.stale(set(server) | set(csv_keys) | emitted)
+    print(f'stale entries (match nothing seen anywhere): {stale_all or "none"}')
+    not_in_data = [k for k in glossary.stale(set(server) | set(csv_keys)) if k not in stale_all]
+    print(f'documented, in the extra key lists, not yet in any run\'s data: {not_in_data or "none"}')
+    print(f'glossary {glossary.glossary_hash()}')
+    return 1 if bad else 0
+
+
+def main(argv, glossary=None, project=None, readme_intro=None, audit_csvs=(), audit_extra_keys=None):
+    """The command line (see the module docstring). Wrappers pass their defaults; flags on argv still win."""
+    cmd, rest = (argv[0], argv[1:]) if argv else ('', [])
+    if cmd not in ('publish', 'verify', 'audit'):
+        print(__doc__)
+        return 2
+    spec = _arg(rest, '--glossary', None)
+    if spec is not None:
+        glossary = G.load(spec)
+    if glossary is None:
+        sys.exit('--glossary FILE_OR_MODULE is required')
+    project = _arg(rest, '--project', None) or project or os.environ.get('WANDB_PROJECT')
+    if not project:
+        sys.exit('--project (or WANDB_PROJECT) is required')
+    shared, user = _arg(rest, '--shared', None), _arg(rest, '--user', None)
+    if cmd == 'publish':
+        return publish(glossary, project, shared_title=shared, user=user, if_idle=_arg(rest, '--if-idle', None),
+                       dry_run='--dry-run' in rest, readme_intro=readme_intro)
+    if cmd == 'verify':
+        return verify(glossary, project, shared_title=shared, user=user)
+    pattern = _arg(rest, '--csv-glob', None)
+    return audit(glossary, project, csv_paths=sorted(glob.glob(pattern)) if pattern else audit_csvs,
+                 extra_keys=audit_extra_keys)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Adds `src/spiky/util/wandb_integration/`, a generic W&B integration for training runs. Nothing project- or deployment-specific is baked in: the project, entity, group, tags, logged metrics and the metric glossary are all passed in.

The code is moved from `experiments/ffn_replacement/tools/` on `research/ffn_replacement_fix` @ 2731e598 and refactored, not rewritten. Sources: `wandb_tracking.py`, `wandb_glossary.py`, `wandb_backfill.py`, and the generic tests from `test_metric_glossary.py`. The conventions it follows are in `claude/wandb.md`; #116 adds the glossary and gotchas sections.

## Modules

**`tracker.py`: `Tracker`, optional W&B logging that can never break a run**
- Usage: `Tracker.start(cfg, exp_dir, project=..., group=..., glossary=..., extra_tags=..., extra_eval_metrics=..., config_extra=..., config_renames=...)`, then `train_step(step, row)`, `eval_step(step, row, model)`, `log(row, step)` and `finish(summary)`.
- **Everything is injected:**
  - `project`, `entity` and `group` are arguments that default to `WANDB_PROJECT`, `WANDB_ENTITY` and `WANDB_RUN_GROUP`. With no project, the tracker is off.
  - Rows are the caller's dicts. The tracker adds only its own `time/sec_per_step`; the key name is configurable or can be turned off.
  - `extra_tags(cfg)` returns more tags. `extra_eval_metrics(model)` returns metrics merged into eval rows (e.g. learned per-layer scalars).
  - `config_renames` renames config keys (e.g. a legacy key that must not be mistaken for its successor); `config_extra` adds values such as derived batch sizes.
- **Run description:**
  - Markdown notes: the description, GitHub links to the run folder at the launch commit and at the branch head (from `git remote get-url origin`), folder and host.
  - With a glossary: a `metric_glossary` artifact (logged with `log_artifact` only) and a drift check. The first time an undocumented key is logged it prints one line, adds the `glossary:undocumented` tag and a summary list. It is never fatal.
- **Launch commit:** branch and commit come from the checkout that holds the run folder, else the working directory's (`code_dir` overrides). This file may now live in a different checkout than the run.

**`glossary.py`: the injected-glossary protocol, written down**
- A glossary is any object, a plain module included, with:
  - `PANEL_TITLE` and an optional `SOURCE`
  - `undocumented(keys)`, `glossary_hash()`, `table_rows()`
  - `panel_markdown()`, which depends only on the content (no commit sha or timestamp) so verify can compare exactly
  - `stale(seen_keys)`
- It is optional for the tracker (the drift check, artifact and pointer need it) and required for publish, verify and audit. `require()` names anything missing; `load()` takes a file path or a module name.

**`workspace.py`: the glossary as a pinned "About these metrics" panel**
- A library, plus `python -m spiky.util.wandb_integration.workspace publish|verify|audit --glossary FILE_OR_MODULE [--project P] [--shared TITLE]`. Project wrappers call `main(argv, glossary=..., project=..., readme_intro=...)`.
- **publish** writes one Markdown Panel into its own pinned section at the top of a view. It replaces that section in place, never touches the other sections or `panelConfigOverrides`, re-reads the spec afterwards, and also points the project description at the panel.
  - The recommended target is a **shared saved view** (`--shared TITLE`).
  - The personal workspace also works, with the clobber warnings and `--if-idle`.
- **verify** is read-only and exits 2 when the section is missing, not first, or stale.
- **audit** lists undocumented and stale keys across server runs, local metrics CSV headers and any key lists the caller passes.

**`backfill.py`: finished runs from their artefacts**
- `backfill_run(run_dir, project=..., group=..., branch=..., host=..., tags=..., config_extra=..., summary_keys=..., require_col=..., is_complete=...)` turns `metrics.csv` + `config.json` (+ `summary.json`) into a run tagged `backfilled`.
- `update_notes(...)` rewrites only the notes, with one `upsertBucket(id, notes)` per run and nothing else re-sent. (`Run.update()` would re-send config, tags and summary.)
- Everything run-specific is passed in: runs dir, branch, host, columns, summary keys, the completeness rule and description overrides.

## Safety design in online mode (unchanged from the research branch)
- **The training loop never calls wandb.** Rows go onto a bounded queue and a background thread does `run.log()`. When the queue is full, rows are dropped and counted, never waited on.
- **A dead server can't hang the run.** A 2 s TCP probe runs before `wandb.init`: unreachable means offline with one line, and a dead server costs about 2 s. An unprobed `init` against a dead server was once measured blocking for more than 11 min.
- **Network work and exit are bounded:**
  - Every network path has capped retries and timeouts (`BOUNDS`).
  - `finish()` has a hard deadline: after 60 s (+ grace) it kills its own `wandb-core` helpers and returns, and the local record stays for `wandb sync`.
- **Errors never reach the loop.** Any tracker error disables it with one line.
- **wandb itself is optional.** It is imported lazily, and if it isn't installed the tracker is off. It stays out of `requirements.txt`.
- **No secrets anywhere:**
  - Auth comes from `~/.netrc`; the server URL and entity come from the environment.
  - No key, URL or entity appears in code, config or logs. `WANDB_BASE_URL` unset means off, so a run can never silently go to wandb.ai.
- **Known regression:** rows logged after a disconnect in the middle of an online run are lost server-side once it reconnects. The trainer's local `metrics.csv` stays complete, so the local file is the record.

## Self-hosted gotchas that shaped this
- **Client/server version skew:** the pip client can be newer than the server's advertised maximum client version. The client in use works, but raw GraphQL goes through the client's internal connection (`gql()`), because there is no public helper.
- **Stale-tab clobber:** the web client auto-saves the whole personal workspace spec, so a tab opened before an API write silently removes the section on its next save. This happened in practice.
- **Saved views are not auto-saved** ("Changes are not auto-saved … Save view"). That is why `--shared` is the recommended target: only an explicit "Save view" from an old tab can undo the write.
- **Overrides replace, not merge:** an entry in `panelConfigOverrides` REPLACES an auto panel's config, so publish never writes one.
- **No Tables in run history:** a `wandb.Table` logged into history renders as a broken panel, so the glossary table is an artifact.

## Why `wandb_integration` and not `util/wandb/`
Collecting `src/spiky/util/test_utils.py` under pytest's default import mode (prepend) puts `src/spiky/util` at `sys.path[0]`.
- If `util/wandb/` had an `__init__.py`, every `import wandb` in that pytest session would load our folder instead of the library. This was measured.
- Without one, it happens to work today, but one reflexive `__init__.py` would break it. A different name removes the trap.

Following the rest of `src/spiky`, there is no `__init__.py` here either.

## Packaging
No `setup.py` change and no reinstall. The editable install's finder maps `spiky.util` and resolves its immediate children, so `spiky.util.wandb_integration.*` imports from an existing `pip install -e .`. Both routes were checked:
- `PYTHONPATH=src` in a checkout of this branch.
- The editable finder with its `spiky.util` mapping pointed at this checkout, with no `PYTHONPATH`: 31 passed.

## Tests
- **New suite:** `python -m pytest src/spiky/util/wandb_integration/tests -q` gives **31 passed** in under 1 s. It is CPU-only, needs no W&B server, trainers or run folders, and imports no project content. It uses a stub glossary, fake runs, a fake `wandb` module and a fake API.
  - Tracker:
    - The drift check flags a key once and is never fatal.
    - A full queue drops rows without blocking.
    - `finish()` gives up at its deadline.
    - A failing `extra_eval_metrics` disables the tracker without raising.
    - The injected project, group, tags, config, metrics and glossary reach `wandb.init`.
    - A failing `extra_tags` or an incomplete glossary doesn't stop the run.
  - Workspace: the section is first, idempotent and leaves the rest alone; stale and duplicate sections are detected; shared view ids; the protocol checks.
  - Backfill: CSV rows become wandb rows, incomplete runs are refused, and the notes-only path writes notes only.
- **Existing suites, CPU session** (`src/spiky/lutorch/tests` + `src/spiky/util`): 118 passed / 160 skipped on main before, and 149 passed / 160 skipped with this branch (= 118 + 31). `util/test_utils.py` still collects.

## Live verification (self-hosted server, throwaway project, stub glossary)
- **Online run:**
  - The run started online and finished (state `finished`), and `finish()` returned in 0.1 s.
  - 30 train steps plus two evals were logged; the loop never waited and no rows were dropped.
  - Read back from the server:
    - History rows are at the expected steps, with `extra_eval_metrics` merged.
    - The group and tags are the injected ones (including `extra_tags(cfg)`), plus the drift tag and summary list for one deliberately undocumented key.
    - The config rename and extra values landed; non-scalar summary values were dropped.
    - The glossary artifact has its `glossary-<hash>` alias, and the notes carry the GitHub links and pointers.
- **Unreachable server:** start fell back to offline, the run finished offline, and no rows were dropped.
- **publish/verify round-trip on a shared saved view:**
  - publish created the view and verified it (exit 0), and verify passed (0).
  - Publishing again replaced the section in place; the other sections and `panelConfigOverrides` were unchanged (0).
  - verify with a changed glossary reported the panel stale (2); verify on the never-published personal workspace reported the section absent (2).

## What stays on `research/ffn_replacement_fix`
The Spiky/LUT-specific layer follows by rebase after this merges:
- `metric_glossary.py`, the glossary content. Its `panel_markdown(source_path)` gets a default so it satisfies the no-argument protocol.
- The CLI wrappers, which carry the project name, `runs_corrected`, branch, host and description overrides, and the "completeness" rule.
- A `wandb_tracking` shim, so frozen run folders keep their old `Tracker.start(cfg, exp_dir, grad_accum=..., total_params=...)` / `train_step(step, loss, ema, lr, grad_norm)` calls. It maps them onto this API, including `learned_confidence_by_layer` as `extra_eval_metrics` and the `form:` tags as `extra_tags`.
- The glossary-content tests: the per-entry checks and the scan of every `metrics.csv` header.

**Not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgeBHTEkV9qLjaRW4feEsK
