### PR TITLE
spiky.util.wandb_integration: DictGlossary, explicit notes link to the glossary panel, NullTracker + import guard

### DIFF
--- a/claude/wandb.md
+++ b/claude/wandb.md
@@ -97,13 +97,21 @@ are needed. Like the rest of `src/spiky`, it has no `__init__.py`. `wandb` itsel
 `requirements.txt`; without it the tracker switches itself off.
 
 ```python
+from spiky.util.wandb_integration.glossary import DictGlossary
 from spiky.util.wandb_integration.tracker import Tracker
+
+GLOSSARY = DictGlossary({                                                  # what every logged key measures
+    "train/loss":    dict(unit="nats/token", section="train", desc="Cross-entropy of the step, ...", short="Step CE."),
+    "val_bpb":       dict(unit="bits/byte", section="eval", desc="Bits per byte on the validation window, ..."),
+    "ln2_norm_L{i}": dict(unit="L2 norm", section="per layer", desc="L2 norm of block i's ln2 gain."),  # {i}: any layer
+}, sections={"train": "Training", "eval": "Evaluation", "per layer": "Per layer"}, source="<path of this file>")
 
 tracker = Tracker.start(cfg, exp_dir, project="Spiky", group="<family>",  # default WANDB_PROJECT / WANDB_RUN_GROUP
                         tags=["<static tag>"],
                         extra_tags=lambda cfg: [f"form:{cfg['form']}"],      # more tags from the config
                         extra_eval_metrics=lambda model: {},                 # merged into eval rows that pass a model
-                        glossary=metric_glossary,                            # optional; protocol below
+                        glossary=GLOSSARY,                                   # optional: drift check + artifact
+                        glossary_panel="<Project> — described",              # optional: link the published panel
                         config_extra={"total_params": n_params},
                         config_renames={"old_key": "old_key_legacy"})
 tracker.train_step(step, {"train/loss": loss, "train/lr": lr})  # logged at step 1 and every log_every (10)
@@ -119,11 +127,37 @@ tracker.finish(summary)                                          # after the loc
   full queue drops rows, counted, and never waits); a 2 s probe of the server before `wandb.init` falls
   back to offline (`wandb sync` later); every network path has capped retries; `finish()` gives up after
   a deadline (60 s plus a grace period); any tracker error disables it with one printed line.
-- **Glossary protocol** (`glossary.py`; a plain module works): `PANEL_TITLE`, optional `SOURCE`,
-  `undocumented(keys)`, `glossary_hash()`, `table_rows()` (`[key, description, unit]` rows),
-  `panel_markdown()` (content only — no sha, no timestamp — so verify compares exactly) and
-  `stale(seen_keys)` for audit. Optional for the tracker (drift check, artifact, notes pointer); required
-  for publish / verify / audit.
+- **Glossaries — `DictGlossary` by default.** Data per key: `unit` and `desc` (the full definition,
+  written from the code), optional `short` (the one-line panel form, default `desc`) and `section`; a key
+  containing `{i}` documents that key for any layer index. Optional `sections` sets the panel's order and
+  headings (sections left out are still documented and in the artifact, just not on the panel), and `notes`
+  adds a bullet list at the bottom of the panel. It provides the whole protocol. **Escape hatch:** any object —
+  a plain module works — with `PANEL_TITLE`, optional `SOURCE`, `undocumented(keys)`, `glossary_hash()`,
+  `table_rows()` (`[key, description, unit]` rows), `panel_markdown()` (content only — no sha, no timestamp —
+  so verify compares exactly) and `stale(seen_keys)`, for what data cannot express (the research glossary's
+  two-tier config notes, for one). A glossary is optional for the tracker (drift check, per-run artifact) and
+  required for publish / verify / audit; `--glossary FILE_OR_MODULE[:NAME]` takes a module's `GLOSSARY` by
+  default.
+- **The notes' link to the published panel is explicit:** `glossary_panel=` the title of the shared saved view
+  it was published into (`publish --shared TITLE`), or `tracker.PERSONAL_WORKSPACE`; the default `None` adds no
+  link. A glossary's `PANEL_TITLE` only names the section publish writes, so a publishable glossary never points
+  runs at a panel by itself. With a glossary, the notes always link the run's own glossary artifact.
+- **Optional means optional — the import guard.** Once the package is imported nothing in it raises:
+  `Tracker.start` never raises and returns an inactive tracker when tracking is off, and `NullTracker` is the
+  same do-nothing surface for code that starts no run (DDP ranks other than 0, dry runs, tests). What no code in
+  the package can cover is the package itself failing to import (absent — e.g. an editable install pointing at
+  an older checkout — or broken). That guard is the consumer's, with a fallback built from builtins
+  (`tracker.IMPORT_GUARD`); anything that imports the package — a `DictGlossary` module too — goes inside it:
+
+  ```python
+  try:
+      from spiky.util.wandb_integration.tracker import Tracker
+      from my_glossary import GLOSSARY  # a DictGlossary imports this package too: keep it inside the guard
+      tracker = Tracker.start(cfg, exp_dir, project=PROJECT, group=GROUP, glossary=GLOSSARY)
+  except Exception as e:  # the package itself could not be imported: Tracker.start never raises
+      print(f'[wandb] off: {type(e).__name__}: {e} -- training continues')
+      tracker = type('NoTracker', (), {'active': False, '__getattr__': lambda self, name: lambda *a, **k: None})()
+  ```
 - **Worked example — how a project wires it up:** `experiments/ffn_replacement/tools/` on
   `research/ffn_replacement_fix`. `wandb_tracking.py` is a thin shim: it pre-binds project and group,
   the LUT tags, `learned_confidence_by_layer` as `extra_eval_metrics`, `metric_glossary` and an
@@ -184,8 +218,8 @@ Derive the GitHub URL from `git remote get-url origin` (an ssh host alias such a
 `git@github-<alias>:<owner>/<repo>.git` maps to `https://github.com/<owner>/<repo>`), and the
 server URL and entity from the environment — never hard-code either.
 
-**Metric glossary.** Keep one dict in code next to the tracker: logged key (or a per-layer
-pattern such as `ln2_norm_L{i}`) → unit, a full description **written from the code that
+**Metric glossary.** Keep one dict in code next to the tracker — a `DictGlossary` (section 3): logged key
+(or a per-layer pattern such as `ln2_norm_L{i}`) → unit, a full description **written from the code that
 computes it** (reduction, which tokens count, cadence, running mean vs instantaneous, the
 exact eval protocol, normalisation), and a one-sentence short form. Surface it where people
 look — the charts:
@@ -199,7 +233,8 @@ look — the charts:
   afterwards, and fail loudly if it is not there;
 - a per-run **glossary artifact** with the full descriptions (a `wandb.Table` of key |
   description | unit, logged with `log_artifact` only); identical content dedups to one version;
-- a pointer to both in every run's notes.
+- in every run's notes, a pointer to its glossary artifact, and — when the tracker is told where the panel was
+  published (`glossary_panel`, section 3) — a link to that panel.
 
 Make drift detectable, never fatal: the tracker flags a logged key with no entry (one
 printed line, a tag, a summary field listing the keys); a read-only audit lists undocumented

--- a/src/spiky/util/wandb_integration/backfill.py
+++ b/src/spiky/util/wandb_integration/backfill.py
@@ -8,7 +8,8 @@ which column marks a complete row, what "complete" means, description overrides)
     from spiky.util.wandb_integration import backfill as B
     B.backfill_run(run_dir, project='P', group='family', branch='research/x', host='gpustar', tags=['line:a'],
                    config_extra={'total_params': 123}, summary_keys=('final_val_loss',), require_col='val_loss',
-                   is_complete=lambda rows, cfg: (rows[-1][0] == cfg['n_steps'], 'last step'), mode='offline')
+                   is_complete=lambda rows, cfg: (rows[-1][0] == cfg['n_steps'], 'last step'), mode='offline',
+                   glossary_panel='P — described')
     B.update_notes(api, entity, 'P', {'exp_1': '/path/to/exp_1'}, descriptions={'exp_1': '...'}, dry_run=True)
 
 backfill_run: same organisation as the live tracker (tracker.py / claude/wandb.md): name = id = cfg exp_name (else
@@ -22,14 +23,20 @@ sends one upsertBucket(id, notes) per run: no config, tags, summary or history i
 artifact is attached. (Run.update() would re-send config, tags and summary.) Backfilled runs (tag "backfilled") link
 to their artefacts commit and say that wandb's Git state shows the HEAD at backfill time; live runs link to their
 launch commit. dry_run prints the notes and writes nothing.
+
+The notes' link to a published glossary panel is explicit, as in Tracker.start: glossary_panel = the title of the
+shared saved view it was published into, or tracker.PERSONAL_WORKSPACE; panel_title names it (default "About these
+metrics"). For compatibility, panel_title given WITHOUT glossary_panel keeps the earlier behaviour: a link to the
+personal workspace.
 """
 import csv
 import json
 import os
 import socket
 
-from spiky.util.wandb_integration.tracker import (_git, github_web_url, gql, normalise_host, run_notes, wandb_config,
-                                                  with_committed_flag, workspace_url)
+from spiky.util.wandb_integration.glossary import DEFAULT_TITLE
+from spiky.util.wandb_integration.tracker import (PERSONAL_WORKSPACE, _git, github_web_url, gql, normalise_host,
+                                                  panel_link, run_notes, wandb_config, with_committed_flag)
 
 _SET_NOTES = 'mutation($id: String!, $notes: String){ upsertBucket(input: {id: $id, notes: $notes}){ bucket { id } } }'
 _GET_NOTES = 'query($e: String!, $p: String!, $r: String!){ project(entityName: $e, name: $p){ run(name: $r){ notes } } }'
@@ -48,8 +55,9 @@ def read_metrics(run_dir, step_col='step', require_col=None):
 
 
 def backfill_notes(cfg, *, name, run_dir, commit, branch, host, backfilled, dirty, shown_git_commit, workspace=None,
-                   panel_title=None, description=None):
-    """Markdown notes for a run recorded in run_dir (links resolved in the checkout that holds run_dir)."""
+                   panel_title=None, description=None, panel_where=None):
+    """Markdown notes for a run recorded in run_dir (links resolved in the checkout that holds run_dir). workspace /
+    panel_title / panel_where: the glossary panel link, if any (see panel_link)."""
     root = _git(['rev-parse', '--show-toplevel'], os.path.abspath(run_dir))
     root = None if root in ('', 'unknown') else root
     sha = _git(['rev-parse', '--verify', '--quiet', f'{commit}^{{commit}}'], root) if commit and root else 'unknown'
@@ -67,9 +75,17 @@ def backfill_notes(cfg, *, name, run_dir, commit, branch, host, backfilled, dirt
                          f"when the backfill ran, not this run's commit. Its artefacts commit is `{sha[:8]}` (linked "
                          f'above).')
     return run_notes(cfg, exp_name=name, info=info, host=host, workspace_url=workspace, panel_title=panel_title,
-                     description=description,
+                     panel_where=panel_where, description=description,
                      code_label='Code + artefacts (artefacts commit)' if backfilled else 'Code at launch',
                      extra_lines=extra)
+
+
+def _panel(base, entity, project, panel_title, glossary_panel):
+    """(url, title, where) of the notes' glossary-panel link, or Nones. panel_title alone: the personal workspace."""
+    if glossary_panel is None and panel_title:
+        glossary_panel = PERSONAL_WORKSPACE
+    url, where = panel_link(base, entity, project, glossary_panel)
+    return url, ((panel_title or DEFAULT_TITLE) if url else None), where
 
 
 def _base(require_entity=False):
@@ -83,7 +99,7 @@ def _base(require_entity=False):
 
 def backfill_run(run_dir, *, project, entity=None, group=None, branch=None, host=None, name=None, tags=(),
                  config_extra=None, config_renames=None, summary_keys=(), step_col='step', require_col=None,
-                 is_complete=None, mode='offline', description=None, panel_title=None, wandb=None):
+                 is_complete=None, mode='offline', description=None, panel_title=None, glossary_panel=None, wandb=None):
     """Upload one finished run (see the module docstring). Returns the local wandb run folder, or None if refused."""
     if mode not in ('online', 'offline'):
         raise ValueError(f'mode must be online or offline, got {mode!r}')
@@ -107,10 +123,10 @@ def backfill_run(run_dir, *, project, entity=None, group=None, branch=None, host
                                     backfill_source='metrics.csv + summary.json' if summ else 'metrics.csv',
                                     **(config_extra or {})), renames=config_renames)
     all_tags = [t for t in ['backfilled', group, branch, commit, host] + list(tags) if t and t != 'unknown']
+    url, title, where = _panel(base, entity, project, panel_title, glossary_panel)
     notes = backfill_notes(cfg, name=name, run_dir=rd, commit=commit, branch=branch, host=host, backfilled=True,
-                           dirty=None, shown_git_commit=_git(['rev-parse', 'HEAD'], rd),
-                           workspace=workspace_url(base, entity, project) if panel_title else None,
-                           panel_title=panel_title, description=description)
+                           dirty=None, shown_git_commit=_git(['rev-parse', 'HEAD'], rd), workspace=url,
+                           panel_title=title, panel_where=where, description=description)
     run = wandb.init(project=project, entity=entity, group=group, job_type='train',
                      name=name, id=name, resume='allow', tags=all_tags, config=config, mode=mode,
                      dir=os.environ.get('WANDB_DIR', os.path.expanduser('~/.cache/wandb')), notes=notes,
@@ -133,10 +149,10 @@ def set_notes(api, entity, project, run, notes):
     return back == notes
 
 
-def update_notes(api, entity, project, runs, *, descriptions=None, panel_title=None, dry_run=False):
+def update_notes(api, entity, project, runs, *, descriptions=None, panel_title=None, glossary_panel=None, dry_run=False):
     """Rewrite the notes of the runs {name: run_dir} already in entity/project (see the module docstring)."""
     base = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/')
-    ws = workspace_url(base, entity, project) if panel_title else None
+    url, title, where = _panel(base, entity, project, panel_title, glossary_panel)
     results = {}
     for name, run_dir in runs.items():
         cfg = json.load(open(os.path.join(run_dir, 'config.json')))
@@ -145,8 +161,8 @@ def update_notes(api, entity, project, runs, *, descriptions=None, panel_title=N
         notes = backfill_notes(cfg, name=name, run_dir=run_dir, commit=conf.get('commit'), branch=conf.get('branch'),
                                host=normalise_host(conf.get('host')), backfilled=backfilled,
                                dirty=None if backfilled else conf.get('commit_dirty'),
-                               shown_git_commit=((r.metadata or {}).get('git') or {}).get('commit'), workspace=ws,
-                               panel_title=panel_title, description=(descriptions or {}).get(name))
+                               shown_git_commit=((r.metadata or {}).get('git') or {}).get('commit'), workspace=url,
+                               panel_title=title, panel_where=where, description=(descriptions or {}).get(name))
         if dry_run:
             print(f'===== {name} ({"backfilled" if backfilled else "live"})\n{notes}\n')
             results[name] = notes

--- a/src/spiky/util/wandb_integration/glossary.py
+++ b/src/spiky/util/wandb_integration/glossary.py
@@ -1,8 +1,25 @@
-"""The metric-glossary protocol: what tracker.py and workspace.py need from an injected glossary.
+"""Metric glossaries for spiky.util.wandb_integration: DictGlossary (the default path) and the protocol it implements.
 
-A glossary says what every logged key measures. This package never imports one. Callers pass an object -- a plain
-module works, as long as it has these names -- to Tracker.start(glossary=...) (optional) and to the workspace
-publish / verify / audit commands (required):
+A glossary says what every logged key measures. This package never imports one. Callers pass it to
+Tracker.start(glossary=...) (optional: the drift check and the per-run glossary artifact) and to the workspace
+publish / verify / audit commands (required).
+
+DEFAULT PATH -- DictGlossary: the project supplies the data, the class supplies the whole protocol.
+
+    from spiky.util.wandb_integration.glossary import DictGlossary
+
+    GLOSSARY = DictGlossary({
+        'train/loss':    dict(unit='nats/token', section='train', desc='Cross-entropy of the step, ...', short='Step CE.'),
+        'ln2_norm_L{i}': dict(unit='L2 norm', section='per layer', desc="L2 norm of block i's ln2 gain."),
+    }, sections={'train': 'Training', 'per layer': 'Per layer ({i} = layer index)'},
+       source='experiments/<family>/<this file>.py')
+
+  Per entry: `unit` and `desc` (the full definition, written from the code) are required; `short` (the one-line panel
+  form, default desc) and `section` (default "metrics") are optional; any other field is an error, because nothing
+  reads it. A key containing {i} documents that key with any non-negative integer in place of {i}. See DictGlossary.
+
+ESCAPE HATCH -- any object with these names (a plain module works), when data alone is not enough (a panel laid out
+differently, two-tier config notes, ...):
 
     PANEL_TITLE: str                      title of the workspace section and its Markdown Panel, e.g. "About these metrics"
     SOURCE: str                           OPTIONAL: where the glossary is defined; shown in messages and artifact metadata
@@ -18,15 +35,22 @@ publish / verify / audit commands (required):
 Who uses what: the tracker's drift check uses undocumented(); its per-run artifact uses glossary_hash() and table_rows();
 publish / verify use PANEL_TITLE, panel_markdown() and glossary_hash(); audit uses undocumented(), stale() and
 glossary_hash().
+
+A glossary never decides whether a run's notes link to a published panel: that is Tracker.start(glossary_panel=...),
+set explicitly. PANEL_TITLE only names the panel publish writes.
 """
+import hashlib
 import importlib
 import importlib.util
+import json
 import os
+import re
 from typing import Iterable, List, Protocol
 
 TRACKER_NEEDS = ('undocumented', 'glossary_hash', 'table_rows')
 PUBLISH_NEEDS = ('PANEL_TITLE', 'panel_markdown', 'glossary_hash')
 AUDIT_NEEDS = ('undocumented', 'stale', 'glossary_hash')
+DEFAULT_TITLE = 'About these metrics'
 
 
 class Glossary(Protocol):                                                    # documentation; nothing checks against it
@@ -41,6 +65,107 @@ class Glossary(Protocol):                                                    # d
     def panel_markdown(self) -> str: ...
 
     def stale(self, seen_keys: Iterable[str]) -> List[str]: ...
+
+
+_MD_CELL = re.compile(r'([\\`*_\[\]|])')                # not < >: some wandb markdown renderers show "\<" literally
+
+
+def _cell(text):
+    """Literal text inside a markdown table cell (an underscore in a name such as clip_grad_norm_ would italicise)."""
+    return _MD_CELL.sub(r'\\\1', text).replace('\n', ' ')
+
+
+class DictGlossary:
+    """The reference glossary: {key: fields} in, the whole protocol out.
+
+    metrics    {key: dict(unit=..., desc=..., short=..., section=...)}; unit and desc required. A key containing {i}
+               matches that key with any non-negative integer in place of {i} (per-layer keys: 'ln2_norm_L{i}').
+    title      PANEL_TITLE, the published section's name (default "About these metrics").
+    sections   {section: panel heading}, in panel order. Given: only these sections are shown in the panel (entries in
+               other sections are still documented and still in the artifact, e.g. columns that exist only in a local
+               metrics file). Omitted: every section is shown, in first-seen order, headed by its own name.
+    notes      optional {name: text}: a bullet list at the bottom of the panel (under notes_title) and `note: <name>`
+               rows in the artifact -- e.g. config keys whose meaning is not what the name suggests.
+    source     SOURCE: where this glossary is defined (shown in drift messages, the panel and the artifact metadata).
+
+    Keys wandb owns (a leading underscore, system/*) count as documented.
+    """
+
+    FIELDS = ('unit', 'desc', 'short', 'section')
+
+    def __init__(self, metrics, *, title=DEFAULT_TITLE, sections=None, notes=None, source=None, notes_title='Notes'):
+        entries = {}
+        for key, fields in metrics.items():
+            unknown = sorted(set(fields) - set(self.FIELDS))
+            if unknown:
+                raise ValueError(f'glossary entry {key!r}: unknown field(s) {unknown}; allowed: {list(self.FIELDS)}')
+            for req in ('unit', 'desc'):
+                if not isinstance(fields.get(req), str) or not fields[req].strip():
+                    raise ValueError(f'glossary entry {key!r}: {req!r} must be a non-empty string')
+            entries[key] = dict(unit=fields['unit'], desc=fields['desc'], short=fields.get('short') or fields['desc'],
+                                section=fields.get('section') or 'metrics')
+        self.METRICS = entries
+        seen = list(dict.fromkeys(e['section'] for e in entries.values()))
+        self.SECTIONS = dict(sections) if sections is not None else {s: s for s in seen}
+        self._order = list(self.SECTIONS) + [s for s in seen if s not in self.SECTIONS]
+        self.NOTES = dict(notes or {})
+        self.PANEL_TITLE, self.SOURCE, self.NOTES_TITLE = title, source, notes_title
+        self._patterns = [(re.compile('^' + re.escape(k).replace(re.escape('{i}'), r'\d+') + '$'), k)
+                          for k in entries if '{i}' in k]
+
+    def entry_key(self, key):
+        """The entry (exact key or {i} pattern) that documents `key`, or None."""
+        if key in self.METRICS:
+            return key
+        for rx, k in self._patterns:
+            if rx.match(key):
+                return k
+        return None
+
+    def lookup(self, key):
+        """The entry's fields for `key` (unit, desc, short, section), or None."""
+        k = self.entry_key(key)
+        return None if k is None else dict(self.METRICS[k])
+
+    def is_documented(self, key):
+        return key.startswith('_') or key.startswith('system/') or self.entry_key(key) is not None
+
+    def undocumented(self, keys):
+        return sorted({k for k in keys if not self.is_documented(k)})
+
+    def stale(self, seen_keys):
+        hit = {self.entry_key(k) for k in seen_keys}
+        return sorted(k for k in self.METRICS if k not in hit)
+
+    def glossary_hash(self):
+        blob = json.dumps({'metrics': self.METRICS, 'sections': self.SECTIONS, 'notes': self.NOTES}, sort_keys=True,
+                          ensure_ascii=True)
+        return hashlib.sha256(blob.encode()).hexdigest()[:12]
+
+    def _sorted_entries(self):
+        return sorted(self.METRICS.items(), key=lambda kv: (self._order.index(kv[1]['section']), kv[0]))
+
+    def table_rows(self):
+        rows = [[k, e['desc'], e['unit']] for k, e in self._sorted_entries()]
+        return rows + [[f'note: {k}', v, '-'] for k, v in self.NOTES.items()]
+
+    def panel_markdown(self):
+        intro = f'One line per logged key (glossary `{self.glossary_hash()}`'
+        intro += (f', from `{self.SOURCE}`' if self.SOURCE else '') + "). Full definitions: the run's `metric_glossary` "
+        intro += 'artifact (Artifacts tab).'
+        out = [f'### {self.PANEL_TITLE}', '', intro, '']
+        for section, heading in self.SECTIONS.items():
+            items = [(k, e) for k, e in self._sorted_entries() if e['section'] == section]
+            if not items:
+                continue
+            out += [f'**{heading}**', '', '| key | unit | what it measures |', '|---|---|---|']
+            out += [f'| `{k}` | {_cell(e["unit"])} | {_cell(e["short"])} |' for k, e in items]
+            out.append('')
+        if self.NOTES:
+            out += [f'**{self.NOTES_TITLE}**', '']
+            out += [f'- `{k}`: {_cell(v)}' for k, v in self.NOTES.items()]
+            out.append('')
+        return '\n'.join(out)
 
 
 def missing(glossary, needs):
@@ -59,7 +184,13 @@ def require(glossary, needs, what):
 
 
 def load(spec):
-    """A glossary from a .py file path or an importable module name (for the workspace command line)."""
+    """A glossary from a .py file path or an importable module name, optionally `:ATTRIBUTE` (for the workspace command
+    line). Without an attribute: the module's GLOSSARY if it has one (e.g. a DictGlossary), else the module itself."""
+    head, sep, attr = spec.rpartition(':')
+    if sep and attr.isidentifier():
+        spec = head
+    else:
+        attr = ''
     if spec.endswith('.py') or os.sep in spec:
         path = os.path.abspath(spec)
         mod_spec = importlib.util.spec_from_file_location(os.path.splitext(os.path.basename(path))[0], path)
@@ -67,5 +198,8 @@ def load(spec):
             raise ImportError(f'cannot load a glossary from {spec!r}')
         mod = importlib.util.module_from_spec(mod_spec)
         mod_spec.loader.exec_module(mod)
-        return mod
-    return importlib.import_module(spec)
+    else:
+        mod = importlib.import_module(spec)
+    if attr:
+        return getattr(mod, attr)
+    return getattr(mod, 'GLOSSARY', mod)

--- a/src/spiky/util/wandb_integration/tests/test_wandb_glossary.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_glossary.py
@@ -1,0 +1,120 @@
+"""DictGlossary, the reference glossary: data in, the whole protocol out ({i} per-layer patterns included), and
+glossary.load for the workspace command line. CPU only, no server, no project content."""
+import re
+
+import pytest
+
+from spiky.util.wandb_integration import glossary as G
+from spiky.util.wandb_integration import workspace as W
+
+METRICS = {
+    'train/loss': dict(unit='nats', section='train', desc='Cross-entropy of the step, mean over positions.',
+                       short='Step CE.'),
+    'train/lr': dict(unit='lr', section='train', desc='Learning rate of the step.'),
+    'val_bpb': dict(unit='bits/byte', section='eval', desc='Bits per byte on the validation window.',
+                    short='Val bpb | bytes_weighted'),
+    'ln2_norm_L{i}': dict(unit='L2', section='per layer', desc="L2 norm of block i's ln2 gain."),
+    'step': dict(unit='step', section='csv', desc='metrics.csv row step; not a wandb key.'),
+}
+SECTIONS = {'train': 'Training', 'eval': 'Evaluation', 'per layer': 'Per layer ({i} = layer index)'}
+
+
+def _g(**kw):
+    return G.DictGlossary(METRICS, sections=SECTIONS, source='tests/example.py', **kw)
+
+
+def test_satisfies_the_whole_protocol():
+    g = _g()
+    assert G.missing(g, G.TRACKER_NEEDS + G.PUBLISH_NEEDS + G.AUDIT_NEEDS) == []
+    assert g.PANEL_TITLE == G.DEFAULT_TITLE and g.SOURCE == 'tests/example.py'
+    assert G.DictGlossary(METRICS, title='Custom').PANEL_TITLE == 'Custom'
+
+
+def test_lookup_undocumented_and_layer_patterns():
+    g = _g()
+    assert g.entry_key('ln2_norm_L0') == g.entry_key('ln2_norm_L11') == 'ln2_norm_L{i}'
+    for k in ('ln2_norm_Lx', 'ln2_norm_L', 'xln2_norm_L0', 'ln2_norm_L0_extra'):
+        assert g.entry_key(k) is None, k
+    assert g.lookup('ln2_norm_L3') == dict(unit='L2', desc="L2 norm of block i's ln2 gain.",
+                                           short="L2 norm of block i's ln2 gain.", section='per layer')
+    assert g.lookup('train/lr')['short'] == 'Learning rate of the step.' and g.lookup('nope') is None
+    assert g.undocumented(['val_bpb', 'brand/new', 'ln2_norm_L3', '_step', 'system/gpu.0.gpu', 'brand/new']) == ['brand/new']
+    assert G.DictGlossary({'k': dict(unit='u', desc='d')}).lookup('k')['section'] == 'metrics'
+
+
+def test_stale():
+    assert _g().stale(['train/loss', 'train/lr', 'val_bpb', 'ln2_norm_L0', 'ln2_norm_L5']) == ['step']
+    assert _g().stale([]) == sorted(METRICS)
+
+
+def test_hash_is_stable_and_content_sensitive():
+    h = _g().glossary_hash()
+    assert h == _g().glossary_hash() and len(h) == 12
+    assert _g(notes={'eval_steps': 'legacy'}).glossary_hash() != h
+    edited = dict(METRICS, val_bpb=dict(METRICS['val_bpb'], desc='Something else.'))
+    assert G.DictGlossary(edited, sections=SECTIONS, source='tests/example.py').glossary_hash() != h
+    assert G.DictGlossary(METRICS, sections=SECTIONS, source='elsewhere.py').glossary_hash() == h   # content only
+
+
+def test_table_rows_follow_section_order_then_notes():
+    rows = _g(notes={'eval_steps': 'legacy, ignored'}).table_rows()
+    assert [r[0] for r in rows] == ['train/loss', 'train/lr', 'val_bpb', 'ln2_norm_L{i}', 'step', 'note: eval_steps']
+    assert rows[0] == ['train/loss', 'Cross-entropy of the step, mean over positions.', 'nats']
+    assert rows[-1] == ['note: eval_steps', 'legacy, ignored', '-'] and all(len(r) == 3 for r in rows)
+
+
+def test_panel_markdown_is_content_only_grouped_and_escaped():
+    g = _g(notes={'eval_steps': 'legacy_ignored'})
+    md = g.panel_markdown()
+    assert md.startswith(f'### {G.DEFAULT_TITLE}\n') and md == _g(notes={'eval_steps': 'legacy_ignored'}).panel_markdown()
+    assert g.glossary_hash() in md and '`tests/example.py`' in md
+    heads = [md.index(h) for h in ('**Training**', '**Evaluation**', '**Per layer ({i} = layer index)**', '**Notes**')]
+    assert heads == sorted(heads)
+    assert '| `step` |' not in md                              # its section is not in `sections`: documented, not shown
+    assert '| `train/lr` | lr | Learning rate of the step. |' in md                        # short defaults to desc
+    assert '| `val_bpb` | bits/byte | Val bpb \\| bytes\\_weighted |' in md
+    assert '- `eval_steps`: legacy\\_ignored' in md
+    for line in md.splitlines():                                    # escaping never breaks the table
+        if line.startswith('| `'):
+            assert len(re.split(r'(?<!\\)\|', line)) == 5, line
+
+
+def test_sections_default_to_first_seen_order():
+    g = G.DictGlossary({'b': dict(unit='u', desc='B.', section='second'), 'a': dict(unit='u', desc='A.', section='first'),
+                        'c': dict(unit='u', desc='C.')})
+    md = g.panel_markdown()
+    assert md.index('**second**') < md.index('**first**') < md.index('**metrics**')
+    assert [r[0] for r in g.table_rows()] == ['b', 'a', 'c']
+
+
+def test_bad_entries_are_rejected():
+    with pytest.raises(ValueError, match="unknown field"):
+        G.DictGlossary({'k': dict(unit='u', desc='d', descr='typo')})
+    with pytest.raises(ValueError, match="'desc' must be"):
+        G.DictGlossary({'k': dict(unit='u')})
+    with pytest.raises(ValueError, match="'unit' must be"):
+        G.DictGlossary({'k': dict(desc='d', unit='')})
+
+
+def test_a_dict_glossary_publishes_and_verifies(capsys, monkeypatch):
+    g = _g()
+    monkeypatch.delenv('WANDB_BASE_URL', raising=False)
+    assert W.main(['publish', '--dry-run', '--project', 'P'], glossary=g) == 0
+    assert capsys.readouterr().out.startswith(g.panel_markdown())
+    spec = W.apply_section({'section': {'panelBankConfig': {'sections': []}}},
+                           W.glossary_section(g.panel_markdown(), g.PANEL_TITLE))
+    assert W.section_state(spec, g.panel_markdown(), g.PANEL_TITLE) == (True, 'present, first, current')
+    stale = _g(notes={'k': 'changed'})
+    assert W.section_state(spec, stale.panel_markdown(), stale.PANEL_TITLE)[0] is False
+
+
+def test_load_returns_a_modules_GLOSSARY_or_a_named_attribute(tmp_path):
+    p = tmp_path / 'proj_glossary.py'
+    p.write_text("from spiky.util.wandb_integration.glossary import DictGlossary\n"
+                 "GLOSSARY = DictGlossary({'k': dict(unit='u', desc='d')}, title='T')\n"
+                 "OTHER = DictGlossary({'j': dict(unit='u', desc='d')})\n")
+    assert isinstance(G.load(str(p)), G.DictGlossary) and G.load(str(p)).PANEL_TITLE == 'T'
+    assert G.load(f'{p}:OTHER').entry_key('j') == 'j'
+    plain = tmp_path / 'plain_glossary.py'
+    plain.write_text("PANEL_TITLE = 'P'\n")
+    assert G.load(str(plain)).PANEL_TITLE == 'P'

--- a/src/spiky/util/wandb_integration/tests/test_wandb_notes_link_and_null.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_notes_link_and_null.py
@@ -1,0 +1,119 @@
+"""The notes' glossary-panel link is explicit (glossary_panel), the shipped NullTracker, and the documented import guard
+for this package failing to import. CPU only, no server (a fake wandb module)."""
+import sys
+import types
+
+import pytest
+
+from spiky.util.wandb_integration import backfill as B
+from spiky.util.wandb_integration import glossary as G
+from spiky.util.wandb_integration import tracker as T
+
+URL = 'http://wandb.invalid:8080'
+
+
+def _start(monkeypatch, tmp_path, fake_wandb, **kw):
+    monkeypatch.setenv('WANDB_BASE_URL', URL)
+    monkeypatch.setenv('WANDB_MODE', 'offline')
+    monkeypatch.setenv('WANDB_ENTITY', 'ent')
+    t = T.Tracker.start({'description': 'D.'}, str(tmp_path), project='Proj', **kw)
+    return t, fake_wandb.runs[-1]
+
+
+def test_a_publishable_glossary_adds_no_panel_link_unless_asked(monkeypatch, tmp_path, fake_wandb, glossary):
+    assert G.missing(glossary, G.PUBLISH_NEEDS) == []                     # publishable, PANEL_TITLE and all
+    t, run = _start(monkeypatch, tmp_path, fake_wandb, glossary=glossary)
+    assert 'at the top of the' not in run.notes and 'artifact [metric\\_glossary:' in run.notes
+    t.finish()
+
+
+def test_panel_link_to_a_shared_saved_view(monkeypatch, tmp_path, fake_wandb, glossary):
+    t, run = _start(monkeypatch, tmp_path, fake_wandb, glossary=glossary, glossary_panel='Proj — described')
+    assert (f'"About these metrics" at the top of the [saved view "Proj — described"]({URL}/ent/Proj?nw=projdescribed)'
+            in run.notes)
+    t.finish()
+
+
+def test_panel_link_to_the_personal_workspace(monkeypatch, tmp_path, fake_wandb, glossary):
+    t, run = _start(monkeypatch, tmp_path, fake_wandb, glossary=glossary, glossary_panel=T.PERSONAL_WORKSPACE)
+    assert f'"About these metrics" at the top of the [project workspace]({URL}/ent/Proj/workspace)' in run.notes
+    t.finish()
+
+
+def test_panel_link_without_a_glossary_uses_the_default_title(monkeypatch, tmp_path, fake_wandb):
+    t, run = _start(monkeypatch, tmp_path, fake_wandb, glossary_panel='V')
+    assert f'"{G.DEFAULT_TITLE}" at the top of the [saved view "V"]({URL}/ent/Proj?nw=v)' in run.notes
+    assert run.artifacts == [] and 'artifact' not in run.notes
+    t.finish()
+
+
+def test_a_bad_glossary_panel_is_reported_not_raised(monkeypatch, capsys, tmp_path, fake_wandb, glossary):
+    t, run = _start(monkeypatch, tmp_path, fake_wandb, glossary=glossary, glossary_panel=42)
+    assert t.active and 'glossary_panel ignored' in capsys.readouterr().out
+    assert 'at the top of the' not in run.notes and 'artifact [metric\\_glossary:' in run.notes
+    t.finish()
+
+
+def test_panel_link_helper():
+    assert T.panel_link('http://h/', 'e', 'p', None) == (None, None)
+    assert T.panel_link('http://h/', 'e', 'p', T.PERSONAL_WORKSPACE) == ('http://h/e/p/workspace', 'project workspace')
+    assert T.panel_link('http://h', 'e', 'p', 'P — described') == ('http://h/e/p?nw=pdescribed', 'saved view "P — described"')
+    assert T.panel_link('', 'e', 'p', 'V') == (None, None) and T.panel_link('http://h', None, 'p', T.PERSONAL_WORKSPACE) == (None, None)
+    with pytest.raises(ValueError):
+        T.panel_link('http://h', 'e', 'p', 3)
+    with pytest.raises(ValueError):
+        T.panel_link('http://h', 'e', 'p', '— —')
+    assert T.shared_view_name('P — described') == 'nw-pdescribed-v'
+
+
+def test_backfill_panel_link_is_explicit_and_panel_title_alone_keeps_the_workspace_link():
+    assert B._panel('http://h', 'e', 'p', None, None) == (None, None, None)
+    assert B._panel('http://h', 'e', 'p', 'Title', None) == ('http://h/e/p/workspace', 'Title', 'project workspace')
+    assert B._panel('http://h', 'e', 'p', None, 'V') == ('http://h/e/p?nw=v', G.DEFAULT_TITLE, 'saved view "V"')
+    assert B._panel('http://h', 'e', 'p', 'Title', 'V') == ('http://h/e/p?nw=v', 'Title', 'saved view "V"')
+    url, title, where = B._panel('http://h', 'e', 'p', None, 'V')
+    md = B.backfill_notes({'description': 'D.'}, name='e', run_dir='/tmp', commit=None, branch=None, host='h',
+                          backfilled=True, dirty=None, shown_git_commit=None, workspace=url, panel_title=title,
+                          panel_where=where)
+    assert f'"{G.DEFAULT_TITLE}" at the top of the [saved view "V"](http://h/e/p?nw=v)' in md
+
+
+def test_null_tracker_has_the_tracker_surface_and_does_nothing():
+    n = T.NullTracker('rank 1')
+    assert not n.active and n.mode is None and n.dropped == 0 and n.reason == 'rank 1' and n.undocumented == []
+    assert n.train_step(1, {'x': 1.0}) is None and n.eval_step(1, {'y': 1.0}, model=object()) is None
+    assert n.log({'z': 1.0}, 1) is None and n.finish({'s': 1.0}) is None
+    public = {m for m in dir(T.Tracker) if not m.startswith('_')} - {'start'}
+    assert public <= set(dir(n)), public - set(dir(n))
+
+
+def _my_glossary_module(monkeypatch):
+    """The `my_glossary` module IMPORT_GUARD imports: a DictGlossary, as a project would define it."""
+    mod = types.ModuleType('my_glossary')
+    mod.GLOSSARY = G.DictGlossary({'train/loss': dict(unit='nats', desc='Step loss.')})
+    monkeypatch.setitem(sys.modules, 'my_glossary', mod)
+    return mod
+
+
+@pytest.mark.parametrize('blocked', ['spiky.util.wandb_integration.tracker', 'my_glossary'])
+def test_import_guard_survives_this_package_being_unimportable(monkeypatch, capsys, blocked):
+    _my_glossary_module(monkeypatch)
+    monkeypatch.setitem(sys.modules, blocked, None)                          # that import now raises
+    ns = dict(cfg={}, exp_dir='/tmp', PROJECT='P', GROUP='g')
+    exec(T.IMPORT_GUARD, ns)
+    tracker = ns['tracker']
+    assert not tracker.active and '[wandb] off: ModuleNotFoundError' in capsys.readouterr().out
+    assert tracker.train_step(1, {'a': 1.0}) is None and tracker.eval_step(1, {}, None) is None
+    assert tracker.log({'b': 1.0}, 2) is None and tracker.finish({}) is None
+
+
+def test_import_guard_uses_the_real_tracker_when_importable(monkeypatch, fake_wandb, tmp_path):
+    mod = _my_glossary_module(monkeypatch)
+    monkeypatch.setenv('WANDB_BASE_URL', URL)
+    monkeypatch.setenv('WANDB_MODE', 'offline')
+    ns = dict(cfg={}, exp_dir=str(tmp_path), PROJECT='P', GROUP='g')
+    exec(T.IMPORT_GUARD, ns)
+    tracker = ns['tracker']
+    assert isinstance(tracker, T.Tracker) and tracker.active and tracker.glossary is mod.GLOSSARY
+    assert fake_wandb.runs[0].init['project'] == 'P'
+    tracker.finish()

--- a/src/spiky/util/wandb_integration/tests/test_wandb_tracker.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_tracker.py
@@ -171,7 +171,8 @@ def test_start_wires_the_injected_project_group_tags_config_metrics_and_glossary
     assert aliases == ['latest', f'glossary-{glossary.glossary_hash()}']
     assert art.files['glossary'].data == glossary.table_rows() and art.metadata['source'] == glossary.SOURCE
     assert 'Tests a thing.' in run.notes
-    assert '"About these metrics" at the top of the [project workspace](http://wandb.invalid:8080/ent/Throwaway/workspace)' in run.notes
+    assert f'artifact [metric\\_glossary:glossary-{glossary.glossary_hash()}]' in run.notes
+    assert 'at the top of the' not in run.notes                  # no panel link unless glossary_panel asks for one
     t.eval_step(2, {'val/loss': 1.0}, model=object())
     t.finish({'final_loss': 1.0})
     assert run.logged == [(2, {'val/loss': 1.0, 'norm_L0': 1.0})] and run.summary == {'final_loss': 1.0}

--- a/src/spiky/util/wandb_integration/tracker.py
+++ b/src/spiky/util/wandb_integration/tracker.py
@@ -2,7 +2,8 @@
 
     from spiky.util.wandb_integration.tracker import Tracker
     tracker = Tracker.start(cfg, exp_dir, project=..., group=..., glossary=None,          # after the model is built
-                            extra_tags=None, extra_eval_metrics=None, config_extra=None, config_renames=None)
+                            extra_tags=None, extra_eval_metrics=None, config_extra=None, config_renames=None,
+                            glossary_panel=None)
     tracker.train_step(step, {'train/loss': loss, 'train/lr': lr})   # once per optimiser step (logged every log_every)
     tracker.eval_step(step, {'val/loss': val}, model)                 # at each eval, after the local record is written
     tracker.finish(summary)                                           # at the end, after summary/checkpoint are written
@@ -13,7 +14,11 @@ WHAT IS INJECTED -- the tracker holds no project knowledge:
   * which keys are logged: the caller's row dicts. The tracker adds only TIMING_KEY (time/sec_per_step) to train rows.
   * tags: `tags` plus extra_tags(cfg) -> iterable. Per-eval metrics read off the model: extra_eval_metrics(model) -> dict.
   * config: the run config minus NOTES_CONFIG_KEYS, with config_renames {old: new} applied, plus config_extra.
-  * glossary (optional): see glossary.py. It drives the drift check, the per-run glossary artifact and the notes pointer.
+  * glossary (optional): a glossary.DictGlossary, or any object with the protocol in glossary.py. It drives the drift
+    check and the per-run glossary artifact.
+  * glossary_panel (optional, explicit): where the project's glossary panel is published, for a link in the notes --
+    the title of the shared saved view (as `workspace publish --shared TITLE`), or PERSONAL_WORKSPACE. None: no link.
+    It is independent of the glossary: a publishable glossary adds no link unless this says where the panel is.
 
 MODE -- ONLINE BY DEFAULT when the server is reachable:
   * WANDB_BASE_URL unset -> tracker OFF (a run can never silently go to wandb.ai); WANDB_MODE=disabled -> OFF.
@@ -43,6 +48,15 @@ GUARDS -- the tracker can never stall or break training:
   * KNOWN LIMIT: rows logged while the server is unreachable in the middle of an ONLINE run can be missing
     server-side after it comes back; the trainer's local metrics file stays complete.
 
+OPTIONAL MEANS OPTIONAL -- what this package can and cannot guarantee:
+  * Once imported, nothing here raises into the loop: Tracker.start never raises and returns an inactive tracker
+    (active False, every call a no-op) when tracking is off for any reason, wandb missing included.
+  * NullTracker is the same do-nothing surface for code paths that deliberately start no run (DDP ranks other than 0,
+    dry runs, tests).
+  * What NO code in this package can cover is the package itself failing to import (absent -- e.g. an editable
+    install pointing at a checkout that predates it -- or broken): nothing of it runs then. That guard belongs to the
+    consumer, and its fallback must be built from builtins. IMPORT_GUARD below is the pattern, as one block.
+
 ORGANISATION (claude/wandb.md section 4): name and id = cfg exp_name, else the run folder name (unique per run folder,
 so a crashed run resumes instead of duplicating); tags = group, branch, short commit, host + injected tags;
 config = the run config (minus NOTES_CONFIG_KEYS, which go into the notes) + branch, commit, commit_dirty, host
@@ -52,8 +66,8 @@ name. branch / commit describe the checkout that holds the run folder (else the 
 DESCRIPTIONS:
   * notes = run_notes(): bold exp_name, the config `description` (else the opening sentences of _arch_note),
     links to the run folder on GitHub at the launch commit and at the branch head (from `git remote get-url origin`),
-    the folder and host, with a glossary: a pointer to its panel at the top of the project workspace and to this
-    run's glossary artifact, then the full _arch_note.
+    the folder and host; with a glossary, a pointer to this run's glossary artifact; with glossary_panel, a link to the
+    published panel (the shared saved view, or the personal workspace); then the full _arch_note.
   * with a glossary: a `metric_glossary` artifact (Table key | description | unit, alias glossary-<hash>) via
     log_artifact ONLY, never into run history (a Table in history renders as a broken panel on the self-hosted
     server). Identical glossaries dedup to one artifact version.
@@ -232,9 +246,52 @@ def workspace_url(base, entity, project):
     return f'{base.rstrip("/")}/{entity}/{project}/workspace' if base and entity and project else None
 
 
+class _PersonalWorkspace:
+    def __repr__(self):
+        return 'PERSONAL_WORKSPACE'
+
+
+# glossary_panel value: the panel was published into each user's personal workspace (`publish` without --shared)
+PERSONAL_WORKSPACE = _PersonalWorkspace()
+
+
+def shared_nw_id(title):
+    """The named-workspace id of a shared saved view: the title lower-cased, letters and digits only."""
+    nwid = re.sub(r'[^a-z0-9]', '', (title or '').lower())
+    if not nwid:
+        raise ValueError(f'cannot derive a view id from {title!r}')
+    return nwid[:40]
+
+
+def shared_view_name(title):
+    return f'nw-{shared_nw_id(title)}-v'
+
+
+def saved_view_url(base, entity, project, title):
+    """The shared saved view titled `title`, opened at <server>/<entity>/<project>?nw=<id> (None without base/entity/
+    project)."""
+    return f'{base.rstrip("/")}/{entity}/{project}?nw={shared_nw_id(title)}' if base and entity and project else None
+
+
+def panel_link(base, entity, project, glossary_panel):
+    """(url, link text) of the published glossary panel, for the run notes, or (None, None).
+    glossary_panel: None -> no link; PERSONAL_WORKSPACE -> the project workspace; a string -> the shared saved view
+    with that title (as `workspace publish --shared TITLE`). ValueError for anything else."""
+    if glossary_panel is None:
+        return None, None
+    if glossary_panel is PERSONAL_WORKSPACE:
+        url = workspace_url(base, entity, project)
+        return (url, 'project workspace') if url else (None, None)
+    if isinstance(glossary_panel, str) and glossary_panel.strip():
+        url = saved_view_url(base, entity, project, glossary_panel)
+        return (url, f'saved view "{md_escape(glossary_panel)}"') if url else (None, None)
+    raise ValueError(f'glossary_panel must be None, PERSONAL_WORKSPACE or a saved view title, got {glossary_panel!r}')
+
+
 def run_notes(cfg, *, exp_name, info, host, workspace_url=None, panel_title=None, artifact_url=None,
-              artifact_label=None, description=None, code_label='Code at launch', extra_lines=()):
-    """Markdown notes for a run (rendered in the run's Overview tab)."""
+              artifact_label=None, description=None, code_label='Code at launch', extra_lines=(), panel_where=None):
+    """Markdown notes for a run (rendered in the run's Overview tab). workspace_url + panel_title (+ panel_where, the
+    link text, default "project workspace") make the glossary-panel link; see panel_link."""
     lines = [f'**{md_escape(exp_name)}**', '', md_escape(description_text(cfg, description)), '']
     web, sha, rel, branch = info.get('web'), info.get('sha'), info.get('rel'), info.get('branch')
     flags = []
@@ -254,7 +311,7 @@ def run_notes(cfg, *, exp_name, info, host, workspace_url=None, panel_title=None
         lines.append(f'- **Run folder:** `{rel}` on `{host}`')
     glossary = []
     if workspace_url and panel_title:
-        glossary.append(f'"{panel_title}" at the top of the [project workspace]({workspace_url})')
+        glossary.append(f'"{panel_title}" at the top of the [{panel_where or "project workspace"}]({workspace_url})')
     if artifact_label:                                   # wandb renders no link whose text is `code`: plain text
         glossary.append(f'artifact [{md_escape(artifact_label)}]({artifact_url})' if artifact_url
                         else f'artifact `{artifact_label}`')
@@ -368,7 +425,7 @@ class Tracker:
         except queue.Full:
             self.dropped += 1                                      # never wait on the tracker
 
-    def _describe(self, cfg, name, info, host, project, entity):
+    def _describe(self, cfg, name, info, host, project, entity, glossary_panel=None):
         """Glossary artifact + markdown notes, after init. Best-effort: a failure prints one line."""
         run, wandb, g = self.run, self._wandb, self.glossary
         base = (os.environ.get('WANDB_BASE_URL') or '').rstrip('/')
@@ -383,9 +440,14 @@ class Tracker:
             except Exception as e:
                 print(f'[wandb] glossary artifact not logged: {type(e).__name__}: {e}', flush=True)
         try:
-            run.notes = run_notes(cfg, exp_name=name, info=info, host=host,
-                                  workspace_url=workspace_url(base, entity, project) if g is not None else None,
-                                  panel_title=getattr(g, 'PANEL_TITLE', None),
+            panel_url, where = panel_link(base, entity, project, glossary_panel)
+        except Exception as e:
+            print(f'[wandb] glossary_panel ignored ({type(e).__name__}: {e}); no panel link in the notes', flush=True)
+            panel_url = where = None
+        try:
+            run.notes = run_notes(cfg, exp_name=name, info=info, host=host, workspace_url=panel_url,
+                                  panel_title=(getattr(g, 'PANEL_TITLE', None) or G.DEFAULT_TITLE) if panel_url else None,
+                                  panel_where=where,
                                   artifact_url=art_url, artifact_label=label and f'{GLOSSARY_ARTIFACT}:{label}')
         except Exception as e:
             print(f'[wandb] markdown notes not set ({type(e).__name__}: {e}); notes stay the _arch_note', flush=True)
@@ -393,7 +455,7 @@ class Tracker:
     @classmethod
     def start(cls, cfg, exp_dir, *, project=None, entity=None, group=None, job_type='train', name=None, tags=(),
               extra_tags=None, extra_eval_metrics=None, glossary=None, config_extra=None, config_renames=None,
-              code_dir=None, log_every=LOG_EVERY, timing_key=TIMING_KEY):
+              code_dir=None, log_every=LOG_EVERY, timing_key=TIMING_KEY, glossary_panel=None):
         """Start a run, or return an inactive tracker (with one line saying why). Never raises.
 
         project / entity / group   default WANDB_PROJECT / WANDB_ENTITY / WANDB_RUN_GROUP; no project -> OFF
@@ -401,7 +463,9 @@ class Tracker:
         tags                       static tags, after group / branch / commit / host
         extra_tags(cfg)            optional callable -> more tags (a failure prints one line; the run starts without them)
         extra_eval_metrics(model)  optional callable -> {key: number}, merged into eval rows that pass a model
-        glossary                   optional, see glossary.py
+        glossary                   optional: a glossary.DictGlossary or any object with the protocol in glossary.py
+        glossary_panel             optional, explicit: the shared saved view's title, or PERSONAL_WORKSPACE, where the
+                                   glossary panel is published -> a link in the notes. None (default): no link.
         config_extra / renames     merged into / renamed in the config (see wandb_config)
         code_dir                   the checkout that describes the code (see code_root)
         """
@@ -471,7 +535,7 @@ class Tracker:
             print(f'[wandb] off: init failed: {type(e).__name__}: {e} -- training continues', flush=True)
             return cls(reason='init failed')
         try:
-            tracker._describe(cfg, name, git_launch_info(exp_dir, code_dir), host, project, entity)
+            tracker._describe(cfg, name, git_launch_info(exp_dir, code_dir), host, project, entity, glossary_panel)
         except Exception as e:
             print(f'[wandb] run description skipped: {type(e).__name__}: {e}', flush=True)
         return tracker
@@ -565,3 +629,42 @@ class Tracker:
             print(f'[wandb] finished in {time.time() - t0:.1f}s{extra}'
                   + (f' (offline; sync with: wandb sync {d})' if self.mode == 'offline' else ''), flush=True)
         self.run = None
+
+
+class NullTracker:
+    """Tracks nothing: Tracker's public surface (active, mode, reason, dropped, undocumented, train_step, eval_step,
+    log, finish), every call a no-op. For code paths that deliberately start no run -- DDP ranks other than 0, dry
+    runs, tests. A consumer that can import this package never needs it for safety (Tracker.start never raises and
+    returns an inactive tracker when tracking is off); for this package failing to import, see IMPORT_GUARD."""
+    active, mode, dropped = False, None, 0
+
+    def __init__(self, reason='not started'):
+        self.reason, self.undocumented = reason, []
+
+    def train_step(self, step, row=None):
+        pass
+
+    def eval_step(self, step, row=None, model=None):
+        pass
+
+    def log(self, row, step=None):
+        pass
+
+    def finish(self, summary=None):
+        pass
+
+
+# The consumer-side guard for the one failure no code in this package can absorb: this package failing to import
+# (absent -- e.g. an editable install pointing at a checkout that predates it -- or broken). Tracker.start never raises,
+# so in practice only an import reaches the except branch; the fallback is built from builtins because nothing of this
+# package is importable there. It supports .active and calls (every method call is a no-op), nothing else. Anything
+# that itself imports this package -- a DictGlossary module included -- must be imported inside the try as well.
+IMPORT_GUARD = '''\
+try:
+    from spiky.util.wandb_integration.tracker import Tracker
+    from my_glossary import GLOSSARY  # a DictGlossary imports this package too: keep it inside the guard
+    tracker = Tracker.start(cfg, exp_dir, project=PROJECT, group=GROUP, glossary=GLOSSARY)
+except Exception as e:  # the package itself could not be imported: Tracker.start never raises
+    print(f'[wandb] off: {type(e).__name__}: {e} -- training continues')
+    tracker = type('NoTracker', (), {'active': False, '__getattr__': lambda self, name: lambda *a, **k: None})()
+'''

--- a/src/spiky/util/wandb_integration/workspace.py
+++ b/src/spiky/util/wandb_integration/workspace.py
@@ -43,7 +43,7 @@ import re
 import sys
 
 from spiky.util.wandb_integration import glossary as G
-from spiky.util.wandb_integration.tracker import gql
+from spiky.util.wandb_integration.tracker import gql, shared_nw_id, shared_view_name  # noqa: F401 (names re-exported)
 
 SECTION_ID, PANEL_ID = 'metric-glossary-section', 'metric-glossary-panel'
 # One full-width column; tall enough to show a few tables without scrolling the page (the panel scrolls inside).
@@ -95,18 +95,6 @@ def section_state(spec, markdown, title):
     if values[0] != markdown:
         return False, 'the panel text differs from the current glossary (stale or edited)'
     return True, 'present, first, current'
-
-
-def shared_nw_id(title):
-    """The named-workspace id of a shared saved view: the title lower-cased, letters and digits only."""
-    nwid = re.sub(r'[^a-z0-9]', '', (title or '').lower())
-    if not nwid:
-        raise ValueError(f'cannot derive a view id from {title!r}')
-    return nwid[:40]
-
-
-def shared_view_name(title):
-    return f'nw-{shared_nw_id(title)}-v'
 
 
 def readme(url, glossary, project, shared_title=None, intro=None):


### PR DESCRIPTION
Follow-up to #117 / #116. Setting up the W&B smoke test from a clean branch showed one theme: `spiky.util.wandb_integration` made every consumer reimplement things the package should provide. This PR fixes the three findings and updates `claude/wandb.md` to match.

## 1. `DictGlossary`: a glossary is data by default
`glossary.DictGlossary(metrics, *, title, sections, notes, source)` implements the whole protocol: `entry_key` / `lookup`, `undocumented()`, `stale()`, `glossary_hash()`, `table_rows()`, `panel_markdown()`, `PANEL_TITLE`, `SOURCE`.

- **Per key:** `unit` and `desc` (the full definition, from the code) are required; `short` (the panel line, default `desc`) and `section` (default `metrics`) are optional. These are exactly the fields the artifact and panel read. Any other field raises, so a typo can't go silently unread.
- **`{i}` per-layer patterns are supported:** `ln2_norm_L{i}` documents `ln2_norm_L0`, `ln2_norm_L11`, and so on. It's about ten lines, the same matching the research glossary uses.
- **`sections={name: heading}`** sets panel order and headings. Sections left out stay documented and in the artifact but aren't shown, e.g. columns that only exist in `metrics.csv`.
- **`notes`** adds a bullet list at the bottom of the panel and `note: <name>` rows in the artifact.
- **`glossary.load()`** (behind `workspace --glossary`) now returns a module's `GLOSSARY`, or `FILE:NAME`.
- **The protocol stays as the escape hatch.** The research `metric_glossary.py` keeps it for its two-tier config notes (full text in the artifact, a short "gotchas" form on the panel), which data alone doesn't express.

**Before / after, on the real smoke-test glossary** (`test/wandb-smoke-2k`, `experiments/wandb_smoke_test/exp_smoke_disposable_vanilla_2k/smoke_glossary.py`):
- **82 lines → 53 lines**, data only: one `DictGlossary({...}, sections={...}, source=...)`.
- Checked equivalent: the same keys, units and descriptions; identical `undocumented()` and `stale()` on the run's key set; identical artifact rows.
- It is now also publishable (it had to omit `PANEL_TITLE` before; see §3).

```python
GLOSSARY = DictGlossary({
    'train/loss': dict(section='train', unit='nats/token', desc='Training cross-entropy of that one optimiser step: ...'),
    ...
    'step': dict(section='metrics.csv', unit='step', desc='metrics.csv only: the optimiser step of the row ...'),
}, sections={'train': 'Training (step 1 and every 10th step)', 'eval': 'Evaluation (every 200 steps)',
             'summary': 'Run summary'},
   source='experiments/wandb_smoke_test/exp_smoke_disposable_vanilla_2k/smoke_glossary.py')
```

## 2. `NullTracker` and the import guard: what can and cannot be solved inside the package
- **Solved inside the package:** once imported, nothing raises into the loop. `Tracker.start` never raises and returns an inactive tracker when tracking is off, `wandb` missing included (unchanged). New `tracker.NullTracker` has Tracker's public surface with every call a no-op, for code paths that deliberately start no run (DDP ranks other than 0, dry runs, tests).
- **Not solvable inside the package:** the package *itself* failing to import, e.g. an editable install pointing at a checkout that predates it, or a broken file. None of its code runs then, so neither a `NullTracker` nor a safe factory can help. That guard belongs to the consumer, and its fallback has to be built from builtins.
- **The pattern ships as `tracker.IMPORT_GUARD`**, documented verbatim in `claude/wandb.md` and exercised by the tests:

```python
try:
    from spiky.util.wandb_integration.tracker import Tracker
    from my_glossary import GLOSSARY  # a DictGlossary imports this package too: keep it inside the guard
    tracker = Tracker.start(cfg, exp_dir, project=PROJECT, group=GROUP, glossary=GLOSSARY)
except Exception as e:  # the package itself could not be imported: Tracker.start never raises
    print(f'[wandb] off: {type(e).__name__}: {e} -- training continues')
    tracker = type('NoTracker', (), {'active': False, '__getattr__': lambda self, name: lambda *a, **k: None})()
```

  **One subtlety §1 introduces:** a glossary module built on `DictGlossary` imports the package as well. If it's imported outside the guard, a missing package kills the run anyway, so the pattern imports it inside, and the tests block both imports in turn. The fallback supports `.active` and calls only; that's all a training loop uses.

## 3. The notes' link to the glossary panel is explicit
**Before:**
- Any glossary with `PANEL_TITLE` made the tracker write "<PANEL_TITLE> at the top of the project workspace" into every run's notes.
- The link went to the *personal* workspace, not the shared saved view `publish --shared` recommends.
- The only opt-out was dropping `PANEL_TITLE`, which made the glossary unpublishable.

**Now:** `Tracker.start(..., glossary_panel=...)`.
- `None` (the default): no panel link.
- A string: the title of the shared saved view the panel was published into, linked as `<server>/<entity>/<project>?nw=<id>`, the same id `publish --shared TITLE` uses.
- `tracker.PERSONAL_WORKSPACE`: the personal workspace, as before.
- An invalid value prints one line and adds no link, and never raises.
- With a glossary, the notes always link the run's *own* glossary artifact. `PANEL_TITLE` now only names the section `publish` writes, and is used as the link text.

**Why a `Tracker.start` argument, not a field on the glossary:**
- *Where* a panel is published is a publishing fact, not glossary content. The same glossary can be published into a saved view, a personal workspace, several projects or nowhere.
- A field on the glossary would recreate the coupling this removes.
- A sentinel object (not a magic string) for the personal workspace keeps any view title usable.

`backfill_run` / `update_notes` take `glossary_panel` too. **Compatibility:** their existing `panel_title=`-only calls keep the personal-workspace link. `shared_nw_id` / `shared_view_name` moved to `tracker.py` (so the tracker can build the view URL without a circular import), and `workspace.py` re-exports them.

## Research branch (`research/ffn_replacement_fix`): unchanged by this PR; what its rebase needs
Checked against this branch's package, with the research code as it is:
- The research test file passes: 7 of 7.
- The `wandb_tracking` shim, run exactly as the frozen `exp_g_0249` `train.py` runs it (offline; package blocked; spiky install removed), passes all checks.
- `wandb_glossary.py` `publish --dry-run` / `audit` / `verify` work.
- A `wandb_backfill.py` notes-only dry-run for `exp_g_0249` is identical to its notes on the server.

**Nothing breaks.** One behaviour changes:
- **`experiments/ffn_replacement/tools/wandb_tracking.py`:** new runs through the shim no longer get the "About these metrics at the top of the project workspace" line. That line pointed at the personal workspace, while Spiky's panel lives in the saved view "Spiky — described". *Rebase fix, one line:* pass `glossary_panel='Spiky — described'` in the shim's `Tracker.start` call. The notes will then link the right place.
- **`wandb_backfill.py`:** no change needed (the `panel_title=` compatibility path). Optionally add `glossary_panel='Spiky — described'` to its two calls for the same fix.
- **`metric_glossary.py`, `wandb_glossary.py`, `test_metric_glossary.py`:** no change.

## Safety machinery: unchanged
The `tracker.py` diff touches only the docstring, the new link helpers, `run_notes` (an optional `panel_where`), `_describe` / `start` (passing `glossary_panel`), and the new `NullTracker` / `IMPORT_GUARD`. No line of the bounded queue, the worker, the 2 s probe / offline fallback, `BOUNDS`, `finish()`'s deadline or the lazy `wandb` import changed, and the never-fatal behaviour is unchanged.

## Tests: 31 → 52 passed (CPU only, no server, no project content)
- **New `tests/test_wandb_glossary.py` (10):**
  - `DictGlossary` meets the whole protocol;
  - lookup, `{i}` patterns and undocumented; stale;
  - hash stability and sensitivity;
  - artifact rows in section order plus notes;
  - panel grouping, escaping and content-only text; default section order;
  - bad entries rejected;
  - a `DictGlossary` publishes (dry run) and its section verifies / goes stale;
  - `load()` with `GLOSSARY` and `:NAME`.
- **New `tests/test_wandb_notes_link_and_null.py` (11):**
  - a publishable glossary adds no panel link unless asked;
  - links to a shared saved view and to the personal workspace; a link without a glossary;
  - a bad `glossary_panel` is reported, not raised; the `panel_link` helper;
  - backfill's explicit link and `panel_title` compatibility;
  - `NullTracker`'s surface;
  - `IMPORT_GUARD` with the package import blocked and with the glossary import blocked, and with the real tracker.
- **`tests/test_wandb_tracker.py`:** one assertion updated. A glossary alone no longer adds the workspace link; the artifact link is asserted instead.

## Live verification (self-hosted server, throwaway project, deleted afterwards)
- **Run:**
  - An online run through this branch's tracker with a `DictGlossary` (sections, an `{i}` key, notes) and `glossary_panel='Throwaway — described'` finished.
  - History rows were all documented, including `norm_L0` / `norm_L1` via `norm_L{i}`, with no drift tag or summary.
  - The `metric_glossary` artifact, downloaded back, has rows equal to `table_rows()` (8, including the notes row).
  - The notes link the **saved view** (`?nw=throwawaydescribed`), not the personal workspace, plus the run's artifact.
- **publish / verify with the `DictGlossary` panel:**
  - publish `--shared` (module `GLOSSARY`) → exit 0;
  - verify with `FILE:GLOSSARY` → 0;
  - publish again, replaced in place (other sections and `panelConfigOverrides` unchanged) → 0;
  - verify with a changed glossary → **2** (stale);
  - verify the never-published personal workspace → **2** (absent);
  - verify a view that doesn't exist → **2**.
- **Spiky untouched:** 9 runs. The audit through the research wrapper, on this branch's package, reads **0 undocumented / 0 stale**. "Spiky — described" still **verifies** (read-only).

## Docs
`claude/wandb.md` §3:
- the example uses `DictGlossary` and `glossary_panel`;
- glossaries: `DictGlossary` by default, the protocol as the escape hatch;
- the explicit notes link;
- "optional means optional": `NullTracker` and the import guard.

§5 mentions `DictGlossary` and the explicit panel link. The doc's example and guard block were executed against this branch.

## Compromises
- `DictGlossary` has one fixed panel layout (sections of key | unit | short tables, then notes). Different layouts use the escape hatch.
- The import guard's fallback is a builtins stand-in (calls and `.active` only). Nothing better is possible without the package.
- `note:` artifact rows are named differently from the research glossary's custom `config:` rows. That glossary stays custom, so nothing changes there.

No packaging change; no secrets or deployment values committed. **Not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgeBHTEkV9qLjaRW4feEsK
