### PR TITLE
spiky.util.wandb_integration: scope audit to a W&B group; publish --no-readme

### DIFF
--- a/claude/wandb.md
+++ b/claude/wandb.md
@@ -86,7 +86,8 @@ Trainers here should not hand-roll the above: the shared package on `main`,
 
 - `tracker.py` — `Tracker`: optional, never-fatal logging from a training loop.
 - `workspace.py` — publish / verify / audit the metric-glossary panel (section 5):
-  `python -m spiky.util.wandb_integration.workspace publish|verify|audit --glossary FILE_OR_MODULE [--project P] [--shared TITLE]`.
+  `python -m spiky.util.wandb_integration.workspace publish|verify|audit --glossary FILE_OR_MODULE [--project P] [--shared TITLE]`,
+  plus `publish --no-readme` (leave the project description alone) and `audit --group NAME` (audit one family).
 - `backfill.py` — upload a finished run from its `metrics.csv` + `config.json` (`backfill_run`), and
   notes-only edits of runs already on the server (`update_notes`).
 - `glossary.py` — the protocol an injected glossary implements; `tests/` — CPU tests, no server.
@@ -238,7 +239,10 @@ look — the charts:
 
 Make drift detectable, never fatal: the tracker flags a logged key with no entry (one
 printed line, a tag, a summary field listing the keys); a read-only audit lists undocumented
-keys on the server and stale entries; a CPU unit test checks every `metrics.csv` column and
+keys on the server and stale entries — scoped to one family with `audit --group NAME`, because in a project with
+several glossaries an unscoped audit flags the other families' keys and accepts any key that merely shares a name (it
+prints its scope, so an unscoped run is visibly unscoped; the tracker's drift key `glossary/undocumented` is never
+reported stale); a CPU unit test checks every `metrics.csv` column and
 every key the tracker emits. The mechanics are generic and live in `spiky.util.wandb_integration`
 (section 3: the drift check and the artifact in `tracker.py`, publish / verify / audit in
 `workspace.py`); the glossary content and its content tests stay with the project — e.g.

--- a/src/spiky/util/wandb_integration/tests/test_wandb_audit_scope.py
+++ b/src/spiky/util/wandb_integration/tests/test_wandb_audit_scope.py
@@ -1,0 +1,134 @@
+"""audit scoped to a W&B group: the filter reaches the API, undocumented and stale are computed over that group only, an
+unscoped audit says so, the tracker's drift key is never stale; publish --no-readme leaves the project description
+alone. CPU only, no server (a fake wandb.Api)."""
+import json
+import sys
+import types
+
+import pytest
+
+from spiky.util.wandb_integration import glossary as G
+from spiky.util.wandb_integration import workspace as W
+
+
+class _Run:
+    def __init__(self, name, group, keys):
+        self.name, self.group, self.summary_metrics = name, group, {k: 1.0 for k in keys}
+
+
+RUNS = [_Run('ffn_1', 'ffn', ['val_bpb', 'ln2_norm_L0', 'lut_tv']),
+        _Run('smoke_1', 'smoke', ['val_bpb', 'train/loss'])]
+
+
+class _Api:
+    calls = []
+
+    def __init__(self, timeout=None):
+        pass
+
+    def runs(self, path, filters=None, per_page=50):
+        _Api.calls.append((path, filters))
+        return [r for r in RUNS if not filters or r.group == filters.get('group')]
+
+
+@pytest.fixture
+def fake_api(monkeypatch):
+    _Api.calls = []
+    monkeypatch.setitem(sys.modules, 'wandb', types.SimpleNamespace(Api=_Api))
+    monkeypatch.setenv('WANDB_BASE_URL', 'http://wandb.invalid')
+    monkeypatch.setenv('WANDB_ENTITY', 'ent')
+    return _Api
+
+
+DRIFT = {'glossary/undocumented': dict(unit='-', desc='Logged keys with no entry (drift check).')}
+FFN = G.DictGlossary({'val_bpb': dict(unit='bits/byte', desc='The fixed 100 x 48 eval.'),
+                      'ln2_norm_L{i}': dict(unit='L2', desc='ln2 gain norm of block i.'),
+                      'lut_tv': dict(unit='tv', desc='Mean cell TV.'), **DRIFT})
+SMOKE = G.DictGlossary({'val_bpb': dict(unit='bits/byte', desc='The batch-coupled 10 x 48 eval.'),
+                        'train/loss': dict(unit='nats', desc='Step loss.'), **DRIFT})
+
+
+def test_a_scoped_audit_passes_the_group_filter_and_reads_only_that_group(fake_api, capsys):
+    assert W.audit(SMOKE, 'P', group='smoke') == 0
+    out = capsys.readouterr().out
+    assert fake_api.calls == [('ent/P', {'group': 'smoke'})]
+    assert "scope: P, group 'smoke' (1 runs)" in out
+    assert "server runs in group 'smoke': 2 keys, 0 undocumented" in out
+    assert 'stale entries (match nothing seen in scope): none' in out
+
+
+def test_each_glossary_is_clean_in_its_own_group(fake_api, capsys):
+    assert W.audit(FFN, 'P', group='ffn') == 0 and W.audit(SMOKE, 'P', group='smoke') == 0
+    out = capsys.readouterr().out
+    assert out.count('0 undocumented') >= 2 and out.count('stale entries (match nothing seen in scope): none') == 2
+
+
+def test_an_unscoped_audit_says_so_and_flags_other_groups_keys(fake_api, capsys):
+    assert W.audit(SMOKE, 'P') == 1
+    out = capsys.readouterr().out
+    assert fake_api.calls == [('ent/P', None)]
+    assert 'ALL 2 runs -- UNSCOPED' in out and 'server runs (all groups): 4 keys, 2 undocumented' in out
+    assert 'ln2_norm_L0' in out and 'lut_tv' in out
+
+
+def test_stale_is_computed_over_the_scope_only(fake_api, capsys):
+    W.audit(FFN, 'P', group='smoke')
+    assert "stale entries (match nothing seen in scope): ['ln2_norm_L{i}', 'lut_tv']" in capsys.readouterr().out
+
+
+def test_the_drift_key_counts_as_always_emitted(fake_api, capsys):
+    W.audit(SMOKE, 'P', group='smoke')
+    out = capsys.readouterr().out
+    stale_line = [line for line in out.splitlines() if line.startswith('stale entries')][0]
+    assert 'glossary/undocumented' not in stale_line
+    assert "not yet in any run's data: ['glossary/undocumented']" in out
+
+
+def test_main_group_flag_beats_the_wrapper_default(fake_api, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(W, 'audit', lambda glossary, project, **kw: seen.update(kw) or 0)
+    assert W.main(['audit', '--project', 'P'], glossary=SMOKE, audit_group='smoke') == 0 and seen['group'] == 'smoke'
+    assert W.main(['audit', '--project', 'P', '--group', 'ffn'], glossary=SMOKE, audit_group='smoke') == 0
+    assert seen['group'] == 'ffn'
+    assert W.main(['audit', '--project', 'P'], glossary=SMOKE) == 0 and seen['group'] is None
+
+
+def _fake_publish_server(monkeypatch):
+    spec = {'section': {'panelBankConfig': {'sections': [{'__id__': 'a1', 'name': 'Charts', 'isPanelsAuto': True,
+                                                          'panels': []}]}}}
+    view = {'id': 'V1', 'name': 'nw-pdescribed-v', 'updatedAt': '2026-09-13T00:00:00Z', 'updatedBy': {'username': 'u'},
+            'specObject': spec}
+    store, queries = {'spec': spec}, []
+
+    def gql(api, query, variables, timeout=None):
+        queries.append(query)
+        if 'upsertView' in query:
+            store['spec'] = json.loads(variables['i']['spec'])
+            return {'upsertView': {'inserted': False, 'view': {'id': 'V1', 'name': view['name']}}}
+        if 'upsertModel' in query:
+            return {'upsertModel': {'project': {'id': 'p', 'name': 'P', 'description': variables['i']['description']}}}
+        return {'view': dict(view, specObject=store['spec'])}
+
+    monkeypatch.setattr(W, 'gql', gql)
+    monkeypatch.setattr(W, '_connect', lambda user=None: (object(), 'http://h', 'ent', 'u'))
+    monkeypatch.setattr(W, '_target', lambda shared, api, base, entity, project, user:
+                        (view, 'http://h/ent/P?nw=pdescribed', 'shared saved view'))
+    return queries
+
+
+def test_publish_no_readme_leaves_the_project_description_alone(monkeypatch, capsys):
+    queries = _fake_publish_server(monkeypatch)
+    g = G.DictGlossary({'k': dict(unit='u', desc='d')})
+    assert W.publish(g, 'P', shared_title='P described', readme=False) == 0
+    assert not any('upsertModel' in q for q in queries) and any('upsertView' in q for q in queries)
+    assert 'project P description left unchanged (--no-readme)' in capsys.readouterr().out
+    assert W.publish(g, 'P', shared_title='P described') == 0
+    assert any('upsertModel' in q for q in queries)                          # the default still sets it
+
+
+def test_main_no_readme_flag(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(W, 'publish', lambda glossary, project, **kw: seen.update(kw) or 0)
+    g = G.DictGlossary({'k': dict(unit='u', desc='d')})
+    assert W.main(['publish', '--project', 'P', '--shared', 'T', '--no-readme'], glossary=g) == 0 and seen['readme'] is False
+    assert W.main(['publish', '--project', 'P', '--shared', 'T'], glossary=g) == 0 and seen['readme'] is True

--- a/src/spiky/util/wandb_integration/workspace.py
+++ b/src/spiky/util/wandb_integration/workspace.py
@@ -2,7 +2,8 @@
 
     WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace publish --glossary G [--project P] [--shared TITLE | --user NAME] [--dry-run] [--if-idle MIN]
     WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace verify  --glossary G [--project P] [--shared TITLE | --user NAME]
-    WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace audit   --glossary G [--project P] [--csv-glob PATTERN]
+    WANDB_BASE_URL=... WANDB_ENTITY=... python -m spiky.util.wandb_integration.workspace audit   --glossary G [--project P] [--group NAME] [--csv-glob PATTERN]
+    (publish also takes --no-readme: leave the project description alone)
 
 G is a .py file or an importable module name; --project defaults to WANDB_PROJECT. A project wrapper calls
 main(argv, glossary=..., project=..., readme_intro=..., audit_csvs=..., audit_extra_keys=...) instead, so its users
@@ -43,7 +44,8 @@ import re
 import sys
 
 from spiky.util.wandb_integration import glossary as G
-from spiky.util.wandb_integration.tracker import gql, shared_nw_id, shared_view_name  # noqa: F401 (names re-exported)
+from spiky.util.wandb_integration.tracker import (UNDOC_SUMMARY, gql, shared_nw_id,  # noqa: F401 (names re-exported)
+                                                  shared_view_name)
 
 SECTION_ID, PANEL_ID = 'metric-glossary-section', 'metric-glossary-panel'
 # One full-width column; tall enough to show a few tables without scrolling the page (the panel scrolls inside).
@@ -110,6 +112,9 @@ def readme(url, glossary, project, shared_title=None, intro=None):
     lines.append("- Each run's **notes** (Overview tab) say what the run tests and link to its code on GitHub at the launch "
                  'commit and its run folder.')
     return '\n'.join(lines) + '\n'
+
+
+readme_text = readme           # publish() takes a readme= flag, which shadows the function name inside it
 
 
 def csv_header_keys(paths):
@@ -181,7 +186,10 @@ def _target(shared_title, api, base, entity, project, user):
     return view, f'{base}/{entity}/{project}?nw={shared_nw_id(shared_title)}', f'shared saved view {shared_title!r} ({name})'
 
 
-def publish(glossary, project, *, shared_title=None, user=None, if_idle=None, dry_run=False, readme_intro=None):
+def publish(glossary, project, *, shared_title=None, user=None, if_idle=None, dry_run=False, readme_intro=None,
+            readme=True):
+    """Write the glossary section into the target view (see the module docstring). readme=False (`--no-readme`) leaves
+    the project description alone -- e.g. when a second glossary is published into a project that already has one."""
     G.require(glossary, G.PUBLISH_NEEDS, 'publish')
     title, md = glossary.PANEL_TITLE, glossary.panel_markdown()
     if dry_run:
@@ -229,9 +237,12 @@ def publish(glossary, project, *, shared_title=None, user=None, if_idle=None, dr
     print(f'section {"replaced" if had else "created"} in {what}: {len(md)} chars, glossary {glossary.glossary_hash()}; '
           f'other sections unchanged and in order: {others_before == others_after}; '
           f'panelConfigOverrides unchanged: {same_overrides}')
-    description = readme(url, glossary, project, shared_title, readme_intro)
-    p = gql(api, _UPSERT_MODEL, {'i': {'entityName': entity, 'name': project, 'description': description}})['upsertModel']
-    print(f'project {p["project"]["name"]} description set ({len(p["project"]["description"])} chars)')
+    if readme:
+        description = readme_text(url, glossary, project, shared_title, readme_intro)
+        p = gql(api, _UPSERT_MODEL, {'i': {'entityName': entity, 'name': project, 'description': description}})['upsertModel']
+        print(f'project {p["project"]["name"]} description set ({len(p["project"]["description"])} chars)')
+    else:
+        print(f'project {project} description left unchanged (--no-readme)')
     if not ok or others_before != others_after:
         bar = '!' * 100
         print(f'{bar}\nWARNING: after the write the glossary section is NOT right in {what}: {why}'
@@ -257,34 +268,49 @@ def verify(glossary, project, *, shared_title=None, user=None):
     return 0 if ok else 2
 
 
-def audit(glossary, project, *, csv_paths=(), extra_keys=None):
-    """extra_keys: {label: iterable of keys} that must be documented even before any run has logged them."""
+def audit(glossary, project, *, csv_paths=(), extra_keys=None, group=None):
+    """Undocumented and stale glossary entries. Returns 1 when anything is undocumented.
+
+    group       only runs of this W&B group count (the family the glossary describes). None reads EVERY run in the
+                project and says so: with several glossaries in one project an unscoped audit is not authoritative --
+                it flags other families' keys and accepts any key that merely shares a name.
+    csv_paths   local metrics files whose headers must be documented (scope them the same way, e.g. a family's glob).
+    extra_keys  {label: iterable of keys} that must be documented even before any run has logged them.
+    The tracker's drift key (glossary/undocumented) counts as always emitted: it only appears in a run's summary when
+    drift happened, so a glossary that documents it is never told it is stale."""
     G.require(glossary, G.AUDIT_NEEDS, 'audit')
     base, entity = _env()
     import wandb
     api = wandb.Api(timeout=60)
-    server = {}
-    for r in api.runs(f'{entity}/{project}', per_page=100):
+    server, n_runs = {}, 0
+    for r in api.runs(f'{entity}/{project}', filters={'group': group} if group else None, per_page=100):
+        n_runs += 1
         for k in r.summary_metrics.keys():
             server.setdefault(k, r.name)
+    if group:
+        print(f'scope: {project}, group {group!r} ({n_runs} runs)')
+    else:
+        print(f'scope: {project}, ALL {n_runs} runs -- UNSCOPED: keys of every group count; pass --group to audit one family')
     csv_keys = csv_header_keys(csv_paths)
     extra = {label: {k: label for k in keys} for label, keys in (extra_keys or {}).items()}
     bad = 0
-    for label, keys in [('server runs', server), ('metrics CSV headers', csv_keys)] + list(extra.items()):
+    runs_label = f'server runs in group {group!r}' if group else 'server runs (all groups)'
+    for label, keys in [(runs_label, server), ('metrics CSV headers', csv_keys)] + list(extra.items()):
         und = glossary.undocumented(keys)
         bad += len(und)
         print(f'{label}: {len(keys)} keys, {len(und)} undocumented'
               + ''.join(f'\n   {k}  (e.g. {keys[k]})' for k in und))
     emitted = set().union(*[set(v) for v in extra.values()]) if extra else set()
+    emitted.add(UNDOC_SUMMARY)                                   # the drift key: present only when drift happened
     stale_all = glossary.stale(set(server) | set(csv_keys) | emitted)
-    print(f'stale entries (match nothing seen anywhere): {stale_all or "none"}')
+    print(f'stale entries (match nothing seen in scope): {stale_all or "none"}')
     not_in_data = [k for k in glossary.stale(set(server) | set(csv_keys)) if k not in stale_all]
-    print(f'documented, in the extra key lists, not yet in any run\'s data: {not_in_data or "none"}')
+    print(f'documented, in the extra key lists or the drift key, not yet in any run\'s data: {not_in_data or "none"}')
     print(f'glossary {glossary.glossary_hash()}')
     return 1 if bad else 0
 
 
-def main(argv, glossary=None, project=None, readme_intro=None, audit_csvs=(), audit_extra_keys=None):
+def main(argv, glossary=None, project=None, readme_intro=None, audit_csvs=(), audit_extra_keys=None, audit_group=None):
     """The command line (see the module docstring). Wrappers pass their defaults; flags on argv still win."""
     cmd, rest = (argv[0], argv[1:]) if argv else ('', [])
     if cmd not in ('publish', 'verify', 'audit'):
@@ -301,12 +327,12 @@ def main(argv, glossary=None, project=None, readme_intro=None, audit_csvs=(), au
     shared, user = _arg(rest, '--shared', None), _arg(rest, '--user', None)
     if cmd == 'publish':
         return publish(glossary, project, shared_title=shared, user=user, if_idle=_arg(rest, '--if-idle', None),
-                       dry_run='--dry-run' in rest, readme_intro=readme_intro)
+                       dry_run='--dry-run' in rest, readme_intro=readme_intro, readme='--no-readme' not in rest)
     if cmd == 'verify':
         return verify(glossary, project, shared_title=shared, user=user)
     pattern = _arg(rest, '--csv-glob', None)
     return audit(glossary, project, csv_paths=sorted(glob.glob(pattern)) if pattern else audit_csvs,
-                 extra_keys=audit_extra_keys)
+                 extra_keys=audit_extra_keys, group=_arg(rest, '--group', None) or audit_group)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Scopes `workspace audit` to one W&B group, and adds `publish --no-readme`. Both are follow-ups from the W&B smoke test, where Spiky gained a second glossary.

## Problem
`audit()` read **every run in the project** (`api.runs(f'{entity}/{project}')`, no filter). With two glossaries in Spiky:
- **ffn_replacement glossary: false clean.** It accepted the smoke run's keys, because the names (`val_bpb`, `train_loss`, …) are in its glossary. The smoke run's `val_bpb` is actually a different eval window. The smoke run also changed that audit's "not yet in any run's data" list.
- **smoke glossary: false alarm.** It flagged **49** ffn_replacement per-layer keys (`lm_*_L*`, `ln*_L*`, `lut_tv*`, `tau_L*`) as undocumented, with exit 1.

An audit that cries wolf, or that passes for the wrong reason, is worse than none.

## Change (`src/spiky/util/wandb_integration/workspace.py`)
- **Scoping:** `audit(glossary, project, *, csv_paths=(), extra_keys=None, group=None)` fetches runs with `api.runs(..., filters={'group': group} if group else None)`. Undocumented and stale are computed over that scope only.
- **Command line:** `workspace audit ... --group NAME`. `main(..., audit_group=None)` lets a project wrapper bind its own family; a `--group` on argv still wins.
- **The scope is printed first:** `scope: Spiky, group 'smoke_test' (1 runs)`. An unscoped audit prints `scope: Spiky, ALL 10 runs -- UNSCOPED: keys of every group count; pass --group to audit one family`, so it can never look authoritative. The run-keys line is labelled by scope too.
- **Drift key: treated as always emitted, not just documented.** `glossary/undocumented` only appears in a run's summary when drift happened. So a glossary that documents it looked "stale" in every clean project. The research wrapper dodged this by listing the key in `extra_keys`.
  - It is the tracker's own key: the package emits it, so the package knows it can appear.
  - Handling it here makes every consumer correct by default; documenting it would require each project to remember a workaround.
  - It only affects *stale*: if a run did drift and a glossary lacks the entry, `undocumented` still flags it.
- **`publish(..., readme=True)` / `publish --no-readme`:** skip the `upsertModel` call that rewrites the **project description**. Publishing `Spiky — smoke test` rewrote Spiky's description (written for `Spiky — described`), and it had to be snapshotted and restored byte-identical by hand. The flag is small (the parameter, one branch, the CLI flag), so it is in this PR. The default is unchanged.

**Not in this PR, proposed separately: a group filter for `publish`.** Publishing a view filtered to one group needs the run-set filter written into the view spec, in the web client's internal stored format: `{"filterFormat": "filterV2", "filters": [{"key": {"section": "run", "name": "group"}, "op": "=", "value": "<group>", "disabled": false}]}`. That format was reverse-engineered from the server's JS bundle and proven by a headless render. It is only a few lines, but it depends on an undocumented client format, so it deserves its own PR with its own render check rather than riding along here.

**Also not in this PR:** a per-glossary section id / `--title` override for `publish` and `verify`. Today every glossary shares the fixed section id `metric-glossary-section`, so two glossaries in one workspace replace each other. It is sized separately (~12 lines + tests).

## Tests: 52 → 60 passed (CPU only, no server; `tests/test_wandb_audit_scope.py`, fake `wandb.Api`)
- the group filter reaches `api.runs`, and only that group's keys are read;
- each of two glossaries is clean in its own group;
- an unscoped audit says UNSCOPED and flags the other group's keys;
- stale is computed over the scope only;
- the drift key counts as always emitted;
- `--group` beats the wrapper's `audit_group`;
- `publish(readme=False)` never calls `upsertModel` (the default still does);
- `--no-readme` is parsed.

## Live check against Spiky (read-only, this branch's package, before merge)
| glossary | unscoped (today) | `--group` |
|---|---|---|
| ffn_replacement (research wrapper) | 10 runs, 0 undocumented — a false clean (includes the smoke run) | `ffn_replacement`: 9 runs, 64 keys, **0 undocumented / 0 stale**, exit 0 |
| smoke test (`smoke_glossary.py:GLOSSARY`) | 10 runs, **49 undocumented**, exit 1 | `smoke_test`: 1 run, 16 keys, **0 undocumented / 0 stale**, exit 0 |

No view, workspace or project description was written.

## Docs
`claude/wandb.md`:
- §3 names `publish --no-readme` and `audit --group NAME`.
- §5 says why an audit must be scoped in a project with several glossaries, that it prints its scope, and that the drift key is never stale.

## After merge (research branch, one line)
`experiments/ffn_replacement/tools/wandb_glossary.py` can pass `audit_group='ffn_replacement'` to `W.main(...)`. Its `audit_extra_keys` stays: it lists the tracker keys that should be documented before any run logs them.

No packaging change; nothing deployment-specific committed. **Not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgeBHTEkV9qLjaRW4feEsK
